### PR TITLE
[Feature] Add uninject script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "build-renderer": "npm run build --prefix renderer",
         "pack-emotes": "node scripts/emotes.js",
         "inject": "node scripts/inject.js",
+        "uninject": "node scripts/uninject.js",
         "lint": "eslint --ext .js common/ && npm run lint --prefix injector && npm run lint --prefix renderer",
         "test": "mocha --require @babel/register --recursive \"./tests/renderer/*.js\"",
         "dist": "npm run build-prod && node scripts/pack.js"

--- a/scripts/discordpath.js
+++ b/scripts/discordpath.js
@@ -1,0 +1,31 @@
+const fs = require("fs");
+const path = require("path");
+
+module.exports = function getDiscordPath(useBdRelease, releaseInput, release, args) {    
+    let resourcePath = "";
+    if (process.platform === "win32") {
+        const basedir = path.join(process.env.LOCALAPPDATA, release.replace(/ /g, ""));
+        if (!fs.existsSync(basedir)) throw new Error(`Cannot find directory for ${release}`);
+        const version = fs.readdirSync(basedir).filter(f => fs.lstatSync(path.join(basedir, f)).isDirectory() && f.split(".").length > 1).sort().reverse()[0];
+        resourcePath = path.join(basedir, version, "resources");
+    }
+    else if (process.platform === "darwin") {
+        const appPath = releaseInput === "canary" ? path.join("/Applications", "Discord Canary.app")
+            : releaseInput === "ptb" ? path.join("/Applications", "Discord PTB.app")
+            : useBdRelease && args[3] ? args[3] ? args[2] : args[2]
+            : path.join("/Applications", "Discord.app");
+
+        resourcePath = path.join(appPath, "Contents", "Resources");
+    }
+    else {
+        const userData = process.env.XDG_CONFIG_HOME ? process.env.XDG_CONFIG_HOME : path.join(process.env.HOME, ".config");
+        const basedir = path.join(userData, release.toLowerCase().replace(" ", ""));
+        if (!fs.existsSync(basedir)) return "";
+        const version = fs.readdirSync(basedir).filter(f => fs.lstatSync(path.join(basedir, f)).isDirectory() && f.split(".").length > 1).sort().reverse()[0];
+        if (!version) return "";
+        resourcePath = path.join(basedir, version, "modules", "discord_desktop_core");
+    }
+
+    if (fs.existsSync(resourcePath)) return resourcePath;
+    return "";
+};

--- a/scripts/inject.js
+++ b/scripts/inject.js
@@ -1,6 +1,7 @@
 const args = process.argv;
 const fs = require("fs");
 const path = require("path");
+const getDiscordPath = require("./discordpath");
 
 const doSanityChecks = require("./validate");
 const buildPackage = require("./package");
@@ -9,34 +10,7 @@ const useBdRelease = args[2] && args[2].toLowerCase() === "release";
 const releaseInput = useBdRelease ? args[3] && args[3].toLowerCase() : args[2] && args[2].toLowerCase();
 const release = releaseInput === "canary" ? "Discord Canary" : releaseInput === "ptb" ? "Discord PTB" : "Discord";
 const bdPath = useBdRelease ? path.resolve(__dirname, "..", "dist", "betterdiscord.asar") : path.resolve(__dirname, "..", "dist");
-const discordPath = (function() {
-    let resourcePath = "";
-    if (process.platform === "win32") {
-        const basedir = path.join(process.env.LOCALAPPDATA, release.replace(/ /g, ""));
-        if (!fs.existsSync(basedir)) throw new Error(`Cannot find directory for ${release}`);
-        const version = fs.readdirSync(basedir).filter(f => fs.lstatSync(path.join(basedir, f)).isDirectory() && f.split(".").length > 1).sort().reverse()[0];
-        resourcePath = path.join(basedir, version, "resources");
-    }
-    else if (process.platform === "darwin") {
-        const appPath = releaseInput === "canary" ? path.join("/Applications", "Discord Canary.app")
-            : releaseInput === "ptb" ? path.join("/Applications", "Discord PTB.app")
-            : useBdRelease && args[3] ? args[3] ? args[2] : args[2]
-            : path.join("/Applications", "Discord.app");
-
-        resourcePath = path.join(appPath, "Contents", "Resources");
-    }
-    else {
-        const userData = process.env.XDG_CONFIG_HOME ? process.env.XDG_CONFIG_HOME : path.join(process.env.HOME, ".config");
-        const basedir = path.join(userData, release.toLowerCase().replace(" ", ""));
-        if (!fs.existsSync(basedir)) return "";
-        const version = fs.readdirSync(basedir).filter(f => fs.lstatSync(path.join(basedir, f)).isDirectory() && f.split(".").length > 1).sort().reverse()[0];
-        if (!version) return "";
-        resourcePath = path.join(basedir, version, "modules", "discord_desktop_core");
-    }
-
-    if (fs.existsSync(resourcePath)) return resourcePath;
-    return "";
-})();
+const discordPath = getDiscordPath(useBdRelease, releaseInput, release, args);
 
 doSanityChecks(bdPath);
 buildPackage(bdPath);

--- a/scripts/uninject.js
+++ b/scripts/uninject.js
@@ -1,0 +1,39 @@
+const args = process.argv;
+const fs = require("fs");
+const path = require("path");
+const getDiscordPath = require("./discordpath");
+
+const useBdRelease = args[2] && args[2].toLowerCase() === "release";
+const releaseInput = useBdRelease ? args[3] && args[3].toLowerCase() : args[2] && args[2].toLowerCase();
+const release = releaseInput === "canary" ? "Discord Canary" : releaseInput === "ptb" ? "Discord PTB" : "Discord";
+
+const discordPath = getDiscordPath(useBdRelease, releaseInput, release, args);
+
+console.log(`Uninjecting ${release}`);
+if (!fs.existsSync(discordPath)) throw new Error(`Cannot find directory for ${release}`);
+console.log(`    ✅ Found ${release} in ${discordPath}`);
+
+const appPath = process.platform === "win32" || process.platform === "darwin" ? path.join(discordPath, "app") : discordPath;
+const indexJs = path.join(appPath, "index.js");
+
+console.log("");
+console.log("Deleting shims...");
+
+try {
+    console.log(`Removing ${appPath}`);
+    if (process.platform === "win32" || process.platform === "darwin") {
+        if (fs.existsSync(appPath)) {
+            fs.rmSync(appPath, {recursive: true, force: true});
+        }
+    }
+    else {
+        if (fs.existsSync(indexJs)) fs.writeFileSync(indexJs, `module.exports = require("./core.asar");`);
+    }
+    console.log("    ✅ Deletion successful");
+    console.log("");
+    console.log(`Uninjection successful, please restart ${release}.`);
+}
+catch (err) {
+    console.log(`❌ Could not delete folder ${appPath}`);
+    console.log(`❌ ${err.message}`);
+}


### PR DESCRIPTION
Since it's possible to build and inject BD via npm scripts, but not remove/uninstall/uninject it, I thought this might be a nice addition for people with the manual install/developers.
I am not entirely sure if I have implemented it for all platforms correctly, I kind of just looked at how the installer uninstalls BD and tried to translate that logic here. Would be happy about suggestions/feedback.

I'm also not too sure if the naming "uninject" makes sense, but since the  "install" script refers to installing npm packages here and "inject" to actually injecting BD, "uninject" probably makes more sense than "uninstall" I think.