### PR TITLE
Fix error messages from BdApi.monkeyPatch

### DIFF
--- a/renderer/src/modules/pluginapi.js
+++ b/renderer/src/modules/pluginapi.js
@@ -220,7 +220,7 @@ BdApi.monkeyPatch = function(what, methodName, options) {
             return patchReturn;
         }
         catch (err) {
-            Logger.err(`${callerId}:monkeyPatch`, `Error in the ${patchType} of ${methodName}`);
+            Logger.err(`${callerId}:monkeyPatch`, `Error in the ${patchType} of ${methodName}`, err);
         }
     });
     return data.cancelPatch;


### PR DESCRIPTION
It seems that you forgot to log the actual error in the console which makes plugin devs unable to find out what's wrong. I passed the `err` argument from the `catch (err) {}` to the logger output so plugin devs should have an easier life now.