### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/renderer/src/moduleloader.js
+++ b/renderer/src/moduleloader.js
@@ -12,7 +12,7 @@ export default function() {
         }
 
         if (request === namespace || request.startsWith(prefix)) {
-            const requested = request.substr(prefix.length);
+            const requested = request.slice(prefix.length);
             if (requested == "bdapi") return BdApi;
         }
 

--- a/renderer/src/modules/addonmanager.js
+++ b/renderer/src/modules/addonmanager.js
@@ -164,8 +164,8 @@ export default class AddonManager {
             if (line.charAt(0) === "@" && line.charAt(1) !== " ") {
                 out[field] = accum;
                 const l = line.indexOf(" ");
-                field = line.substr(1, l - 1);
-                accum = line.substr(l + 1);
+                field = line.slice(1, l >= 0 ? l : 0);
+                accum = line.slice(l + 1);
             }
             else {
                 accum += " " + line.replace("\\n", "\n").replace(escapedAtRegex, "@");


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.