### PR TITLE
Enable DevTools on Stable

### DIFF
--- a/injector/src/index.js
+++ b/injector/src/index.js
@@ -22,6 +22,19 @@ if (!process.argv.includes("--vanilla")) {
     else CSP.remove();
 }
 
+// Enable DevTools on Stable.
+let fakeAppSettings;
+Object.defineProperty(global, "appSettings", {
+    get() {
+        return fakeAppSettings;
+    },
+    set(value) {
+        if (!value.hasOwnProperty("settings")) value.settings = {};
+        value.settings.DANGEROUS_ENABLE_DEVTOOLS_ONLY_ENABLE_IF_YOU_KNOW_WHAT_YOURE_DOING = true;
+        fakeAppSettings = value;
+    },
+});
+
 // Use Discord's info to run the app
 if (process.platform == "win32" || process.platform == "darwin") {
     const basePath = path.join(app.getAppPath(), "..", "app.asar");


### PR DESCRIPTION
A new change on Stable makes it so that Chromium DevTools is disabled and the global hook isn't created unless the `DANGEROUS_ENABLE_DEVTOOLS_ONLY_ENABLE_IF_YOU_KNOW_WHAT_YOURE_DOING` `settings.json` setting is set to `true`.