### PR TITLE
Add webpack aliases.

### DIFF
--- a/renderer/src/modules/api/webpack.js
+++ b/renderer/src/modules/api/webpack.js
@@ -9,6 +9,10 @@ import WebpackModules, {Filters} from "../webpackmodules";
  * @name Webpack
  */
 const Webpack = {
+    /**
+     * A Proxy that returns the module source by ID.
+     */
+    modules: WebpackModules.modules,
 
     /**
      * Series of {@link Filters} to be used for finding webpack modules.
@@ -61,6 +65,22 @@ const Webpack = {
     },
 
     /**
+     * Searches for a module by value, returns module & matched key. Useful in combination with the Patcher. 
+     * @param {(value: any, index: number, array: any[]) => boolean} filter A function to use to filter the module
+     * @param {object} [options] Set of options to customize the search
+     * @param {any} [options.target=null] Optional module target to look inside.
+     * @param {Boolean} [options.defaultExport=true] Whether to return default export when matching the default export
+     * @param {Boolean} [options.searchExports=false] Whether to execute the filter on webpack export getters. 
+     * @return {[Any, string]}
+     */
+    getMangled(filter, options = {}) {
+        if (("first" in options)) return Logger.error("BdApi.Webpack~getModule", "Unsupported option first.");
+        if (("defaultExport" in options) && typeof(options.defaultExport) !== "boolean") return Logger.error("BdApi.Webpack~getModule", "Unsupported type used for options.defaultExport", options.defaultExport, "boolean expected.");
+        if (("searchExports" in options) && typeof(options.searchExports) !== "boolean") return Logger.error("BdApi.Webpack~getModule", "Unsupported type used for options.searchExports", options.searchExports, "boolean expected.");
+        return WebpackModules.getMangled(filter, options);
+    },
+
+    /**
      * Finds a module using a filter function.
      * @memberof Webpack
      * @param {function} filter A function to use to filter modules. It is given exports, module, and moduleID. Return `true` to signify match.
@@ -104,6 +124,90 @@ const Webpack = {
         if (("signal" in options) && !(options.signal instanceof AbortSignal)) return Logger.error("BdApi.Webpack~waitForModule", "Unsupported type used for options.signal", options.signal, "AbortSignal expected.");
         if (("searchExports" in options) && typeof(options.searchExports) !== "boolean") return Logger.error("BdApi.Webpack~getModule", "Unsupported type used for options.searchExports", options.searchExports, "boolean expected.");
         return WebpackModules.getLazy(filter, options);
+    },
+
+    /**
+     * Finds all modules matching a filter function.
+     * @param {Function} filter A function to use to filter modules
+     */
+    getModules(filter) {return WebpackModules.getModule(filter, {first: false});},
+
+    /**
+     * Finds a module using its code.
+     * @param {RegEx} regex A regular expression to use to filter modules
+     * @param {object} [options] Options to configure the search
+     * @param {Boolean} [options.defaultExport=true] Whether to return default export when matching the default export
+     * @param {Boolean} [options.searchExports=false] Whether to execute the filter on webpack exports
+     * @return {Any}
+     */
+    getByRegex(regex, options = {}) {
+        return WebpackModules.getModule(Filters.byRegex(regex), options);
+    },
+
+    /**
+     * Finds akk modules using its code.
+     * @param {RegEx} regex A regular expression to use to filter modules
+     * @param {object} [options] Options to configure the search
+     * @param {Boolean} [options.defaultExport=true] Whether to return default export when matching the default export
+     * @param {Boolean} [options.searchExports=false] Whether to execute the filter on webpack exports
+     * @return {Any[]}
+     */
+    getAllByRegex(regex, options = {}) {
+        return WebpackModules.getModule(Filters.byRegex(regex), options);
+    },
+
+    /**
+     * Finds a single module using properties on its prototype.
+     * @param {...string} prototypes Properties to use to filter modules
+     * @return {Any}
+     */
+    getByPrototypes(...prototypes) {
+        return WebpackModules.getModule(Filters.byPrototypeFields(prototypes));
+    },
+
+    /**
+     * Finds all modules with a set of properties of its prototype.
+     * @param {...string} prototypes Properties to use to filter modules
+     * @return {Any[]}
+     */
+    getAllByPrototypes(...prototypes) {
+        return WebpackModules.getModule(Filters.byPrototypeFields(prototypes), {first: false});
+    },
+
+    /**
+     * Finds a single module using its own properties.
+     * @param {...string} props Properties to use to filter modules
+     * @return {Any}
+     */
+    getByProps(...props) {
+        return WebpackModules.getModule(Filters.byProps(props));
+    },
+
+    /**
+     * Finds all modules with a set of properties.
+     * @param {...string} props Properties to use to filter modules
+     * @return {Any[]}
+     */
+    getAllByProps(...props) {
+        return WebpackModules.getModule(Filters.byProps(props), {first: false});
+    },
+
+    /**
+     * Finds a single module using a set of strings.
+     * @param {...String} props Strings to use to filter modules
+     * @return {Any}
+     */
+    getByString(...strings) {
+        return WebpackModules.getModule(Filters.byStrings(...strings));
+    },
+
+    /**
+     * Finds all modules with a set of strings.
+     * @param {...String} strings Strings to use to filter modules
+     * @return {Any[]}
+     */
+    getAllByString(...strings) {
+        return WebpackModules.getModule(Filters.byStrings(...strings), {first: false});
     },
 };
 

