### PR TITLE
Fetch API

### DIFF
--- a/preload/src/api/fetch.js
+++ b/preload/src/api/fetch.js
@@ -1,0 +1,88 @@
+import * as https from "https";
+import * as http from "http";
+
+const redirectCodes = new Set([301, 302, 307, 308]);
+
+export function nativeFetch(url, options) {
+    let state = "PENDING";
+    const data = {content: [], headers: null, statusCode: null, url: url, statusText: "", redirected: false};
+    const listeners = new Set();
+    const errors = new Set();
+
+    /** * @param {URL} url */
+    const execute = (url, options, redirect = false) => {
+        const Module = url.protocol === "http" ? http : https;
+        
+        const req = Module.request(url.href, {
+            headers: options.headers ?? {},
+            method: options.method ?? "GET"
+        }, res => {
+            if (redirectCodes.has(res.statusCode) && res.headers.location && options.redirect !== "manual") {
+                const final = new URL(res.headers.location);
+
+                for (const [key, value] of new URL(url).searchParams.entries()) {
+                    final.searchParams.set(key, value);
+                }
+
+                return execute(final, options, true);
+            }
+
+            res.on("data", chunk => data.content.push(chunk));
+            res.on("end", () => {
+                data.content = Buffer.concat(data.content);
+                data.headers = res.headers;
+                data.statusCode = res.statusCode;
+                data.url = url.toString();
+                data.statusText = res.statusMessage;
+                data.redirected = redirect;
+                state = "DONE";
+
+                listeners.forEach(listener => listener());
+            });
+            res.on("error", error => {
+                state = "ABORTED";
+                errors.forEach(e => e(error));
+            });
+        });
+
+        if (options.body) {
+            try {req.write(options.body)}
+            catch (error) {
+                state = "ABORTED";
+                errors.forEach(e => e(error));
+            } finally {
+                req.end();
+            }
+        } else {
+            req.end();
+        }
+
+        if (options.signal) {
+            options.signal.addEventListener("abort", () => {
+                req.end();
+                state = "ABORTED";
+            });
+        }
+    };
+
+    execute(new URL(url), options);
+
+    return {
+        onComplete(listener) {
+            listeners.add(listener);
+        },
+        onError(listener) {
+            errors.add(listener);
+        },
+        readData() {
+            switch (state) {
+                case "PENDING":
+                    throw new Error("Cannot read data before request is done!");
+                case "ABORTED":
+                    throw new Error("Request was aborted.");
+                case "DONE":
+                    return data;
+            }
+        }
+    };
+}

--- a/preload/src/api/https.js
+++ b/preload/src/api/https.js
@@ -34,7 +34,15 @@ const makeRequest = (url, options, callback, setReq) => {
             req.end();
         });
     });
