### PR TITLE
Simple recovery mode

### DIFF
--- a/assets/locales/de.json
+++ b/assets/locales/de.json
@@ -310,5 +310,8 @@
     "WindowPrefs": {
         "enabledInfo": "Um diese Funktion zu verwenden, benötigst du ein Theme mit transparentem Hintergrund. Auf Windows funktioniert das Maximieren des Fensters ggf. nicht mehr.\n\nUm die Änderungen zu übernehmen muss Discord neugeladen werden. Willst du jetzt neuladen?",
         "disabledInfo": "Um die Änderungen zu übernehmen muss Discord neugeladen werden. Willst du jetzt neuladen?"
+    },
+    "RecoveryMode": {
+        "noticeMessage": "BetterDiscord ist im Wiederherstellungsmodus und lädt weder Addons noch CustomCSS. Versuche Plugins zu entfernen und lade Discord neu."
     }
 }

--- a/assets/locales/en-us.json
+++ b/assets/locales/en-us.json
@@ -310,5 +310,8 @@
     "WindowPrefs": {
         "enabledInfo": "This option requires a transparent theme in order to work properly. On Windows this may break your aero snapping and maximizing.\n\nIn order to take effect, Discord needs to be restarted. Do you want to restart now?",
         "disabledInfo": "In order to take effect, Discord needs to be restarted. Do you want to restart now?"
+    },
+    "RecoveryMode": {
+        "noticeMessage": "BetterDiscord is in Recovery Mode and won't load any addons or CustomCSS. Try removing plugins and reloading Discord."
     }
 }

--- a/common/constants/recoverymode.js
+++ b/common/constants/recoverymode.js
@@ -1,0 +1,1 @@
+export const RECOVERY_MODE_KEY = "BD_RECOVERY_MODE";

--- a/injector/src/modules/betterdiscord.js
+++ b/injector/src/modules/betterdiscord.js
@@ -4,6 +4,7 @@ import electron from "electron";
 
 import ReactDevTools from "./reactdevtools";
 import * as IPCEvents from "common/constants/ipcevents";
+import { RECOVERY_MODE_KEY } from "common/constants/recoverymode";
 
 // Build info file only exists for non-linux (for current injection)
 const appPath = electron.app.getAppPath();
