### PR TITLE
Fix byRegex not supporting filter argument

### DIFF
--- a/renderer/src/modules/pluginapi.js
+++ b/renderer/src/modules/pluginapi.js
@@ -610,7 +610,7 @@ BdApi.Webpack = {
          * @param {function} filter Additional filter
          * @returns {function} A filter that checks for a regex match
          */
-         byRegex(regex) {return Filters.byRegex(regex);},
+         byRegex(regex, filter) {return Filters.byRegex(regex, filter);},
 
          /**
          * Generates a function that filters by strings.


### PR DESCRIPTION
In `BdApi` the optional `filter` argument wasn't forwarded to the internal function.