### PR TITLE
Fallback to textarea when Monaco load fails

### DIFF
--- a/renderer/src/modules/dommanager.js
+++ b/renderer/src/modules/dommanager.js
@@ -91,10 +91,11 @@ export default class DOMManager {
 
     static injectScript(id, url) {
         id = this.escapeID(id);
-        return new Promise(resolve => {
+        return new Promise((resolve, reject) => {
             const script = this.getElement(`#${id}`, this.bdScripts) || this.createElement("script", {id});
             script.src = url;
             script.onload = resolve;
+            script.onerror = reject;
             this.bdScripts.append(script);
         });
     }

--- a/renderer/src/styles/builtins/customcss.css
+++ b/renderer/src/styles/builtins/customcss.css
@@ -98,3 +98,11 @@
 .monaco-editor .view-overlays .current-line {
     width: 1e+06px !important;
 }
+
+.bd-fallback-editor {
+    height: 100%;
+    width: 100%;
+    resize: none;
+    overflow: auto;
+    white-space: nowrap;
+}


### PR DESCRIPTION
Now whenever the Monaco editor fails to load it will just use a small fallback editor that is essentially just a textarea.

Currently when the editor fails to load the Editor module never finishes loading and every built-in module past that (most notably plugins and themes) will never be loaded. The editor failing to load happens to people every now and then, especially when firewall or other network settings block it.

![image](https://user-images.githubusercontent.com/5641607/163488937-42a586ff-7958-4ad2-b41f-4bdca1577a28.png)

The only thing I am wondering about is the `showSettings` method that seems to be completely unused.