### PR TITLE
remove usage of e.which

### DIFF
--- a/renderer/src/builtins/developer/debugger.js
+++ b/renderer/src/builtins/developer/debugger.js
@@ -14,7 +14,7 @@ export default new class DeveloperMode extends Builtin {
     }
 
     debugListener(e) {
-        if (e.which === 119 || e.which == 118) { // F8
+        if (e.key === "F7" || e.key == "F8") { // F8
             debugger; // eslint-disable-line no-debugger
             e.preventDefault();
             e.stopImmediatePropagation();

--- a/renderer/src/builtins/developer/debugger.js
+++ b/renderer/src/builtins/developer/debugger.js
@@ -14,7 +14,7 @@ export default new class DeveloperMode extends Builtin {
     }
 
     debugListener(e) {
-        if (e.key === "F7" || e.key == "F8") { // F8
+        if (e.key === "F7" || e.key == "F8") {
             debugger; // eslint-disable-line no-debugger
             e.preventDefault();
             e.stopImmediatePropagation();

--- a/renderer/src/builtins/developer/devtools.js
+++ b/renderer/src/builtins/developer/devtools.js
@@ -13,7 +13,7 @@ export default new class DevToolsListener extends Builtin {
     }
 
     toggleDevTools(e) {
-        if (e.ctrlKey && e.shiftKey && e.which === 73) { // Ctrl + Shift + I
+        if (e.ctrlKey && e.shiftKey && e.key === "I") {
             e.stopPropagation();
             e.preventDefault();
             if (this.get(this.collection, this.category, this.id)) IPC.toggleDevTools();

--- a/renderer/src/builtins/developer/inspectelement.js
+++ b/renderer/src/builtins/developer/inspectelement.js
@@ -15,7 +15,7 @@ export default new class InspectElement extends Builtin {
     }
 
     inspectElement(e) {
-        if (e.ctrlKey && e.shiftKey && e.which === 67) { // Ctrl + Shift + C
+        if (e.ctrlKey && e.shiftKey && e.key === "C") { // Ctrl + Shift + C
             IPC.inspectElement();
         }
     }

--- a/renderer/src/ui/publicservers/menu.js
+++ b/renderer/src/ui/publicservers/menu.js
@@ -75,7 +75,7 @@ export default class PublicServers extends React.Component {
     }
 
     searchKeyDown(e) {
-        if (this.state.loading || e.which !== 13) return;
+        if (this.state.loading || e.key !== "Enter") return;
         const term = e.target.value;
         if (this.state.tab == "Featured" || this.state.tab == "Popular") this.setState({tab: "All"}, () => this.search(term));
         else this.search(term);


### PR DESCRIPTION
`UIEvent.which` is a non-standard feature, and as of 2020 [`KeyboardEvent.keyCode` is now deprecated](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode). Using `KeyboardEvent.key` also has some upsides for code readibility.