-    req.end();
+
+    if (options.formData) {
+        // Make sure to close the socket.
+        try {req.write(options.formData);}
+        finally {req.end();}
+    } else {
+        req.end();
+    }
+
 };
 
 const request = function (url, options, callback) {

--- a/preload/src/api/index.js
+++ b/preload/src/api/index.js
@@ -3,6 +3,7 @@ export {default as https} from "./https";
 export * as electron from "./electron";
 export * as crypto from "./crypto";
 export * as vm from "./vm";
+export * from "./fetch";
 
 // We can expose that without any issues.
 export * as path from "path";

--- a/renderer/src/modules/api/fetch.js
+++ b/renderer/src/modules/api/fetch.js
@@ -1,0 +1,63 @@
+import Remote from "../../polyfill/remote";
+
+class FetchResponse extends Response {
+    constructor(options) {
+        super(options.content, {
+            headers: new Headers(options.headers),
+            method: options.method ?? "GET",
+            body: options.content,
+            ...options
+        });
+
+        this._options = options;
+    }
+
+    get url() {return this._options.url;}
+    get redirected() {return this._options.redirected;}
+}
+
+const convertSignal = signal => {
+    const listeners = new Set();
+
+    signal.addEventListener("abort", () => {
+        listeners.forEach(l => l());
+    });
+
+    return {
+        addEventListener(_, listener) {
+            listeners.add(listener);
+        }
+    };
+};
+
+export function fetch(url, options = {}) {
+    return new Promise((resolve, reject) => {
+        const ctx = Remote.nativeFetch(url, {
+            ...(options.headers && {headers: options.headers instanceof Headers ? Object.fromEntries(options.headers.entries()) : options.headers}),
+            ...(options.body && {body: options.body}),
+            ...(options.method && {method: options.method}),
+            ...(options.signal && {signal: convertSignal(options.signal)})
+        });
+
+        ctx.onError(error => {
+            reject(error);
+        });
+
+        ctx.onComplete(() => {
+            try {
+                const data = ctx.readData();
+
+                const req = new FetchResponse({
+                    method: options.method ?? "GET",
+                    status: data.statusCode,
+                    ...options,
+                    ...data
+                });
+
+                resolve(req);
+            } catch (error) {
+                reject(error);
+            }
+        });
+    });
+}

--- a/renderer/src/modules/api/fetch.js
+++ b/renderer/src/modules/api/fetch.js
@@ -1,6 +1,6 @@
 import Remote from "../../polyfill/remote";
 
-const methods = new Set(["GET" | "PUT" | "POST" | "DELETE"]);
+const methods = new Set(["GET", "PUT", "POST", "DELETE"]);
 
 class FetchResponse extends Response {
     constructor(options) {

--- a/renderer/src/modules/api/index.js
+++ b/renderer/src/modules/api/index.js
@@ -12,7 +12,7 @@ import Utils from "./utils";
 import Webpack from "./webpack";
 import * as Legacy from "./legacy";
 import ContextMenu from "./contextmenu";
-import {fetch} from "./fetch";
+import fetch from "./fetch";
 import {DiscordModules} from "modules";
 
 const bounded = new Map();
@@ -58,7 +58,7 @@ export default class BdApi {
     Components = {
         get Tooltip() {return DiscordModules.Tooltip;}
     }
-    fetch = fetch; 
+    Net = {fetch}; 
 }
 
 // Add legacy functions
@@ -128,8 +128,9 @@ BdApi.Components = {
     get Tooltip() {return DiscordModules.Tooltip;}
 };
 
-BdApi.fetch = fetch;
+BdApi.Net = {fetch};
 
 Object.freeze(BdApi);
+Object.freeze(BdApi.Net);
 Object.freeze(BdApi.prototype);
 Object.freeze(BdApi.Components);

--- a/renderer/src/modules/api/index.js
+++ b/renderer/src/modules/api/index.js
@@ -12,6 +12,7 @@ import Utils from "./utils";
 import Webpack from "./webpack";
 import * as Legacy from "./legacy";
 import ContextMenu from "./contextmenu";
+import {fetch} from "./fetch";
 import {DiscordModules} from "modules";
 
 const bounded = new Map();
@@ -57,6 +58,7 @@ export default class BdApi {
     Components = {
         get Tooltip() {return DiscordModules.Tooltip;}
     }
+    fetch = fetch; 
 }
 
 // Add legacy functions
@@ -125,6 +127,8 @@ BdApi.ContextMenu = ContextMenuAPI;
 BdApi.Components = {
     get Tooltip() {return DiscordModules.Tooltip;}
 };
+
+BdApi.fetch = fetch;
 
 Object.freeze(BdApi);
 Object.freeze(BdApi.prototype);

--- a/renderer/src/polyfill/index.js
+++ b/renderer/src/polyfill/index.js
@@ -7,6 +7,12 @@ import * as https from "./https";
 import Buffer from "./buffer";
 import crypto from "./crypto";
 import Remote from "./remote";
+import Logger from "common/logger";
+
+const deprecated = new Map([
+    ["request", "Use BdApi.Net.fetch instead."],
+    ["https", "Use BdApi.Net.fetch instead."],
+]);
 
 const originalFs = Object.assign({}, fs);
 originalFs.writeFileSync = (path, data, options) => fs.writeFileSync(path, data, Object.assign({}, options, {originalFs: true}));
@@ -14,6 +20,10 @@ originalFs.writeFile = (path, data, options) => fs.writeFile(path, data, Object.
 
 export const createRequire = function (path) {
     return mod => {
+        if (deprecated.has(mod)) {
+            Logger.warn("Remote~Require", `The "${mod}" module is marked as deprecated. ${deprecated.get(mod)}`);
+        }
+
         switch (mod) {
             case "request": return request;
             case "https": return https;


### PR DESCRIPTION
Adds `BdApi.fetch()` api which is equivalent design of the global `fetch()` api but it can bypass CSP. This also introduces the deprecation of `require("https")`/`require("request")` as well.

It also adds the ability to add a body to requests using current `require("https")` polyflll, reason being not much effort required to implement this.