### PR TITLE
Editor: Fix Addon Editor not loading when CustomCSS disabled

### DIFF
--- a/renderer/src/builtins/customcss.js
+++ b/renderer/src/builtins/customcss.js
@@ -26,33 +26,6 @@ export default new class CustomCSS extends Builtin {
     }
 
     async enabled() {
-        if (!window.monaco && !window.MonacoEnvironment) {
-            Object.defineProperty(window, "MonacoEnvironment", {
-                value: {
-                    getWorkerUrl: function() {
-                        return `data:text/javascript;charset=utf-8,${encodeURIComponent(`
-                            self.MonacoEnvironment = {
-                                baseUrl: 'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.20.0/min'
-                            };
-                            importScripts('https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.20.0/min/vs/base/worker/workerMain.min.js');`
-                        )}`;
-                    }
-                }
-            });
-
-            const commonjsLoader = window.require;
-            delete window.module; // Make monaco think this isn't a local node script or else it freaks out
-
-            DOMManager.linkStyle("monaco-style", "https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.20.0/min/vs/editor/editor.main.min.css", {documentHead: true});
-            await DOMManager.injectScript("monaco-script", "https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.20.0/min/vs/loader.min.js");
-
-            const amdLoader = window.require; // Grab Monaco's amd loader
-            window.require = commonjsLoader; // Revert to commonjs
-            // this.log(amdLoader, window.require);
-            amdLoader.config({paths: {vs: "https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.20.0/min/vs"}});
-            amdLoader(["vs/editor/editor.main"], () => {}); // exposes the monaco global
-        }
-
         Settings.registerPanel(this.id, Strings.Panels.customcss, {
             order: 2,
             element: () => [<SettingsTitle text={Strings.CustomCSS.editorTitle} />, React.createElement(CSSEditor, {

--- a/renderer/src/modules/core.js
+++ b/renderer/src/modules/core.js
@@ -61,12 +61,11 @@ export default new class Core {
         ComponentPatcher.initialize();
 
         Logger.log("Startup", "Initializing Editor");
-        Editor.initialize();
+        await Editor.initialize();
 
         Logger.log("Startup", "Initializing Builtins");
         for (const module in Builtins) {
-            if (module === "CustomCSS") await Builtins[module].initialize();
-            else Builtins[module].initialize();
+            Builtins[module].initialize();
         }
 
         Logger.log("Startup", "Loading Plugins");

--- a/renderer/src/modules/core.js
+++ b/renderer/src/modules/core.js
@@ -17,6 +17,7 @@ import Strings from "./strings";
 import IPC from "./ipc";
 import LoadingIcon from "../loadingicon";
 import Styles from "../styles/index.css";
+import Editor from "./editor";
 
 export default new class Core {
     async startup() {
@@ -58,6 +59,9 @@ export default new class Core {
 
         Logger.log("Startup", "Initializing ComponentPatcher");
         ComponentPatcher.initialize();
+
+        Logger.log("Startup", "Initializing Editor");
+        Editor.initialize();
 
         Logger.log("Startup", "Initializing Builtins");
         for (const module in Builtins) {

--- a/renderer/src/modules/editor.js
+++ b/renderer/src/modules/editor.js
@@ -1,0 +1,33 @@
+import DOMManager from "./dommanager";
+
+export default new class Editor {
+
+    async initialize() {
+        const baseUrl = "https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.20.0/min"
+
+        Object.defineProperty(window, "MonacoEnvironment", {
+            value: {
+                getWorkerUrl: function() {
+                    return `data:text/javascript;charset=utf-8,${encodeURIComponent(`
+                        self.MonacoEnvironment = {
+                            baseUrl: '${baseUrl}'
+                        };
+                        importScripts('${baseUrl}/vs/base/worker/workerMain.min.js');`
+                    )}`;
+                }
+            }
+        });
+
+        const commonjsLoader = window.require;
+        delete window.module; // Make monaco think this isn't a local node script or else it freaks out
+
+        DOMManager.linkStyle("monaco-style", `${baseUrl}/vs/editor/editor.main.min.css`, {documentHead: true});
+        await DOMManager.injectScript("monaco-script", `${baseUrl}/vs/loader.min.js`);
+        
+        const amdLoader = window.require; // Grab Monaco's amd loader
+        window.require = commonjsLoader; // Revert to commonjs
+        // this.log(amdLoader, window.require);
+        amdLoader.config({paths: {vs: `${baseUrl}/vs`}});
+        amdLoader(["vs/editor/editor.main"], () => {}); // exposes the monaco global
+    }
+};


### PR DESCRIPTION
Fixes #864
This loads the editor unconditionall, even if CustomCSS is disabled and the Addon Editor is set to "Detached Window". I don't think the added complexity for loading it conditionally would be justified considering it's probably only a small fraction of the userbase this applies to.
On top of that it also would need to be loaded for #909 if that is to BetterDiscord.