### PR TITLE
Add :wide modifier

### DIFF
--- a/renderer/src/builtins/emotes/emotes.js
+++ b/renderer/src/builtins/emotes/emotes.js
@@ -26,7 +26,7 @@ const Emotes = {
 
 const blocklist = [];
 const overrides = ["twitch", "subscriber", "bttv", "ffz"];
-const modifiers = ["flip", "spin", "pulse", "spin2", "spin3", "1spin", "2spin", "3spin", "tr", "bl", "br", "shake", "shake2", "shake3", "flap"];
+const modifiers = ["flip", "spin", "pulse", "spin2", "spin3", "1spin", "2spin", "3spin", "tr", "bl", "br", "shake", "shake2", "shake3", "flap", "wide"];
 
  export default new class EmoteModule extends Builtin {
     get name() {return "Emotes";}

--- a/renderer/src/styles/builtins/emotes.css
+++ b/renderer/src/styles/builtins/emotes.css
@@ -58,6 +58,11 @@
     transform: scaleX(-1);
 }
 
+.emotewide {
+    width: 6rem !important;
+    object-fit: fill;
+}
+
 .emotespin {
     animation: 1s emote-spin infinite linear;
 }


### PR DESCRIPTION
I bring an _incredibly important_ change -- the addition of a `:wide` modifier for emotes, with similar behavior to widePeepoHappy and widePeepoSad on Twitch.

Here's what it looks like in a text chat:

<img width="139" alt="Screen Shot 2021-12-10 at 4 37 27 PM" src="https://user-images.githubusercontent.com/9936817/145654115-841dedff-8b25-4192-982d-93c1299dcdf2.png">

Yeah, it looks awful, but that's the point.
