### PR TITLE
Update webpackmodules.js

### DIFF
--- a/renderer/src/modules/webpackmodules.js
+++ b/renderer/src/modules/webpackmodules.js
@@ -170,6 +170,7 @@ export default class WebpackModules {
                         if (!foundModule) continue;
                         if (first) return foundModule;
                         rm.push(foundModule);
+                        foundModule = null;
                     }
                 }
                 else {


### PR DESCRIPTION
`foundModule` should be reset after finding the module, otherwise it returns duplicates of as much as how many `getters loop` iterations are left after the first valid condition