### PR TITLE
Add ability to use native OS frame

### DIFF
--- a/assets/locales/en-us.json
+++ b/assets/locales/en-us.json
@@ -39,7 +39,7 @@
                 },
                 "frame": {
                     "name": "Window Frame",
-                    "note": "Adds the native os window frame to the main window"
+                    "note": "Adds the native OS window frame to the main window (requires restart)"
                 }
             },
             "addons": {
@@ -235,6 +235,10 @@
     },
     "WindowPrefs": {
         "enabledInfo": "This option requires a transparent theme in order to work properly. On Windows this may break your aero snapping and maximizing.\n\nIn order to take effect, Discord needs to be restarted. Do you want to restart now?",
+        "disabledInfo": "In order to take effect, Discord needs to be restarted. Do you want to restart now?"
+    },
+    "NativeFrame": {
+        "enabledInfo": "In order to take effect, Discord needs to be restarted. Do you want to restart now?",
         "disabledInfo": "In order to take effect, Discord needs to be restarted. Do you want to restart now?"
     },
     "Notices": {

--- a/injector/src/modules/browserwindow.js
+++ b/injector/src/modules/browserwindow.js
@@ -21,13 +21,6 @@ class BrowserWindow extends electron.BrowserWindow {
         if (typeof(shouldHaveFrame) === "boolean") options.frame = shouldHaveFrame;
 
         super(options);
-
-        if (typeof(shouldHaveFrame) === "boolean" && shouldHaveFrame) {
-            this.webContents.insertCSS(`div[class^="titleBar_"], div[class*=" titleBar_"] {
-                display: none !important;
-            }`);
-        }
-
         this.__originalPreload = originalPreload;
         BetterDiscord.setup(this);
     }

--- a/injector/src/modules/browserwindow.js
+++ b/injector/src/modules/browserwindow.js
@@ -23,6 +23,27 @@ class BrowserWindow extends electron.BrowserWindow {
         super(options);
         this.__originalPreload = originalPreload;
         BetterDiscord.setup(this);
+
+        if (typeof(shouldHaveFrame) === "boolean" && shouldHaveFrame) {
+            // Override the window open handler to force new windows (such as pop-outs) to have frames
+            this.webContents.on("did-finish-load", () => {
+                const originalWindowOpenHandler = this.webContents._windowOpenHandler;
+
+                this.webContents.setWindowOpenHandler((details) => {
+                    const originalResponse = originalWindowOpenHandler(details);
+                    originalResponse.overrideBrowserWindowOptions.frame = true;
+                    return originalResponse;
+                });
+            });
+
+            // Remove the title bar and menu from new windows
+            this.webContents.on("did-create-window", (window) => {
+                window.removeMenu();
+                window.webContents.insertCSS(`div[class^="titleBar_"], div[class*=" titleBar_"] {
+                    display: none !important;
+                }`);
+            });
+        }
     }
 }
 

