### PR TITLE
allow requesting with a body

### DIFF
--- a/preload/src/api/https.js
+++ b/preload/src/api/https.js
@@ -34,6 +34,11 @@ const makeRequest = (url, options, callback, setReq) => {
             req.end();
         });
     });
+    
+    if (options.body) {
+        req.write(options.body)
+    }
+    
     req.end();
 };
 


### PR DESCRIPTION
After many hours of debugging wondering why my requests always failed, I traced the issue back to the https module.

It doesn't currently write the body to the request, making it almost useless for anything other than a GET request.