### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,4 @@ jobs:
         with:
           if-no-files-found: error
           retention-days: 30
-          path: |
-            dist/*.js
-            dist/betterdiscord.asar
+          path: dist/betterdiscord.asar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Prepare PNPM
         uses: pnpm/action-setup@v4
+        with:
+          version: 7
 
       - name: Prepare Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,62 +2,45 @@ name: BetterDiscord CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      
-    - name: Install Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: 16
-        
-    - uses: pnpm/action-setup@v2
-      name: Install pnpm
-      id: pnpm-install
-      with:
-        version: 7
-        run_install: false
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Get pnpm store directory
-      id: pnpm-cache
-      shell: bash
-      run: |
-        echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+      - name: Prepare PNPM
+        uses: pnpm/action-setup@v4
 
-    - uses: actions/cache@v3
-      name: Setup pnpm cache
-      with:
-        path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-pnpm-store-
+      - name: Prepare Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 16
+          cache: pnpm
 
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile
-      
-#    - name: Lint
-#      run: pnpm lint
-      
-#    - name: Run tests
-#      run: pnpm test
-      
-    - name: Build asar
-      run: pnpm dist
-      
-    - uses: actions/upload-artifact@v3
-      name: Upload artifact
-#      if: ${{ github.ref == 'refs/heads/main' }} # Only create artifacts when pushed to main
-      with:
-        name: betterdiscord.asar
-        path: dist/betterdiscord.asar
-        retention-days: 30
-        if-no-files-found: error
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      #    - name: Lint
+      #      run: pnpm lint
+
+      #    - name: Run tests
+      #      run: pnpm test
+
+      - name: Build asar
+        run: pnpm dist
+
+      - uses: actions/upload-artifact@v4
+        name: Upload artifact
+        if: ${{github.ref == 'refs/heads/main'}} # Only create artifacts when pushed to main
+        with:
+          if-no-files-found: error
+          retention-days: 30
+          path: |
+            dist/*.js
+            dist/betterdiscord.asar


### PR DESCRIPTION
This PR does 2 things:

~~1. This PR adds the 3 JS files (`injector.js`, `preload.js`, and `renderer.js`) to GitHub releases, alongside `betterdiscord.asar`
	Why? I am coming from https://github.com/ArmCord/ArmCord with the intent to add loading BetterDiscord into the client as an option. Ideally, we would be able to just use the ASAR - I have tried figuring this out repeatedly, but the file is always saved corrupted (the actual released file is fine, however)
These files will be useful to programatically inject BetterDiscord into an electron application on the fly.~~

2. This PR updates the actions. I have tested them. (https://github.com/ArmCord/BetterDiscord/actions/runs/10542695408
	Why? 
		- [`actions/upload-artifact@v3` will be deprecated and unusable on November 30th.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)
		- `actions/cache@v3` has been integrated into `actions/setup-node@v4`