--- a/injector/src/modules/browserwindow.js
+++ b/injector/src/modules/browserwindow.js
@@ -23,7 +23,7 @@ class BrowserWindow extends electron.BrowserWindow {
         super(options);
 
         if (typeof(shouldHaveFrame) === "boolean" && shouldHaveFrame) {
-            this.webContents.insertCSS(`div[class*="titleBar_"] {
+            this.webContents.insertCSS(`div[class^="titleBar_"], div[class*=" titleBar_"] {
                 display: none !important;
             }`);
         }

--- a/injector/src/modules/browserwindow.js
+++ b/injector/src/modules/browserwindow.js
@@ -17,10 +17,17 @@ class BrowserWindow extends electron.BrowserWindow {
         }
 
         // Only affect frame if it is *explicitly* set
-        // const shouldHaveFrame = BetterDiscord.getSetting("window", "frame");
-        // if (typeof(shouldHaveFrame) === "boolean") options.frame = shouldHaveFrame;
+        const shouldHaveFrame = BetterDiscord.getSetting("window", "frame");
+        if (typeof(shouldHaveFrame) === "boolean") options.frame = shouldHaveFrame;
 
         super(options);
+
+        if (typeof(shouldHaveFrame) === "boolean" && shouldHaveFrame) {
+            this.webContents.insertCSS(`div[class*="titleBar_"] {
+                display: none !important;
+            }`);
+        }
+
         this.__originalPreload = originalPreload;
         BetterDiscord.setup(this);
     }

--- a/injector/src/modules/browserwindow.js
+++ b/injector/src/modules/browserwindow.js
@@ -31,7 +31,10 @@ class BrowserWindow extends electron.BrowserWindow {
 
                 this.webContents.setWindowOpenHandler((details) => {
                     const originalResponse = originalWindowOpenHandler(details);
-                    originalResponse.overrideBrowserWindowOptions.frame = true;
+                    // Only set the frame option if it's a pop-out
+                    if (details.frameName === "DISCORD_CHANNEL_CALL_POPOUT") {
+                        originalResponse.overrideBrowserWindowOptions.frame = true;
+                    }
                     return originalResponse;
                 });
             });

--- a/renderer/src/builtins/builtins.js
+++ b/renderer/src/builtins/builtins.js
@@ -18,4 +18,5 @@ export {default as StopDevToolsWarning} from "./developer/devtoolswarning";
 export {default as DebugLogs} from "./developer/debuglogs";
 
 export {default as WindowPrefs} from "./window/transparency";
+export {default as NativeFrame} from "./window/frame";
 export {default as RemoveMinimumSize} from "./window/removeminimumsize";

--- a/renderer/src/builtins/window/frame.js
+++ b/renderer/src/builtins/window/frame.js
@@ -1,0 +1,33 @@
+import Builtin from "@structs/builtin";
+
+import Strings from "@modules/strings";
+import IPC from "@modules/ipc";
+
+import Modals from "@ui/modals";
+
+
+export default new class NativeFrame extends Builtin {
+    get name() {return "NativeFrame";}
+    get category() {return "window";}
+    get id() {return "frame";}
+
+    enabled() {
+        this.showModal(Strings.NativeFrame.enabledInfo);
+        document.body.classList.add("bd-frame");
+    }
+
+    disabled() {
+        this.showModal(Strings.NativeFrame.disabledInfo);
+        document.body.classList.remove("bd-frame");
+    }
+
+    showModal(info) {
+        if (!this.initialized) return;
+        Modals.showConfirmationModal(Strings.Modals.additionalInfo, info, {
+            confirmText: Strings.Modals.restartNow,
+            cancelText: Strings.Modals.restartLater,
+            danger: true,
+            onConfirm: () => IPC.relaunch()
+        });
+    }
+};

--- a/renderer/src/data/settings.js
+++ b/renderer/src/data/settings.js
@@ -52,8 +52,8 @@ export default [
         shown: false,
         settings: [
             {type: "switch", id: "transparency", value: false},
-            {type: "switch", id: "removeMinimumSize", value: false},
-            {type: "switch", id: "frame", value: false, hidden: true}
+            {type: "switch", id: "frame", value: false},
+            {type: "switch", id: "removeMinimumSize", value: false}
         ]
     },
     {

--- a/renderer/src/modules/core.js
+++ b/renderer/src/modules/core.js
@@ -49,6 +49,13 @@ export default new class Core {
         Logger.log("Startup", "Initializing Settings");
         Settings.initialize();
 
+        Logger.log("Startup", "Injecting Setting-dependent BD Styles");
+        if (Settings.get("settings", "window", "frame", false)) {
+            DOMManager.injectStyle("bd-frame", `div[class^="titleBar_"], div[class*=" titleBar_"] {
+                display: none !important;
+            }`);
+        }
+
         Logger.log("Startup", "Initializing DOMManager");
         DOMManager.initialize();
 


### PR DESCRIPTION
Enables the functionality to use native OS frame controls. If there is a reason why these were disabled, feel free to close this.

Fixes #1030.