### PR TITLE
Fix module search warnings

### DIFF
--- a/renderer/src/modules/webpackmodules.js
+++ b/renderer/src/modules/webpackmodules.js
@@ -215,7 +215,7 @@ export default class WebpackModules {
             if (!modules.hasOwnProperty(index)) continue;
             const module = modules[index];
             const {exports} = module;
-            if (!exports || exports === window || exports === document.documentElement) continue;
+            if (!exports || exports === window || exports === document.documentElement || exports[Symbol.toStringTag] === "DOMTokenList") continue;
 
             for (let q = 0; q < queries.length; q++) {
                 const query = queries[q];
@@ -225,7 +225,7 @@ export default class WebpackModules {
 
                 const wrappedFilter = wrapFilter(filter);
 
-                if (typeof(exports) === "object" && searchExports) {
+                if (typeof(exports) === "object" && searchExports && !exports.TypedArray) {
                     for (const key in exports) {
                         let foundModule = null;
                         const wrappedExport = exports[key];
@@ -350,10 +350,10 @@ export default class WebpackModules {
         return new Promise((resolve) => {
             const cancel = () => this.removeListener(listener);
             const listener = function(exports) {
-                if (!exports || exports === window || exports === document.documentElement) return;
+                if (!exports || exports === window || exports === document.documentElement || exports[Symbol.toStringTag] === "DOMTokenList") return;
 
                 let foundModule = null;
-                if (typeof(exports) === "object" && searchExports) {
+                if (typeof(exports) === "object" && searchExports && !exports.TypedArray) {
                     for (const key in exports) {
                         foundModule = null;
                         const wrappedExport = exports[key];

--- a/renderer/src/modules/webpackmodules.js
+++ b/renderer/src/modules/webpackmodules.js
@@ -164,9 +164,9 @@ export default class WebpackModules {
             try {module = modules[index]} catch {continue;};
 
             const {exports} = module;
-            if (!exports || exports === window || exports === document.documentElement) continue;
+            if (!exports || exports === window || exports === document.documentElement || exports[Symbol.toStringTag] === "DOMTokenList") continue;
             
-            if (typeof(exports) === "object" && searchExports && exports[Symbol.toStringTag] !== "DOMTokenList") {
+            if (typeof(exports) === "object" && searchExports && !exports.TypedArray) {
                 for (const key in exports) {
                     let foundModule = null;
                     let wrappedExport = null;


### PR DESCRIPTION
I've been noticing a lot of "Illegal invocation" warnings when using `toString` in module filters (like BD's `byStrings` filter), and found it's because one of the modules exports an instance of `DOMTokenList`. It seems like there was a check added to `getModule` in v1.9.1 to fix it, but it would just skip searching through the exports object and move on to return the module anyway. This moves that check up to skip the outer loop iteration entirely.

I also found a similar issue since one of the modules exports a prototype of `TypedArray` and added a check for that.

Another possible solution is to have plugin devs account for these issues in their filters, but BD's own filter would have to be updated too.