### PR TITLE
Fix color of BD setting page titles

### DIFF
--- a/renderer/src/styles/ui/bdsettings.css
+++ b/renderer/src/styles/ui/bdsettings.css
@@ -165,7 +165,7 @@
 }
 
 .bd-settings-title {
-    color: var(--header-primary, );
+    color: var(--header-primary, #888);
     font-weight: 600;
     cursor: default;
     flex: 1;

--- a/renderer/src/styles/ui/bdsettings.css
+++ b/renderer/src/styles/ui/bdsettings.css
@@ -165,7 +165,7 @@
 }
 
 .bd-settings-title {
-    color: #FFFFFF;
+    color: var(--header-primary, );
     font-weight: 600;
     cursor: default;
     flex: 1;


### PR DESCRIPTION
Before:

<img width="591" alt="Screenshot_2022-10-24 15 27 55" src="https://user-images.githubusercontent.com/25517624/197609405-b4726bde-82ed-4183-8988-6ec8c6682376.png">

After:
<img width="592" alt="Screenshot_2022-10-24 15 28 26" src="https://user-images.githubusercontent.com/25517624/197609486-c691b417-b818-4fc3-a130-1d18bc1aaec0.png">
