### PR TITLE
Block webhook requests using Electron's webRequest API

### DIFF
--- a/injector/src/index.js
+++ b/injector/src/index.js
@@ -5,6 +5,7 @@ import Module from "module";
 import ipc from "./modules/ipc";
 import BrowserWindow from "./modules/browserwindow";
 import CSP from "./modules/csp";
+import Secure from "./modules/secure";
 
 if (!process.argv.includes("--vanilla")) {
     process.env.NODE_OPTIONS = "--no-force-async-hooks-checks";
@@ -16,10 +17,10 @@ if (!process.argv.includes("--vanilla")) {
     // Register all IPC events
     ipc.registerEvents();
 
+    // Ready state agnostic because Linux users install to discord_desktop_core when the app is ready already
+    app.whenReady().then(() => CSP.remove());
 
-    // Remove CSP immediately on linux since they install to discord_desktop_core still
-    if (process.platform == "win32" || process.platform == "darwin") app.once("ready", CSP.remove);
-    else CSP.remove();
+    Secure.blockWebhooks();
 }
 
 // Enable DevTools on Stable.

--- a/injector/src/modules/secure.js
+++ b/injector/src/modules/secure.js
@@ -1,0 +1,15 @@
+const {session} = require("electron");
+
+export default class Secure {
+    static blockWebhooks() {
+        console.info("[Secure] Blocking webhook requests");
+        session.defaultSession.webRequest.onBeforeRequest(
+            {
+                urls: ["*://*/*"]
+            },
+            async (details, cb) => {
+                cb({cancel: details.url.includes("api/webhooks")});
+            }
+        );
+    }
+}

--- a/renderer/src/secure.js
+++ b/renderer/src/secure.js
@@ -21,11 +21,4 @@ export default function() {
     // Prevent interception by patching Reflect.apply and Function.prototype.bind
     Object.defineProperty(Reflect, "apply", {value: Reflect.apply, writable: false, configurable: false});
     Object.defineProperty(Function.prototype, "bind", {value: Function.prototype.bind, writable: false, configurable: false});
-
-    const oOpen = XMLHttpRequest.prototype.open;
-    XMLHttpRequest.prototype.open = function() {
-        const url = arguments[1];
-        if (url.toLowerCase().includes("api/webhooks")) return null;
-        return Reflect.apply(oOpen, this, arguments);
-    };
 }


### PR DESCRIPTION
This PR uses Electron's own webRequest API to block webhook requests which are most commonly done by token loggers. The previous version used a patch to XHR which did not affect fetch afaik and could potentially be bypassed in other ways. 

Of course requests done using native modules such as `request` or node's own `http` will be unaffected by this change.

A blocked webhook request would look like this:
![image](https://user-images.githubusercontent.com/5641607/163604337-9f8d1e8d-b032-4008-9d55-2fc3059ed8f1.png)