### PR TITLE
Add relaxed semver regex for checking current version of plugins

### DIFF
--- a/renderer/src/modules/updater.js
+++ b/renderer/src/modules/updater.js
@@ -196,7 +196,7 @@ class AddonUpdater {
         if (this.pending.includes(filename)) return;
         const info = this.cache[path.basename(filename)];
         if (!info) return;
-        let hasUpdate = info.update > currentVersion;
+        let hasUpdate = info.version > currentVersion;
         if (semverRegex.test(info.version) && relaxedSemverRegex.test(currentVersion)) {
             hasUpdate = semverComparator(currentVersion, info.version);
         }

--- a/renderer/src/modules/updater.js
+++ b/renderer/src/modules/updater.js
@@ -135,6 +135,7 @@ export class CoreUpdater {
 }
 
 const semverRegex = /^[0-9]+\.[0-9]+\.[0-9]+$/;
+const relaxedSemverRegex = /^[0-9]+(\.[0-9]+){0,2}$/;
 
 /**
  * This works on basic semantic versioning e.g. "1.0.0".
@@ -196,7 +197,7 @@ class AddonUpdater {
         const info = this.cache[path.basename(filename)];
         if (!info) return;
         let hasUpdate = info.update > currentVersion;
-        if (semverRegex.test(info.version) && semverRegex.test(currentVersion)) {
+        if (semverRegex.test(info.version) && relaxedSemverRegex.test(currentVersion)) {
             hasUpdate = semverComparator(currentVersion, info.version);
         }
         if (!hasUpdate) return;


### PR DESCRIPTION
Currently new updates aren't picked up if the old version doesn't match the x.x.x format for versioning. This change picks up old formats of versions (e.g. x.x) but only allows plugins to be updated if the new version matches x.x.x formatting