### PR TITLE
Fixed 'data' event in electron17 https polyfill

### DIFF
--- a/renderer/src/polyfill/https.js
+++ b/renderer/src/polyfill/https.js
@@ -16,7 +16,7 @@ export function get(url, options = {}, callback) {
 
     Remote.https.get(url, options, (error, res, body) => {
         if (error) return emitter.emit("error", error);
-        emitter.emit("data", options && options.encoding === "binary" ? new Buffer(Buffer.from(body, "binary")) : body);
+        emitter.emit("data", options && options.encoding === "binary" ? Buffer.from(body, "binary") : body);
         emitter.emit("end", res);
     });
 

--- a/renderer/src/polyfill/https.js
+++ b/renderer/src/polyfill/https.js
@@ -4,16 +4,19 @@ import Remote from "./remote";
 export function get(url, options = {}, callback) {
     if (typeof(options) === "function") {
         callback = options;
-        options = null;
+        options = {};
     }
 
     const emitter = new EventEmitter();
 
     callback(emitter);
 
+    if(!options.encoding)
+        options['encoding'] = "binary";
+
     Remote.https.get(url, options, (error, res, body) => {
         if (error) return emitter.emit("error", error);
-        emitter.emit("data", body);
+        emitter.emit("data", new Buffer(Buffer.from(body,"binary")));
         emitter.emit("end", res);
     });
 

--- a/renderer/src/polyfill/https.js
+++ b/renderer/src/polyfill/https.js
@@ -16,7 +16,7 @@ export function get(url, options = {}, callback) {
 
     Remote.https.get(url, options, (error, res, body) => {
         if (error) return emitter.emit("error", error);
-        emitter.emit("data", new Buffer(Buffer.from(body,"binary")));
+        emitter.emit("data", new Buffer(Buffer.from(body, "binary")));
         emitter.emit("end", res);
     });
 

--- a/renderer/src/polyfill/https.js
+++ b/renderer/src/polyfill/https.js
@@ -19,7 +19,7 @@ export function get(url, options = {}, callback) {
 
     Remote.https.get(url, options, (error, res, body) => {
         if (error) return emitter.emit("error", error);
-        emitter.emit("data", options.encoding === "binary" ? Buffer.from(body, "binary") : body);
+        emitter.emit("data", Buffer.from(body, options.encoding));
         emitter.emit("end", res);
     });
 

--- a/renderer/src/polyfill/https.js
+++ b/renderer/src/polyfill/https.js
@@ -11,12 +11,15 @@ export function get(url, options = {}, callback) {
 
     callback(emitter);
 
-    if(options && !options.encoding)
+    if(!options)
+        options = {};
+
+    if(!options.encoding)
         options.encoding = "binary";
 
     Remote.https.get(url, options, (error, res, body) => {
         if (error) return emitter.emit("error", error);
-        emitter.emit("data", options && options.encoding === "binary" ? Buffer.from(body, "binary") : body);
+        emitter.emit("data", options.encoding === "binary" ? Buffer.from(body, "binary") : body);
         emitter.emit("end", res);
     });
 

--- a/renderer/src/polyfill/https.js
+++ b/renderer/src/polyfill/https.js
@@ -11,12 +11,12 @@ export function get(url, options = {}, callback) {
 
     callback(emitter);
 
-    if(!options.encoding)
-        options['encoding'] = "binary";
+    if(options && !options.encoding)
+        options.encoding = "binary";
 
     Remote.https.get(url, options, (error, res, body) => {
         if (error) return emitter.emit("error", error);
-        emitter.emit("data", new Buffer(Buffer.from(body, "binary")));
+        emitter.emit("data", options && options.encoding === "binary" ? new Buffer(Buffer.from(body, "binary")) : body);
         emitter.emit("end", res);
     });
 


### PR DESCRIPTION
I outlined the issue in more detail in #plugin-discussion on discord but basically this makes it return a buffer array of the raw bytes to behave more like the regular data event. The binary encoding option is there because body is normally 7-bit asciis which makes it not work when getting files. There's probably a better way to do this idk