### PR TITLE
Add bd-transparency class.

### DIFF
--- a/renderer/src/builtins/window/transparency.js
+++ b/renderer/src/builtins/window/transparency.js
@@ -9,10 +9,12 @@ export default new class WindowTransparency extends Builtin {
 
     enabled() {
         this.showModal(Strings.WindowPrefs.enabledInfo);
+        document.body.classList.add("bd-transparency");
     }
 
     disabled() {
         this.showModal(Strings.WindowPrefs.disabledInfo);
+        document.body.classList.remove("bd-transparency");
     }
 
     showModal(info) {


### PR DESCRIPTION
A lot theme devs have been asking if bd could add a class to the dom so they can detect whenever the user has transparency enabled or not. I decicded to add the class to the `body` because discord is updating the classList of the `html` every time you focus discord etc. Which would make our class to be removed. Adding it to the body makes it stay.