--- a/renderer/src/modules/api/webpack.js
+++ b/renderer/src/modules/api/webpack.js
@@ -79,6 +79,13 @@ const Webpack = {
         byDisplayName(name) {return Filters.byDisplayName(name);},
 
         /**
+         * Generates a function that filters by a specific internal Store name.
+         * @param {string} name Name the store should have
+         * @returns {function} A filter that checks for a Store name match
+         */
+        byStoreName(name) {return Filters.byStoreName(name);},
+
+        /**
          * Generates a combined function from a list of filters.
          * @param {...function} filters A list of filters
          * @returns {function} Combinatory filter of all arguments
@@ -112,23 +119,26 @@ const Webpack = {
      * @param {Boolean} [options.searchExports=false] Whether to execute the filter on webpack exports
      * @return {any}
      */
-    get(filter, options = {}) {
+    getModule(filter, options = {}) {
         if (("first" in options) && typeof(options.first) !== "boolean") return Logger.error("BdApi.Webpack~get", "Unsupported type used for options.first", options.first, "boolean expected.");
-        if (("defaultExport" in options) && typeof(options.defaultExport) !== "boolean") return Logger.error("BdApi.Webpack~get", "Unsupported type used for options.defaultExport", options.defaultExport, "boolean expected.");
-        if (("searchExports" in options) && typeof(options.searchExports) !== "boolean") return Logger.error("BdApi.Webpack~get", "Unsupported type used for options.searchExports", options.searchExports, "boolean expected.");
+        if (("defaultExport" in options) && typeof(options.defaultExport) !== "boolean") return Logger.error("BdApi.Webpack~getModule", "Unsupported type used for options.defaultExport", options.defaultExport, "boolean expected.");
+        if (("searchExports" in options) && typeof(options.searchExports) !== "boolean") return Logger.error("BdApi.Webpack~getModule", "Unsupported type used for options.searchExports", options.searchExports, "boolean expected.");
         return WebpackModules.getModule(filter, options);
     },
 
     /**
      * Finds all modules matching a filter function.
      * @param {Function} filter A function to use to filter modules
+     * @param {object} [options] Options to configure the search
+     * @param {Boolean} [options.defaultExport=true] Whether to return default export when matching the default export
+     * @param {Boolean} [options.searchExports=false] Whether to execute the filter on webpack exports
+     * @return {any[]}
      */
-    getAll(filter) {return WebpackModules.getModule(filter, {first: false});},
-
-    /**
-     * @deprecated
-     */
-    getModule() {return Webpack.get(...arguments);},
+    getModules(filter, options = {}) {
+        if (("defaultExport" in options) && typeof(options.defaultExport) !== "boolean") return Logger.error("BdApi.Webpack~getModules", "Unsupported type used for options.defaultExport", options.defaultExport, "boolean expected.");
+        if (("searchExports" in options) && typeof(options.searchExports) !== "boolean") return Logger.error("BdApi.Webpack~getModules", "Unsupported type used for options.searchExports", options.searchExports, "boolean expected.");
+        return WebpackModules.getModule(filter, Object.assign(options, {first: false}));
+    },
 
     /**
      * Finds multiple modules using multiple filters.
@@ -232,7 +242,7 @@ const Webpack = {
      * @param {...String} props Strings to use to filter modules
      * @return {Any}
      */
-    getByString(...strings) {
+    getByStrings(...strings) {
         const options = getOptions(strings);
 
         return WebpackModules.getModule(Filters.byStrings(...strings), options);
@@ -243,11 +253,18 @@ const Webpack = {
      * @param {...String} strings Strings to use to filter modules
      * @return {Any[]}
      */
-    getAllByString(...strings) {
+    getAllByStrings(...strings) {
         const options = getOptions(strings, {first: false});
 
         return WebpackModules.getModule(Filters.byStrings(...strings), options);
     },
+
+    /**
+     * Finds an internal Store module using the name.
+     * @param {String} name Name of the store to find (usually includes "Store")
+     * @return {Any}
+     */
+    getStore(name) {return WebpackModules.getModule(Filters.byStoreName(name));},
 };
 
 Object.freeze(Webpack);

--- a/renderer/src/modules/api/webpack.js
+++ b/renderer/src/modules/api/webpack.js
@@ -45,11 +45,16 @@ const Webpack = {
         byKeys(...keys) {return Filters.byKeys(keys);},
 
         /**
+         * @deprecated
+         */
+        byPrototypeFields(...props) {return Filters.byPrototypeKeys(props);},
+
+        /**
          * Generates a function that filters by a set of properties on the object's prototype.
          * @param {...string} props List of property names
          * @returns {function} A filter that checks for a set of properties on the object's prototype.
          */
-        byPrototypeFields(...props) {return Filters.byPrototypeFields(props);},
+        byPrototypeKeys(...props) {return Filters.byPrototypeKeys(props);},
 
         /**
          * Generates a function that filters by a regex.
@@ -115,9 +120,15 @@ const Webpack = {
     },
 
     /**
+     * Finds all modules matching a filter function.
+     * @param {Function} filter A function to use to filter modules
+     */
+    getAll(filter) {return WebpackModules.getModule(filter, {first: false});},
+
+    /**
      * @deprecated
      */
-    getModule() {return this.get.apply(this, arguments);},
+    getModule() {return Webpack.get(...arguments);},
 
     /**
      * Finds multiple modules using multiple filters.
@@ -149,12 +160,6 @@ const Webpack = {
     },
 
     /**
-     * Finds all modules matching a filter function.
-     * @param {Function} filter A function to use to filter modules
-     */
-    getModules(filter) {return WebpackModules.getModule(filter, {first: false});},
-
-    /**
      * Finds a module using its code.
      * @param {RegEx} regex A regular expression to use to filter modules
      * @param {object} [options] Options to configure the search
@@ -183,10 +188,10 @@ const Webpack = {
      * @param {...string} prototypes Properties to use to filter modules
      * @return {Any}
      */
-    getByPrototypes(...prototypes) {
+    getByPrototypeKeys(...prototypes) {
         const options = getOptions(prototypes);
 
-        return WebpackModules.getModule(Filters.byPrototypeFields(prototypes), options);
+        return WebpackModules.getModule(Filters.byPrototypeKeys(prototypes), options);
     },
 
     /**
@@ -194,10 +199,10 @@ const Webpack = {
      * @param {...string} prototypes Properties to use to filter modules
      * @return {Any[]}
      */
-    getAllByPrototypeFields(...prototypes) {
+    getAllByPrototypeKeys(...prototypes) {
         const options = getOptions(prototypes, {first: false});
 
-        return WebpackModules.getModule(Filters.byPrototypeFields(prototypes), options);
+        return WebpackModules.getModule(Filters.byPrototypeKeys(prototypes), options);
     },
 
     /**

--- a/renderer/src/modules/api/webpack.js
+++ b/renderer/src/modules/api/webpack.js
@@ -1,6 +1,18 @@
 import Logger from "common/logger";
 import WebpackModules, {Filters} from "../webpackmodules";
 
+const getOptions = (args, defaultOptions = {}) => {
+    if (args.length > 1 &&
+        typeof(args[args.length - 1]) === "object" &&
+        !Array.isArray(args[args.length - 1]) &&
+        args[args.length - 1] !== null
+    ) {
+        Object.assign(defaultOptions, args.pop());
+    }
+
+    return defaultOptions;
+};
+
 /**
  * `Webpack` is a utility class for getting internal webpack modules. Instance is accessible through the {@link BdApi}.
  * This is extremely useful for interacting with the internals of Discord.
@@ -162,7 +174,9 @@ const Webpack = {
      * @return {Any}
      */
     getByPrototypes(...prototypes) {
-        return WebpackModules.getModule(Filters.byPrototypeFields(prototypes));
+        const options = getOptions(prototypes);
+
+        return WebpackModules.getModule(Filters.byPrototypeFields(prototypes), options);
     },
 
     /**
@@ -171,7 +185,9 @@ const Webpack = {
      * @return {Any[]}
      */
     getAllByPrototypes(...prototypes) {
-        return WebpackModules.getModule(Filters.byPrototypeFields(prototypes), {first: false});
+        const options = getOptions(prototypes, {first: false});
+
+        return WebpackModules.getModule(Filters.byPrototypeFields(prototypes), options);
     },
 
     /**
@@ -180,7 +196,9 @@ const Webpack = {
      * @return {Any}
      */
     getByProps(...props) {
-        return WebpackModules.getModule(Filters.byProps(props));
+        const options = getOptions(props);
+
+        return this.getModule(Filters.byProps(props), options);
     },
 
     /**
@@ -189,7 +207,9 @@ const Webpack = {
      * @return {Any[]}
      */
     getAllByProps(...props) {
-        return WebpackModules.getModule(Filters.byProps(props), {first: false});
+        const options = getOptions(props, {first: false});
+
+        return WebpackModules.getModule(Filters.byProps(props), options);
     },
 
     /**
@@ -198,7 +218,9 @@ const Webpack = {
      * @return {Any}
      */
     getByString(...strings) {
-        return WebpackModules.getModule(Filters.byStrings(...strings));
+        const options = getOptions(strings);
+
+        return WebpackModules.getModule(Filters.byStrings(...strings), options);
     },
 
     /**
@@ -207,7 +229,9 @@ const Webpack = {
      * @return {Any[]}
      */
     getAllByString(...strings) {
-        return WebpackModules.getModule(Filters.byStrings(...strings), {first: false});
+        const options = getOptions(strings, {first: false});
+
+        return WebpackModules.getModule(Filters.byStrings(...strings), options);
     },
 };
 

--- a/renderer/src/modules/api/webpack.js
+++ b/renderer/src/modules/api/webpack.js
@@ -33,11 +33,16 @@ const Webpack = {
      */
     Filters: {
         /**
+         * @deprecated
+         */
+        byProps(...props) {return Filters.byKeys(props);},
+
+        /**
          * Generates a function that filters by a set of properties.
-         * @param {...string} props List of property names
+         * @param {...string} keys List of property names
          * @returns {function} A filter that checks for a set of properties
          */
-        byProps(...props) {return Filters.byProps(props);},
+        byKeys(...keys) {return Filters.byKeys(keys);},
 
         /**
          * Generates a function that filters by a set of properties on the object's prototype.
@@ -85,11 +90,11 @@ const Webpack = {
      * @param {Boolean} [options.searchExports=false] Whether to execute the filter on webpack export getters. 
      * @return {[Any, string]}
      */
-    getMangled(filter, options = {}) {
-        if (("first" in options)) return Logger.error("BdApi.Webpack~getModule", "Unsupported option first.");
-        if (("defaultExport" in options) && typeof(options.defaultExport) !== "boolean") return Logger.error("BdApi.Webpack~getModule", "Unsupported type used for options.defaultExport", options.defaultExport, "boolean expected.");
-        if (("searchExports" in options) && typeof(options.searchExports) !== "boolean") return Logger.error("BdApi.Webpack~getModule", "Unsupported type used for options.searchExports", options.searchExports, "boolean expected.");
-        return WebpackModules.getMangled(filter, options);
+    getWithKey(filter, options = {}) {
+        if (("first" in options)) return Logger.error("BdApi.Webpack~getWithKey", "Unsupported option first.");
+        if (("defaultExport" in options) && typeof(options.defaultExport) !== "boolean") return Logger.error("BdApi.Webpack~getWithKey", "Unsupported type used for options.defaultExport", options.defaultExport, "boolean expected.");
+        if (("searchExports" in options) && typeof(options.searchExports) !== "boolean") return Logger.error("BdApi.Webpack~getWithKey", "Unsupported type used for options.searchExports", options.searchExports, "boolean expected.");
+        return WebpackModules.getWithKey(filter, options);
     },
 
     /**
@@ -102,12 +107,17 @@ const Webpack = {
      * @param {Boolean} [options.searchExports=false] Whether to execute the filter on webpack exports
      * @return {any}
      */
-    getModule(filter, options = {}) {
-        if (("first" in options) && typeof(options.first) !== "boolean") return Logger.error("BdApi.Webpack~getModule", "Unsupported type used for options.first", options.first, "boolean expected.");
-        if (("defaultExport" in options) && typeof(options.defaultExport) !== "boolean") return Logger.error("BdApi.Webpack~getModule", "Unsupported type used for options.defaultExport", options.defaultExport, "boolean expected.");
-        if (("searchExports" in options) && typeof(options.searchExports) !== "boolean") return Logger.error("BdApi.Webpack~getModule", "Unsupported type used for options.searchExports", options.searchExports, "boolean expected.");
+    get(filter, options = {}) {
+        if (("first" in options) && typeof(options.first) !== "boolean") return Logger.error("BdApi.Webpack~get", "Unsupported type used for options.first", options.first, "boolean expected.");
+        if (("defaultExport" in options) && typeof(options.defaultExport) !== "boolean") return Logger.error("BdApi.Webpack~get", "Unsupported type used for options.defaultExport", options.defaultExport, "boolean expected.");
+        if (("searchExports" in options) && typeof(options.searchExports) !== "boolean") return Logger.error("BdApi.Webpack~get", "Unsupported type used for options.searchExports", options.searchExports, "boolean expected.");
         return WebpackModules.getModule(filter, options);
     },
+
+    /**
+     * @deprecated
+     */
+    getModule() {return this.get.apply(this, arguments);},
 
     /**
      * Finds multiple modules using multiple filters.
@@ -134,7 +144,7 @@ const Webpack = {
     waitForModule(filter, options = {}) {
         if (("defaultExport" in options) && typeof(options.defaultExport) !== "boolean") return Logger.error("BdApi.Webpack~waitForModule", "Unsupported type used for options.defaultExport", options.defaultExport, "boolean expected.");
         if (("signal" in options) && !(options.signal instanceof AbortSignal)) return Logger.error("BdApi.Webpack~waitForModule", "Unsupported type used for options.signal", options.signal, "AbortSignal expected.");
-        if (("searchExports" in options) && typeof(options.searchExports) !== "boolean") return Logger.error("BdApi.Webpack~getModule", "Unsupported type used for options.searchExports", options.searchExports, "boolean expected.");
+        if (("searchExports" in options) && typeof(options.searchExports) !== "boolean") return Logger.error("BdApi.Webpack~waitForModule", "Unsupported type used for options.searchExports", options.searchExports, "boolean expected.");
         return WebpackModules.getLazy(filter, options);
     },
 
@@ -184,7 +194,7 @@ const Webpack = {
      * @param {...string} prototypes Properties to use to filter modules
      * @return {Any[]}
      */
-    getAllByPrototypes(...prototypes) {
+    getAllByPrototypeFields(...prototypes) {
         const options = getOptions(prototypes, {first: false});
 
         return WebpackModules.getModule(Filters.byPrototypeFields(prototypes), options);
@@ -195,10 +205,10 @@ const Webpack = {
      * @param {...string} props Properties to use to filter modules
      * @return {Any}
      */
-    getByProps(...props) {
+    getByKeys(...props) {
         const options = getOptions(props);
 
-        return this.getModule(Filters.byProps(props), options);
+        return WebpackModules.getModule(Filters.byKeys(props), options);
     },
 
     /**
@@ -206,10 +216,10 @@ const Webpack = {
      * @param {...string} props Properties to use to filter modules
      * @return {Any[]}
      */
-    getAllByProps(...props) {
+    getAllByKeys(...props) {
         const options = getOptions(props, {first: false});
 
-        return WebpackModules.getModule(Filters.byProps(props), options);
+        return WebpackModules.getModule(Filters.byKeys(props), options);
     },
 
     /**

--- a/renderer/src/modules/api/webpack.js
+++ b/renderer/src/modules/api/webpack.js
@@ -145,7 +145,7 @@ const Webpack = {
     },
 
     /**
-     * Finds akk modules using its code.
+     * Finds all modules using its code.
      * @param {RegEx} regex A regular expression to use to filter modules
      * @param {object} [options] Options to configure the search
      * @param {Boolean} [options.defaultExport=true] Whether to return default export when matching the default export
@@ -153,7 +153,7 @@ const Webpack = {
      * @return {Any[]}
      */
     getAllByRegex(regex, options = {}) {
-        return WebpackModules.getModule(Filters.byRegex(regex), options);
+        return WebpackModules.getModule(Filters.byRegex(regex), Object.assign({}, options, {first: true}));
     },
 
     /**

--- a/renderer/src/modules/webpackmodules.js
+++ b/renderer/src/modules/webpackmodules.js
@@ -22,7 +22,7 @@ export class Filters {
      * @param {module:WebpackModules.Filters~filter} filter - Additional filter
      * @returns {module:WebpackModules.Filters~filter} - A filter that checks for a set of properties
      */
-    static byProps(props, filter = m => m) {
+    static byKeys(props, filter = m => m) {
         return module => {
             if (!module) return false;
             if (typeof(module) !== "object" && typeof(module) !== "function") return false;
@@ -275,7 +275,7 @@ export default class WebpackModules {
      * @param {Boolean} [options.searchExports=false] Whether to execute the filter on webpack export getters. 
      * @return {[Any, string]}
      */
-    static *getMangled(filter, {target = null, ...rest} = {}) {
+    static *getWithKey(filter, {target = null, ...rest} = {}) {
         yield target ??= this.getModule(exports =>
             Object.values(exports).some(filter),
             rest
@@ -333,7 +333,7 @@ export default class WebpackModules {
      * @return {Any}
      */
     static getByProps(...props) {
-        return this.getModule(Filters.byProps(props));
+        return this.getModule(Filters.byKeys(props));
     }
 
     /**
@@ -342,7 +342,7 @@ export default class WebpackModules {
      * @return {Any}
      */
     static getAllByProps(...props) {
-        return this.getModule(Filters.byProps(props), {first: false});
+        return this.getModule(Filters.byKeys(props), {first: false});
     }
 
     /**

--- a/renderer/src/modules/webpackmodules.js
+++ b/renderer/src/modules/webpackmodules.js
@@ -94,12 +94,22 @@ export class Filters {
     /**
      * Generates a {@link module:WebpackModules.Filters~filter} that filters by a set of properties.
      * @param {string} name - Name the module should have
-     * @param {module:WebpackModules.Filters~filter} filter - Additional filter
      * @returns {module:WebpackModules.Filters~filter} - A filter that checks for a set of properties
      */
     static byDisplayName(name) {
         return module => {
             return module && module.displayName === name;
+        };
+    }
+
+    /**
+     * Generates a {@link module:WebpackModules.Filters~filter} that filters by a set of properties.
+     * @param {string} name - Name the store should have (usually includes the word Store)
+     * @returns {module:WebpackModules.Filters~filter} - A filter that checks for a set of properties
+     */
+    static byStoreName(name) {
+        return module => {
+            return module?._dispatchToken && module?.getName?.() === name;
         };
     }
 

--- a/renderer/src/modules/webpackmodules.js
+++ b/renderer/src/modules/webpackmodules.js
@@ -41,7 +41,7 @@ export class Filters {
      * @param {module:WebpackModules.Filters~filter} filter - Additional filter
      * @returns {module:WebpackModules.Filters~filter} - A filter that checks for a set of properties on the object's prototype
      */
-    static byPrototypeFields(fields, filter = m => m) {
+    static byPrototypeKeys(fields, filter = m => m) {
         return module => {
             if (!module) return false;
             if (typeof(module) !== "object" && typeof(module) !== "function") return false;
@@ -315,7 +315,7 @@ export default class WebpackModules {
      * @return {Any}
      */
     static getByPrototypes(...prototypes) {
-        return this.getModule(Filters.byPrototypeFields(prototypes));
+        return this.getModule(Filters.byPrototypeKeys(prototypes));
     }
 
     /**
@@ -324,7 +324,7 @@ export default class WebpackModules {
      * @return {Any}
      */
     static getAllByPrototypes(...prototypes) {
-        return this.getModule(Filters.byPrototypeFields(prototypes), {first: false});
+        return this.getModule(Filters.byPrototypeKeys(prototypes), {first: false});
     }
 
     /**

--- a/renderer/src/ui/settings.js
+++ b/renderer/src/ui/settings.js
@@ -62,7 +62,7 @@ export default new class SettingsRenderer {
     }
 
     async patchSections() {
-        const UserSettings = await WebpackModules.getLazy(Filters.byPrototypeFields(["getPredicateSections"]));
+        const UserSettings = await WebpackModules.getLazy(Filters.byPrototypeKeys(["getPredicateSections"]));
         
         Patcher.after("SettingsManager", UserSettings.prototype, "getPredicateSections", (thisObject, args, returnValue) => {
             let location = returnValue.findIndex(s => s.section.toLowerCase() == "changelog") - 1;


### PR DESCRIPTION
This PR adds some shorthand convenience functions that make module requests even easier to perform. Additionally it makes some naming changes to help clarify the intended meaning of each term. Notably, terms like `Props` or `Fields` have been changed to `Keys` to match expectations and help differentiate from React props.

- Implements the following aliases to the `BdApi.Webpack` module:
	* `getByKeys()` | `getAllByKeys()`
	* `getByRegex()` | `getAllByRegex()`
	* `getByString()` | `getAllByString()`
	* `getByPrototypeKeys()` | `getAllByPrototypeKeys()`

- Implements a `getWithKey()` function to the `BdApi.Webpack` module to quickly search for the both `module` & mangled `key` referencing a function inside webpack.
	### Example Usage:
	```js
	const {Webpack, Patcher} = new BdApi("PluginName");
	const [module, method] = Webpack.getWithKey(m => doSomething(m));
	
	Patcher.after(module, method, () => {...})
	```

- Implements a `modules` proxy to `BdApi.Webpack` to look inside a webpack module's source. (mirrors `require.m`). It does **not** allow writing to the modules cache. It is only meant for string searching/extraction.
	### Example Usage:
	```js
	const {Webpack} = BdApi;
	const module = Webpack.get((m, _, i) => Webpack.modules[i]?.toString().includes("someHiddenString"));
	```
	
- Adds a new `get` to `BdApi.Webpack` which is the equivalent of `getModule` while deprecating the latter
- Adds a new `getAll` to `BdApi.Webpack` which will get all matching modules

- Adds `byKeys` to `BdApi.Webpack.Filters` which deprecates `byProps`
- Same as above for `byPrototypeKeys` and `byPrototypeFields`