### PR TITLE
Fix `BdApi.loadData()` returning `undefined` when met with `false`

### DIFF
--- a/renderer/src/modules/datastore.js
+++ b/renderer/src/modules/datastore.js
@@ -195,9 +195,13 @@ export default new class DataStore {
     }
 
     getPluginData(pluginName, key) {
-        if (this.pluginData[pluginName] !== undefined) return this.pluginData[pluginName][key] || undefined;
+        if (this.pluginData[pluginName] !== undefined) {
+            if (this.pluginData[pluginName][key] === false) return false;
+            return this.pluginData[pluginName][key] || undefined;
+        }
         if (!fs.existsSync(this.getPluginFile(pluginName))) return undefined;
         this.pluginData[pluginName] = JSON.parse(fs.readFileSync(this.getPluginFile(pluginName)));
+        if (this.pluginData[pluginName][key] === false) return false;
         return this.pluginData[pluginName][key] || undefined;
     }
 


### PR DESCRIPTION
Fixes #805
Currently, the `getPluginData()` function does not account for a value of `false` in the returned key. This results in the function returning `undefined` instead of `false` in cases where the returned key is set to `false`.
This accounts for the issue by checking if the key in question is set to `false` and returning `false` if it is, instead of defaulting to `undefined` as it does in the absence of other values.