### PR TITLE
Update Crash Dialog

### DIFF
--- a/injector/src/modules/betterdiscord.js
+++ b/injector/src/modules/betterdiscord.js
@@ -95,10 +95,10 @@ export default class BetterDiscord {
 
             // If a previous crash was detected, show a message explaining why BD isn't there
             electron.dialog.showMessageBox({
-                title: "BetterDiscord Crashed",
+                title: "Discord Crashed",
                 type: "warning",
-                message: "BetterDiscord seems to have crashed your Discord client.",
-                detail: "BetterDiscord has automatically disabled itself temporarily. Try removing all your plugins then restarting Discord."
+                message: "BetterDiscord might have crashed your Discord client.",
+                detail: "BetterDiscord has automatically disabled itself, to enable it again, restart Discord.\n\nThis issue may have been caused by a plugin. Try removing all of your plugins or moving them out of the plugins folder and check if BetterDiscord still crashes."
             });
             hasCrashed = false;
         });


### PR DESCRIPTION
A lot of people seem to think that when BD disables itself you need to reinstall it to enable it so I thought about something like this that makes it clear that that is not necesary.
Also in rare ocassions (for example with the gif or mp4 crash videos) BD itself was not the cause of the crash. Thats why I changed it to "might have crashed".

![image](https://user-images.githubusercontent.com/63931154/125192340-a7297700-e247-11eb-8134-d89d36197a32.png)
