### PR TITLE
Fix duplicate 's' in pt-br translation

### DIFF
--- a/assets/locales/pt-br.json
+++ b/assets/locales/pt-br.json
@@ -192,7 +192,7 @@
     "Addons": {
         "title": "{{name}} v{{version}} by {{author}}",
         "byline": "por {{author}}",
-        "openFolder": "Abrir Pasta de {{type}}s",
+        "openFolder": "Abrir Pasta de {{type}}",
         "reload": "Recarregar",
         "addonSettings": "Configurações",
         "website": "Site",


### PR DESCRIPTION
There are two 's' at the end of the button in the Portuguese translation.
![image](https://user-images.githubusercontent.com/61747990/127051258-c807a1f1-8d04-49bc-adb9-c6930b65ba2f.png)
![image](https://user-images.githubusercontent.com/61747990/127051344-a0e6da3d-b194-40b4-84fe-394829a97309.png)
