### PR TITLE
Remove linebreak-style eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,6 @@
         "handle-callback-err": "error",
         "key-spacing": "error",
         "keyword-spacing": "error",
-        "linebreak-style": ["error", "windows"],
         "new-cap": ["error", {"newIsCap": true}],
         "no-array-constructor": "error",
         "no-caller": "error",


### PR DESCRIPTION
The eslint `linebreak-style` rule won't stop anyone from commiting non-CLRF linesbreaks. In fact pretty much the whole project uses LF instead of CLRF.

This messes with non-Windows people because default mode for `autocrlf` is `false` (checkout as is commit as is) on Linux resulting in the whole project being flagged for wrong linefeed style on checkout. I think the windows git installer sets it to `true` by default (checkout as CRLF, commit as LF).

As a result the whole repo is using LF despite dictating CRLF which trips up Linux users (and probably also Mac users) because eslint flags every line. But when they actually try to commit CRLF the every file they edit will end up editing every single line. One could say the other's should just use `autocrlf` but why would a Linux user need to checkout CRLF when they would have to commit LF in the end anyway.