### PR TITLE
ReactDevTools: fixed not loading on Linux

### DIFF
--- a/injector/src/modules/betterdiscord.js
+++ b/injector/src/modules/betterdiscord.js
@@ -15,13 +15,6 @@ if (process.platform === "win32" || process.platform === "darwin") dataPath = pa
 else dataPath = process.env.XDG_CONFIG_HOME ? process.env.XDG_CONFIG_HOME : path.join(process.env.HOME, ".config"); // This will help with snap packages eventually
 dataPath = path.join(dataPath, "BetterDiscord") + "/";
 
-
-electron.app.once("ready", async () => {
-    if (!BetterDiscord.getSetting("developer", "reactDevTools")) return;
-    await ReactDevTools.install();
-});
-
-
 let hasCrashed = false;
 export default class BetterDiscord {
     static getWindowPrefs() {
@@ -112,6 +105,12 @@ export default class BetterDiscord {
             hasCrashed = true;
         });
     }
+}
+
+if (BetterDiscord.getSetting("developer", "reactDevTools")) {
+    electron.app.whenReady().then(async ()=>{
+        await ReactDevTools.install();
+    });
 }
 
 if (BetterDiscord.getSetting("general", "mediaKeys")) {


### PR DESCRIPTION
This will not fix whatever causes the ReactDevTools to not be added to the Electron/Chromium DevTools sometimes, but it addresses the DevTools not loading on Linux at all because the injection method is different, resulting in the BD running the electron app is already ready.
Simple patch using the fact that resolved promises will fire their `.then()` callback even if the promise was already resolved when the `.then()` callback was attached
```js
console.log('READY STATE '+ electron.app.isReady());
electron.app.once("loaded", async ()=>{console.log("loaded");});
electron.app.whenReady().then(async ()=>{console.log("whenReady");});
> READY STATE true
> whenReady
> [... loaded will be logged]
```