### PR TITLE
fix(locales): french typo

### DIFF
--- a/assets/locales/fr.json
+++ b/assets/locales/fr.json
@@ -197,7 +197,7 @@
         "addonSettings": "Réglages",
         "website": "Site web",
         "source": "Source",
-        "invite": "Server de support",
+        "invite": "Serveur de support",
         "donate": "Donner",
         "patreon": "Patreon",
         "name": "Nom",


### PR DESCRIPTION
**Server** is for english while **Serveur** is the real french word.