@@ -64,10 +65,8 @@ export default class BetterDiscord {
         if (!fs.existsSync(location)) return; // TODO: cut a fatal log
         const content = fs.readFileSync(location).toString();
 
-        if (recoveryMode) {
-            await browserWindow.webContents.executeJavaScript("window.BD_RECOVERY_MODE = true;");
-        }
-
+        if (recoveryMode) await browserWindow.webContents.executeJavaScript(`window.${RECOVERY_MODE_KEY} = true;`);
+        
         const success = await browserWindow.webContents.executeJavaScript(`
             (() => {
                 try {

--- a/renderer/src/builtins/customcss.js
+++ b/renderer/src/builtins/customcss.js
@@ -4,6 +4,7 @@ import CSSEditor from "../ui/customcss/csseditor";
 import FloatingWindows from "../ui/floatingwindows";
 import SettingsTitle from "../ui/settings/title";
 import Utilities from "../modules/utilities";
+import { isRecoveryMode } from "../modules/recoverymode";
 
 const fs = require("fs");
 const electron = require("electron");
@@ -100,6 +101,8 @@ export default new class CustomCSS extends Builtin {
     }
 
     insertCSS(newCss) {
+        if (isRecoveryMode()) return;
+
         if (typeof(newCss) === "undefined") newCss = this.insertedCss;
         else this.insertedCss = newCss;
         DOMManager.updateCustomCSS(newCss);

--- a/renderer/src/index.js
+++ b/renderer/src/index.js
@@ -11,4 +11,4 @@ window.BdApi = BdApi;
 
 // Add loading icon at the bottom right
 LoadingIcon.show();
-BetterDiscord.startup();
+BetterDiscord.startup().then(()=>LoadingIcon.hide());

--- a/renderer/src/modules/core.js
+++ b/renderer/src/modules/core.js
@@ -32,11 +32,6 @@ export default new class Core {
         Logger.log("Startup", "Injecting BD Styles");
         DOMManager.injectStyle("bd-stylesheet", Styles.toString());
 
-        if (window.BD_RECOVERY_MODE) {
-            Logger.log("Startup", "Detected Recovery Mode");
-            return showRecoveryNotice();
-        }
-
         Logger.log("Startup", "Initializing DataStore");
         DataStore.initialize();
 
@@ -45,7 +40,7 @@ export default new class Core {
 
         Logger.log("Startup", "Performing incompatibility checks");
         if (window.ED) return Modals.alert(Strings.Startup.notSupported, Strings.Startup.incompatibleApp.format({app: "EnhancedDiscord"}));
-        if (window.WebSocket && window.WebSocket.name && window.WebSocket.name.includes("Patched")) return Modals.alert(Strings.Startup.notSupported, Strings.Startup.incompatibleApp.format({app: "Powercord"}));
+        if (window?.WebSocket?.name && window.WebSocket.name.includes("Patched")) return Modals.alert(Strings.Startup.notSupported, Strings.Startup.incompatibleApp.format({app: "Powercord"}));
 
         Logger.log("Startup", "Getting update information");
         this.checkForUpdate();
@@ -64,6 +59,11 @@ export default new class Core {
 
         Logger.log("Startup", "Initializing ComponentPatcher");
         ComponentPatcher.initialize();
+
+        if (window.BD_RECOVERY_MODE) {
+            Logger.log("Startup", "Detected Recovery Mode");
+            return showRecoveryNotice();
+        }
 
         Logger.log("Startup", "Initializing Editor");
         await Editor.initialize();

--- a/renderer/src/modules/core.js
+++ b/renderer/src/modules/core.js
@@ -60,17 +60,17 @@ export default new class Core {
         Logger.log("Startup", "Initializing ComponentPatcher");
         ComponentPatcher.initialize();
 
-        if (isRecoveryMode()) {
-            Logger.log("Startup", "Detected Recovery Mode");
-            return showRecoveryNotice();
-        }
-
         Logger.log("Startup", "Initializing Editor");
         await Editor.initialize();
 
         Logger.log("Startup", "Initializing Builtins");
         for (const module in Builtins) {
             Builtins[module].initialize();
+        }
+
+        if (isRecoveryMode()) {
+            Logger.log("Startup", "Detected Recovery Mode");
+            return showRecoveryNotice();
         }
 
         Logger.log("Startup", "Loading Plugins");

--- a/renderer/src/modules/core.js
+++ b/renderer/src/modules/core.js
@@ -17,7 +17,7 @@ import Strings from "./strings";
 import IPC from "./ipc";
 import Styles from "../styles/index.css";
 import Editor from "./editor";
-import { showRecoveryNotice } from "./recoverymode";
+import { isRecoveryMode, showRecoveryNotice } from "./recoverymode";
 
 export default new class Core {
     async startup() {
@@ -60,7 +60,7 @@ export default new class Core {
         Logger.log("Startup", "Initializing ComponentPatcher");
         ComponentPatcher.initialize();
 
-        if (window.BD_RECOVERY_MODE) {
+        if (isRecoveryMode()) {
             Logger.log("Startup", "Detected Recovery Mode");
             return showRecoveryNotice();
         }

--- a/renderer/src/modules/core.js
+++ b/renderer/src/modules/core.js
@@ -15,9 +15,9 @@ import DiscordModules from "./discordmodules";
 import ComponentPatcher from "./componentpatcher";
 import Strings from "./strings";
 import IPC from "./ipc";
-import LoadingIcon from "../loadingicon";
 import Styles from "../styles/index.css";
 import Editor from "./editor";
+import { showRecoveryNotice } from "./recoverymode";
 
 export default new class Core {
     async startup() {
@@ -31,6 +31,11 @@ export default new class Core {
         // Load css early
         Logger.log("Startup", "Injecting BD Styles");
         DOMManager.injectStyle("bd-stylesheet", Styles.toString());
+
+        if (window.BD_RECOVERY_MODE) {
+            Logger.log("Startup", "Detected Recovery Mode");
+            return showRecoveryNotice();
+        }
 
         Logger.log("Startup", "Initializing DataStore");
         DataStore.initialize();
@@ -75,9 +80,6 @@ export default new class Core {
         Logger.log("Startup", "Loading Themes");
         // const themeErrors = [];
         const themeErrors = ThemeManager.initialize();
-
-        Logger.log("Startup", "Removing Loading Icon");
-        LoadingIcon.hide();
 
         // Show loading errors
         Logger.log("Startup", "Collecting Startup Errors");

--- a/renderer/src/modules/pluginapi.js
+++ b/renderer/src/modules/pluginapi.js
@@ -5,6 +5,7 @@ import DiscordModules from "./discordmodules";
 import DataStore from "./datastore";
 import DOMManager from "./dommanager";
 import Toasts from "../ui/toasts";
+import Notices from "../ui/notices";
 import Modals from "../ui/modals";
 import PluginManager from "./pluginmanager";
 import ThemeManager from "./thememanager";
@@ -111,6 +112,19 @@ BdApi.showConfirmationModal = function (title, content, options = {}) {
  */
 BdApi.showToast = function(content, options = {}) {
     Toasts.show(content, options);
+};
+
+/**
+ * Show a notice above discord's chat layer.
+ * @param {string} content Content of the notice
+ * @param {object} options Options for the notice.
+ * @param {string} [options.type="info" | "error" | "warning" | "success"] Type for the notice. Will affect the color.
+ * @param {Array<{label: string, onClick: (onClose: () => void) => void}>} [options.buttons] Buttons that should be added next to the notice text.
+ * @param {number} [options.timeout=10000] Timeout until the toast is closed. Won't fire if it's set to 0;
+ * @returns {void}
+ */
+ BdApi.showNotice = function (content, options = {}) {
+    Notices.show(content, options);
 };
 
 // Finds module

--- a/renderer/src/modules/recoverymode.js
+++ b/renderer/src/modules/recoverymode.js
@@ -1,7 +1,7 @@
 import { Strings } from "modules";
 import PluginManager from "./pluginmanager";
-import ThemeManager from "./thememanager";
 import Notices from "../ui/notices";
+import { RECOVERY_MODE_KEY } from "common/constants/recoverymode";
 
 const shell = require("electron").shell;
 
@@ -40,5 +40,8 @@ export const showRecoveryNotice = async () => {
             }
         ), 0
     )
-    
+}
+
+export const isRecoveryMode = () => {
+    return !!window[RECOVERY_MODE_KEY];
 }

--- a/renderer/src/modules/recoverymode.js
+++ b/renderer/src/modules/recoverymode.js
@@ -1,0 +1,44 @@
+import { Strings } from "modules";
+import PluginManager from "./pluginmanager";
+import ThemeManager from "./thememanager";
+import Notices from "../ui/notices";
+
+const shell = require("electron").shell;
+
+function waitForContainer() {
+    // TODO: experiment with waiting for NoticeStore instead
+    return new Promise(resolve => {
+        const checkForContainer = function () {
+            if (document.readyState != "complete") setTimeout(checkForContainer, 100);
+            if (document.querySelector(`.${Notices.baseClass}`)) return resolve();
+            setTimeout(checkForContainer, 100);
+        };
+        checkForContainer();
+    });
+};
+
+export const showRecoveryNotice = async () => {
+    await waitForContainer();
+    setTimeout(
+        () => Notices.show(
+            Strings.RecoveryMode.noticeMessage,
+            {
+                type: "error",
+                buttons: [
+                    {
+                        label: Strings.Addons.openFolder.format({type: Strings.Panels.plugins}),
+                        onClick: () => {
+                            shell.openPath(PluginManager.addonFolder);
+                        }
+                    },
+                    {
+                        label: "Reload",
+                        onClick: () => window.location.reload()
+                    }
+                ],
+                timeout: 0
+            }
+        ), 0
+    )
+    
+}

--- a/renderer/src/styles/ui/notices.css
+++ b/renderer/src/styles/ui/notices.css
@@ -1,0 +1,91 @@
+.bd-notice-success {
+    --color: #43b581;
+}
+
+.bd-notice-error {
+    --color: #f04747;
+}
+
+.bd-notice-info {
+    --color: #4a90e2;
+}
+
+.bd-notice-warning {
+    --color: #ffa600;
+}
+
+.bd-notice-closing {
+    transition: height 400ms ease;
+    height: 0 !important;
+}
+
+@keyframes bd-open-notice {
+    from {
+        height: 0;
+    }
+}
+
+.bd-notice {
+    animation: bd-open-notice 400ms ease;
+    overflow: hidden;
+    height: 36px;
+    font-size: 14px;
+    line-height: 36px;
+    font-weight: 500;
+    text-align: center;
+    position: relative;
+    padding-left: 4px;
+    padding-right: 28px;
+    z-index: 101;
+    flex-shrink: 0;
+    flex-grow: 0;
+    border-radius: 8px 0 0;
+    box-shadow: var(--elevation-low);
+    color: #fff;
+    background: var(--color, var(--background-mobile-primary));
+}
+
+.bd-notice-close {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 36px;
+    height: 36px;
+    background: url(https://discord.com/assets/7731c77d99babca1a8faec204d98c380.svg) no-repeat;
+    background-position: 50% 55%;
+    background-size: 10px 10px;
+    opacity: .5;
+    transition: opacity .2s;
+    cursor: pointer;
+    -webkit-app-region: no-drag;
+}
+
+.bd-notice-button {
+    font-size: 14px;
+    font-weight: 500;
+    position: relative;
+    top: 6px;
+    border: 1px solid;
+    color: #fff;
+    border-radius: 3px;
+    height: 24px;
+    padding: 0 10px;
+    box-sizing: border-box;
+    display: inline-block;
+    vertical-align: top;
+    margin-left: 10px;
+    line-height: 22px;
+    transition: background-color .2s ease,color .2s ease,border-color .2s ease;
+    -webkit-app-region: no-drag;
+    border-color: #fff;
+    background: transparent;
+}
+
+.bd-notice-button:hover {
+    color: var(--color, var(--background-mobile-primary));
+    background: #fff;
+}
+
+.bd-notice-close:hover {
+    opacity: 1;
+}

--- a/renderer/src/ui/notices.js
+++ b/renderer/src/ui/notices.js
@@ -17,7 +17,7 @@ export default class Notices {
         Object.assign(element, options);
         const filteredChildren = children.filter((n) => n);
     
-        if (filteredChildren.length > 0) Reflect.apply(element.append, element, filteredChildren);
+        if (filteredChildren.length > 0) element.append(...filteredChildren);
 
         return element;
     }

--- a/renderer/src/ui/notices.js
+++ b/renderer/src/ui/notices.js
@@ -1,0 +1,86 @@
+import {WebpackModules} from "modules";
+
+export default class Notices {
+    static get baseClass() {return this.__baseClass || (this.__baseClass = WebpackModules.getByProps("container", "base")?.base);}
+
+    /** Shorthand for `type = "info"` for {@link module:Notices.show} */
+    static info(content, options = {}) {return this.show(content, Object.assign({}, options, {type: "info"}));}
+    /** Shorthand for `type = "warning"` for {@link module:Notices.show} */
+    static warn(content, options = {}) {return this.show(content, Object.assign({}, options, {type: "warning"}));}
+    /** Shorthand for `type = "error"` for {@link module:Notices.show} */
+    static error(content, options = {}) {return this.show(content, Object.assign({}, options, {type: "error"}));}
+    /** Shorthand for `type = "success"` for {@link module:Notices.show} */
+    static success(content, options = {}) {return this.show(content, Object.assign({}, options, {type: "success"}));}
+
+    static createElement(type, options = {}, ...children) {
+        const element = document.createElement(type);
+        Object.assign(element, options);
+        const filteredChildren = children.filter((n) => n);
+    
+        if (filteredChildren.length > 0) Reflect.apply(element.append, element, filteredChildren);
+
+        return element;
+    }
+
+    static joinClassNames(...classNames) {
+        return classNames.filter((n) => n).join(" ");
+    }
+
+    /**
+     * Show a notice above discord's chat layer.
+     * @param {string} content Content of the notice
+     * @param {object} options Options for the notice.
+     * @param {string} [options.type="info" | "error" | "warning" | "success"] Type for the notice. Will affect the color.
+     * @param {Array<{label: string, onClick: (onClose: () => void) => void}>} [options.buttons] Buttons that should be added next to the notice text.
+     * @param {number} [options.timeout=10000] Timeout until the toast is closed. Won't fire if it's set to 0;
+     * @returns {void}
+     */
+    static show(content, options = {}) {
+        const {type, buttons = [], timeout = 10000} = options;
+        const haveContainer = this.ensureContainer();
+        if (!haveContainer) return;
+
+        const closeNotification = function () {
+            if (noticeElement) {
+                noticeElement.classList.add("bd-notice-closing");
+                setTimeout(() => {
+                    noticeElement.remove();
+                }, 300);
+            }
+        };
+
+        const noticeElement = this.createElement("div", {
+            className: this.joinClassNames("bd-notice", type && `bd-notice-${type}`),
+        }, this.createElement("div", {
+            className: "bd-notice-close",
+            onclick: closeNotification
+        }), this.createElement("span", {
+            className: "bd-notice-content"
+        }, content), ...buttons.map((button) => {
+            if (!button || !button.label || typeof(button.onClick) !== "function") return null;
+
+            return this.createElement("button", {
+                className: "bd-notice-button",
+                onclick: button.onClick.bind(null, closeNotification)
+            }, button.label);
+        }));
+
+        document.getElementById("bd-notices").appendChild(noticeElement);
+
+        if (timeout > 0) {
+            setTimeout(closeNotification, timeout);
+        }
+    }
+
+    static ensureContainer() {
+        if (document.getElementById("bd-notices")) return true;
+        const container = document.querySelector(`.${this.baseClass}`);
+        if (!container) return false;
+        const noticeContainer = this.createElement("div", {
+            id: "bd-notices"
+        });
+        container.prepend(noticeContainer);
+
+        return true;
+    }
+}


### PR DESCRIPTION
This is based on #1022 which is why it looks kinda messed in the git. That will be fixed once that PR has been merged.

![image](https://user-images.githubusercontent.com/5641607/132244995-927dcfd0-ce24-44eb-8146-9aff7d7dc08e.png)
(Outdated image, removed themes from the notice)

At the moment it skips pretty much the whole BD renderer part from being loaded, so there are no settings tabs, etc.

Crashing in Recovery Mode results in skipping the injection same as before.

- [x] Notice with open plugin folder and reload button
- [x] Load CustomCss but don't actually apply it
- [ ] Load plugins without actually running their code
- [ ] Load themes without applying them
- [ ] Add a message to the settings menu when in recovery mode
- [ ] Add Recovery Mode button to the "Well this is awkward" crash screen