### PR TITLE
Add Development support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -20,7 +20,7 @@ assignees: ''
 <!-- If applicable, add screenshots to help explain your problem. -->
 
 **Discord Version**
-<!-- Stable, Canary, PTB -->
+<!-- Stable, Canary, Development, PTB -->
 
 **Additional Context**
 <!-- Add any other context about the problem here. -->

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For normal users, installing via the installers makes the most sense. However wh
 1. Clone this repository `git clone https://github.com/BetterDiscord/BetterDiscord.git`
 2. Install dependencies with `npm install`
 3. Build both the Injector and Renderer bundles with `npm run build` this will create a `injector.js`, `preload.js`, and `renderer.js` in the `dist` folder.
-4. Run the inject script to inject the local files into your Discord client (`npm run inject`). Alternately install it to non-stable using `npm run inject canary`.
+4. Run the inject script to inject the local files into your Discord client (`npm run inject`). Alternately install it to non-stable using `npm run inject canary` or `npm run inject development`.
 
 # FAQ
 

--- a/renderer/src/modules/datastore.js
+++ b/renderer/src/modules/datastore.js
@@ -10,7 +10,7 @@ const discordVersion = window?.DiscordNative?.remoteApp?.getVersion?.() ?? "0.0.
 // =======================
 // %appdata%\BetterDiscord
 //     -> data
-//         -> [releaseChannel]\ (stable/canary/ptb)
+//         -> [releaseChannel]\ (stable/canary/development/ptb)
 //             -> settings.json
 //             -> plugins.json
 //             -> themes.json
@@ -59,7 +59,7 @@ export default new class DataStore {
         const oldData = __non_webpack_require__(oldFile); // got the data
         fs.renameSync(oldFile, `${oldFile}.bak`); // rename file after grabbing data to prevent loop
         const setChannelData = (channel, key, value, ext = "json") => fs.writeFileSync(path.resolve(this.baseFolder, channel, `${key}.${ext}`), JSON.stringify(value, null, 4));
-        const channels = ["stable", "canary", "ptb"];
+        const channels = ["stable", "canary", "development", "ptb"];
         let customcss = "";
         let favoriteEmotes = {};
         try {customcss = oldData.bdcustomcss ? atob(oldData.bdcustomcss) : "";}

--- a/scripts/inject.js
+++ b/scripts/inject.js
@@ -7,7 +7,7 @@ const buildPackage = require("./package");
 
 const useBdRelease = args[2] && args[2].toLowerCase() === "release";
 const releaseInput = useBdRelease ? args[3] && args[3].toLowerCase() : args[2] && args[2].toLowerCase();
-const release = releaseInput === "canary" ? "Discord Canary" : releaseInput === "ptb" ? "Discord PTB" : "Discord";
+const release = releaseInput === "canary" ? "Discord Canary" : releaseInput === "development" ? "Discord Development" : releaseInput === "ptb" ? "Discord PTB" : "Discord";
 const bdPath = useBdRelease ? path.resolve(__dirname, "..", "dist", "betterdiscord.asar") : path.resolve(__dirname, "..", "dist");
 const discordPath = (function() {
     let resourcePath = "";


### PR DESCRIPTION
It seems that BetterDiscord only supports PTB, Canary and Stable. I decided to change this. This should now allow you to inject to Development by `npm run inject development` :D