### PR TITLE
Fix fetch

### DIFF
--- a/preload/src/api/fetch.js
+++ b/preload/src/api/fetch.js
@@ -12,6 +12,7 @@ const redirectCodes = new Set([301, 302, 307, 308]);
  * @property {number} [maxRedirects] - Maximum amount of redirects to be followed.
  * @property {AbortSignal} [signal] - Signal to abruptly cancel the request
  * @property {Uint8Array | string} [body] - Defines a request body. Data must be serializable. 
+ * @property {number} [timeout] - Request timeout time.
  */
 
 /**

--- a/renderer/src/modules/api/fetch.js
+++ b/renderer/src/modules/api/fetch.js
@@ -1,10 +1,11 @@
 import Remote from "../../polyfill/remote";
 
 const methods = new Set(["GET", "PUT", "POST", "DELETE"]);
+const bodylessStatusCodes = new Set([101, 204, 205, 304]);
 
 class FetchResponse extends Response {
     constructor(options) {
-        super(options.content, {
+        super(bodylessStatusCodes.has(options.status) ? null : options.content, {
             headers: new Headers(options.headers),
             method: options.method ?? "GET",
             body: options.content,
@@ -40,6 +41,7 @@ const convertSignal = signal => {
  * @property {number} [maxRedirects] - Maximum amount of redirects to be followed.
  * @property {AbortSignal} [signal] - Signal to abruptly cancel the request
  * @property {Uint8Array | string} [body] - Defines a request body. Data must be serializable. 
+ * @property {number} [timeout] - Request timeout time.
  */
 
 /**
@@ -58,7 +60,7 @@ export default function fetch(url, options = {}) {
         if (typeof options.body === "string" || options.body instanceof Uint8Array) data.body = options.body;
         if (typeof options.method === "string" && methods.has(options.method)) data.method = options.method;
         if (options.signal instanceof AbortSignal) data.signal = convertSignal(options.signal);
-
+        if (typeof options.timeout === 'number') data.timeout = options.timeout;
         let ctx;
         try {
             ctx = Remote.nativeFetch(url, data);


### PR DESCRIPTION
Fixes FetchOptions missing timeout property.

Fixes timeout property in options was not used when using `BdApi.Net.fetch`.

Fixes  `TypeError: Failed to construct 'Response': Response with null body status cannot have body` when making a request with `BdApi.Net.fetch` and response answer has a status code (101, 204, 205, 304) that must not have a body.

Fixes `Uncaught Error: Cannot pipe, not readable` when piping response with `require('request')` (It is deprecated module but why not)
```JS
const request = require('request').get(url, (error, res, body) => {
         
 });

const stream = require('fs').createWriteStream('data.txt');
      
request.pipe(stream); // Uncaught Error: Cannot pipe, not readable
```