### PR TITLE
Fix window size retention

### DIFF
--- a/renderer/src/builtins/window/removeminimumsize.js
+++ b/renderer/src/builtins/window/removeminimumsize.js
@@ -15,7 +15,7 @@ export default new class RemoveMinimumSize extends Builtin {
         window.addEventListener("resize", this.onResize);
 
         const winprefs = DataStore.getData("windowprefs");
-        if (!winprefs.height || !winprefs.width) return; // If the values don't exist exit
+        if (!winprefs.height || !winprefs.width) return DataStore.setData("windowprefs", {}); // If the values don't exist exit and initialize
         if ((winprefs.height >= DISCORD_MIN_HEIGHT) && (winprefs.width >= DISCORD_MIN_WIDTH)) return; // If both values are normally valid don't touch
         IPC.setWindowSize(winprefs.width, winprefs.height);
     }


### PR DESCRIPTION
Fixes errors on startup and not saving the window size with Remove Minimum Size enabled due to never initializing the `windowprefs` file.