### PR TITLE
Refactor emote matching implementation

### DIFF
--- a/renderer/src/builtins/emotes/emotes.js
+++ b/renderer/src/builtins/emotes/emotes.js
@@ -185,7 +185,7 @@ const modifiers = ["flip", "spin", "pulse", "spin2", "spin3", "1spin", "2spin", 
                     // eat through whitespace
                     while (idx < len && isWhitespace(node[idx])) idx++;
             
-                    if (mismatch || name.length < 4) continue;
+                    if (mismatch || name.length < 4 || blocklist.includes(name)) continue;
 
                     let category = Overrides[override];
             

--- a/renderer/src/builtins/emotes/emotes.js
+++ b/renderer/src/builtins/emotes/emotes.js
@@ -189,7 +189,7 @@ const modifiers = ["flip", "spin", "pulse", "spin2", "spin3", "1spin", "2spin", 
 
                     let category = Overrides[override];
             
-                    if (!override || !(override in Overrides)) {
+                    if (!category) {
                         modifier = override;
             
                         // go through each source and see if we can find a match

--- a/renderer/src/builtins/emotes/emotes.js
+++ b/renderer/src/builtins/emotes/emotes.js
@@ -24,8 +24,14 @@ const Emotes = {
     FrankerFaceZ: {}
 };
 
+const Overrides = {
+    twitch: 'TwitchGlobal',
+    subscriber: 'TwitchSubscriber',
+    bttv: 'BTTV',
+    ffz: 'FFZ',
+};
+
 const blocklist = [];
-const overrides = ["twitch", "subscriber", "bttv", "ffz"];
 const modifiers = ["flip", "spin", "pulse", "spin2", "spin3", "1spin", "2spin", "3spin", "tr", "bl", "br", "shake", "shake2", "shake3", "flap"];
 
  export default new class EmoteModule extends Builtin {
@@ -180,8 +186,10 @@ const modifiers = ["flip", "spin", "pulse", "spin2", "spin3", "1spin", "2spin", 
                     while (idx < len && isWhitespace(node[idx])) idx++;
             
                     if (mismatch || name.length < 4) continue;
+
+                    let category = Overrides[override];
             
-                    if (!override || !(override in Emotes)) {
+                    if (!override || !(override in Overrides)) {
                         modifier = override;
             
                         // go through each source and see if we can find a match
@@ -189,13 +197,13 @@ const modifiers = ["flip", "spin", "pulse", "spin2", "spin3", "1spin", "2spin", 
                             const emotes = Emotes[source];
             
                             if (name in emotes) {
-                                override = source;
+                                category = source;
                                 break;
                             }
                         }
             
-                        if (!override) continue;
-                    } else if (!(name in Emotes[override])) {
+                        if (!category) continue;
+                    } else if (!(name in Emotes[category])) {
                         continue;
                     }
             

--- a/renderer/src/builtins/emotes/emotes.js
+++ b/renderer/src/builtins/emotes/emotes.js
@@ -217,7 +217,7 @@ const modifiers = ["flip", "spin", "pulse", "spin2", "spin3", "1spin", "2spin", 
                     const post = node.substring(idx);
         
                     const el = DiscordModules.React.createElement(BDEmote, {
-                        url: EmoteURLs[override].format({id: Emotes[current][name]}),
+                        url: EmoteURLs[category].format({id: Emotes[category][name]}),
                         isFavorite: this.isFavorite(name),
                         name,
                         modifier,


### PR DESCRIPTION
Reimplementation of the matcher, instead of trying to break up message content into array of words, it steps through each character instead.

This way saves the cost incurred when breaking up said content, and we can easily skip matching the rest of the word and seek to the next word if it encounters a mismatch, this is currently only used when encountering extra colon on the emote (`emote:override:modifier:unrelated`) but this can be easily expanded.

