### PR TITLE
[Bugfix] Fix Custom css crashing on Canary

### DIFF
--- a/renderer/src/modules/discordmodules.js
+++ b/renderer/src/modules/discordmodules.js
@@ -36,7 +36,6 @@ export default Utilities.memoizeObject({
 
     /* Current User Info, State and Settings */
     get UserInfoStore() {return WebpackModules.getByProps("getToken");},
-    get UserSettingsStore() {return WebpackModules.getByProps("getAllSettings", "theme");},
     get AccountManager() {return WebpackModules.getByProps("register", "login");},
     get UserSettingsUpdater() {return WebpackModules.getByProps("updateRemoteSettings");},
     get OnlineWatcher() {return WebpackModules.getByProps("isOnline");},
@@ -44,6 +43,8 @@ export default Utilities.memoizeObject({
     get RelationshipStore() {return WebpackModules.getByProps("isBlocked", "getFriendIDs");},
     get RelationshipManager() {return WebpackModules.getByProps("addRelationship");},
     get MentionStore() {return WebpackModules.getByProps("getMentions");},
+    get LocaleStore() {return WebpackModules.getByProps("locale", "addChangeListener");},
+    get ThemeStore() {return WebpackModules.getByProps("theme", "addChangeListener");},
 
     /* User Stores and Utils */
     get UserStore() {return WebpackModules.getByProps("getCurrentUser");},

--- a/renderer/src/modules/localemanager.js
+++ b/renderer/src/modules/localemanager.js
@@ -3,10 +3,10 @@ import DiscordModules from "./discordmodules";
 import Utilities from "./utilities";
 import Events from "./emitter";
 
-const {Dispatcher, UserSettingsStore} = DiscordModules;
+const {Dispatcher, LocaleStore} = DiscordModules;
 
 export default new class LocaleManager {
-    get discordLocale() {return UserSettingsStore?.locale ?? this.defaultLocale;}
+    get discordLocale() {return LocaleStore?.locale ?? this.defaultLocale;}
     get defaultLocale() {return "en-US";}
 
     constructor() {

--- a/renderer/src/ui/customcss/editor.jsx
+++ b/renderer/src/ui/customcss/editor.jsx
@@ -12,7 +12,7 @@ export default class CodeEditor extends React.Component {
     constructor(props) {
         super(props);
 
-        this.props.theme = DiscordModules.UserSettingsStore && DiscordModules.UserSettingsStore.theme === "light" ? "vs" : "vs-dark";
+        this.props.theme = DiscordModules.ThemeStore && DiscordModules.ThemeStore.theme === "light" ? "vs" : "vs-dark";
 
         this.props.language = this.props.language.toLowerCase().replace(/ /g, "_");
         if (!languages.includes(this.props.language)) this.props.language = CodeEditor.defaultProps.language;
@@ -36,7 +36,7 @@ export default class CodeEditor extends React.Component {
             this.editor = window.monaco.editor.create(document.getElementById(this.props.id), {
                 value: this.props.value,
                 language: this.props.language,
-                theme: DiscordModules.UserSettingsStore.theme == "light" ? "vs" : "vs-dark",
+                theme: DiscordModules.ThemeStore.theme == "light" ? "vs" : "vs-dark",
                 fontSize: Settings.get("settings", "editor", "fontSize"),
                 lineNumbers: Settings.get("settings", "editor", "lineNumbers"),
                 minimap: {enabled: Settings.get("settings", "editor", "minimap")},
@@ -69,19 +69,19 @@ export default class CodeEditor extends React.Component {
             document.getElementById(this.props.id).appendChild(textarea);
         }
 
-        if (DiscordModules.UserSettingsStore) DiscordModules.UserSettingsStore.addChangeListener(this.onThemeChange);
+        if (DiscordModules.ThemeStore) DiscordModules.ThemeStore.addChangeListener(this.onThemeChange);
         window.addEventListener("resize", this.resize);
     }
 
     componentWillUnmount() {
         window.removeEventListener("resize", this.resize);
-        if (DiscordModules.UserSettingsStore) DiscordModules.UserSettingsStore.removeChangeListener(this.onThemeChange);
+        if (DiscordModules.ThemeStore) DiscordModules.ThemeStore.removeChangeListener(this.onThemeChange);
         for (const binding of this.bindings) binding.dispose();
         this.editor.dispose();
     }
 
     onThemeChange() {
-        const newTheme = DiscordModules.UserSettingsStore.theme === "light" ? "vs" : "vs-dark";
+        const newTheme = DiscordModules.ThemeStore.theme === "light" ? "vs" : "vs-dark";
         if (newTheme === this.props.theme) return;
         this.props.theme = newTheme;
         if (window.monaco?.editor) window.monaco.editor.setTheme(this.props.theme);


### PR DESCRIPTION
Issue in question: #1371

Tested on `Canary 141822 (e53c017)`, it seems that the locale and theme get saved in their own Store. This PR adds the LocaleStore and the ThemeStore to the DiscordModules, the UserSettingsStore seems to be no longer needed. 