### PR TITLE
Rework React DevTools resolution

### DIFF
--- a/injector/src/modules/reactdevtools.js
+++ b/injector/src/modules/reactdevtools.js
@@ -15,7 +15,8 @@ const findExtension = function() {
                 path.resolve(process.env.LOCALAPPDATA, "Google/Chrome SxS/User Data"),
                 path.resolve(process.env.LOCALAPPDATA, "Opera Software/Opera Stable"), // Opera stores things differently
                 path.resolve(process.env.LOCALAPPDATA, "BraveSoftware/Brave-Browser/User Data"),
-                path.resolve(process.env.LOCALAPPDATA, "Vivaldi/User Data")
+                path.resolve(process.env.LOCALAPPDATA, "Vivaldi/User Data"),
+                path.resolve(process.env.LOCALAPPDATA, "Microsoft/Edge/User Data")
             ];
             break;
         case "darwin":
@@ -39,7 +40,8 @@ const findExtension = function() {
                 path.resolve(process.env.HOME, ".config/opera"),
                 path.resolve(process.env.HOME, ".config/BraveSoftware/Brave-Browser"),
                 path.resolve(process.env.HOME, ".config/vivaldi"),
-                path.resolve(process.env.HOME, ".config/vivaldi-snapshot")
+                path.resolve(process.env.HOME, ".config/vivaldi-snapshot"),
+                path.resolve(process.env.HOME, ".config/microsoft-edge")
             ];
             if ("CHROME_USER_DATA_DIR" in process.env) browserFolders.unshift(process.env.CHROME_USER_DATA_DIR);
             break;


### PR DESCRIPTION
Now searches in all of the paths described in the Chromium Project documentation:
https://chromium.googlesource.com/chromium/src.git/+/HEAD/docs/user_data_dir.md
As a result it should be able to find the extensions in the folders for Chrome, Chromium, Chrome Beta, and Chrome Canary

On top of that it also searches for directories for the following popular chromium-based browsers: Opera, Brave, Vivaldi, Microsoft Edge

Other candidates could include  ~~Microsoft Edge and~~ Opera GX among others but these were not included in this PR.

It would be nice if a Windows user could verify that it works properly, same for Mac but I will test that one myself as well.