### PR TITLE
Move plugin configs outside of plugin folder

### DIFF
--- a/src/betterdiscord/modules/core.ts
+++ b/src/betterdiscord/modules/core.ts
@@ -99,6 +99,7 @@ export default new class Core {
         if (Config.get("version") !== previousVersion) {
             Modals.showChangelogModal(Changelog);
             JsonStore.set("misc", "version", Config.get("version"));
+            JsonStore.transferPluginConfigs();
         }
     }
 

--- a/src/betterdiscord/modules/core.ts
+++ b/src/betterdiscord/modules/core.ts
@@ -93,6 +93,7 @@ export default new class Core {
         if (Config.get("version") !== previousVersion) {
             Modals.showChangelogModal(Changelog);
             JsonStore.set("misc", "version", Config.get("version"));
+            JsonStore.transferPluginConfigs();
         }
 
         allModulesLoaded.then(() => PluginManager.startAddons("idle"));

--- a/src/betterdiscord/stores/config.ts
+++ b/src/betterdiscord/stores/config.ts
@@ -16,6 +16,7 @@ export default new class ConfigStore extends Store {
         dataPath: path.join(process.env.BETTERDISCORD_DATA_PATH!, "data"),
         pluginsPath: path.join(process.env.BETTERDISCORD_DATA_PATH!, "plugins"),
         themesPath: path.join(process.env.BETTERDISCORD_DATA_PATH!, "themes"),
+        pluginDataPath: path.join(process.env.BETTERDISCORD_DATA_PATH!, "data", "plugins"),
         channelPath: path.join(process.env.BETTERDISCORD_DATA_PATH!, "data", window?.DiscordNative?.app?.getReleaseChannel?.() ?? "stable"),
     };
 

--- a/src/betterdiscord/stores/config.ts
+++ b/src/betterdiscord/stores/config.ts
@@ -16,6 +16,7 @@ class ConfigStore extends Store {
         dataPath: path.join(process.env.BETTERDISCORD_DATA_PATH!, "data"),
         pluginsPath: path.join(process.env.BETTERDISCORD_DATA_PATH!, "plugins"),
         themesPath: path.join(process.env.BETTERDISCORD_DATA_PATH!, "themes"),
+        pluginDataPath: path.join(process.env.BETTERDISCORD_DATA_PATH!, "data", "plugins"),
         channelPath: path.join(process.env.BETTERDISCORD_DATA_PATH!, "data", window?.DiscordNative?.app?.getReleaseChannel?.() ?? "stable"),
     };
 

--- a/src/betterdiscord/stores/json.ts
+++ b/src/betterdiscord/stores/json.ts
@@ -73,7 +73,7 @@ class JsonStore extends Store {
 
     // Plugin data
     #getPluginFile(pluginName: string) {
-        return path.resolve(Config.get("pluginsPath"), pluginName + ".config.json");
+        return path.resolve(Config.get("pluginDataPath"), pluginName + ".config.json");
     }
 
     #ensurePluginData(pluginName: string) {
@@ -250,6 +250,28 @@ class JsonStore extends Store {
         }
 
         listeners.all.delete(callback);
+    }
+
+    public transferPluginConfigs() {
+        try {
+            const files: string[] = fs.readdirSync(path.resolve(Config.get("pluginsPath")))
+                .filter((file: string) => file.endsWith(".config.json"));
+            if (files.length) {
+                files.forEach(file => {
+                    const oldPath = path.join(Config.get("pluginsPath"), file);
+                    const newPath = path.join(Config.get("pluginDataPath"), file);
+                    try {
+                        fs.renameSync(oldPath, newPath);
+                    }
+                    catch (err) {
+                        Logger.err("JsonStore", `Failed to transfer ${file}`, err);
+                    }
+                });
+            }
+        }
+        catch (err) {
+            Logger.err("JsonStore", "Failed to transfer config files", err);
+        }
     }
 };
 

--- a/src/electron/main/modules/betterdiscord.ts
+++ b/src/electron/main/modules/betterdiscord.ts
@@ -46,6 +46,7 @@ export default class BetterDiscord {
         if (!fs.existsSync(path.join(dataFolder, "canary"))) fs.mkdirSync(path.join(dataFolder, "canary"));
         if (!fs.existsSync(path.join(dataFolder, "ptb"))) fs.mkdirSync(path.join(dataFolder, "ptb"));
         if (!fs.existsSync(path.join(dataFolder, "development"))) fs.mkdirSync(path.join(dataFolder, "development"));
+        if (!fs.existsSync(path.join(dataFolder, "plugins"))) fs.mkdirSync(path.join(dataFolder, "plugins"));
         if (!fs.existsSync(path.join(bdFolder, "plugins"))) fs.mkdirSync(path.join(bdFolder, "plugins"));
         if (!fs.existsSync(path.join(bdFolder, "themes"))) fs.mkdirSync(path.join(bdFolder, "themes"));
     }

--- a/src/electron/main/modules/betterdiscord.ts
+++ b/src/electron/main/modules/betterdiscord.ts
@@ -96,6 +96,7 @@ export default class BetterDiscord {
         if (!fs.existsSync(path.join(dataFolder, "canary"))) fs.mkdirSync(path.join(dataFolder, "canary"));
         if (!fs.existsSync(path.join(dataFolder, "ptb"))) fs.mkdirSync(path.join(dataFolder, "ptb"));
         if (!fs.existsSync(path.join(dataFolder, "development"))) fs.mkdirSync(path.join(dataFolder, "development"));
+        if (!fs.existsSync(path.join(dataFolder, "plugins"))) fs.mkdirSync(path.join(dataFolder, "plugins"));
         if (!fs.existsSync(path.join(bdFolder, "plugins"))) fs.mkdirSync(path.join(bdFolder, "plugins"));
         if (!fs.existsSync(path.join(bdFolder, "themes"))) fs.mkdirSync(path.join(bdFolder, "themes"));
     }


### PR DESCRIPTION
Moves plugin configs to a dedicated folder(`plugin_data`) under `data\[releaseChannel]`.

Adding a button to copy or sync configs across release channels might be useful but is likely outside the scope of this PR.

If merged, this change may prompt some support requests from users who find their configs missing. We could consider a temporary popup on the next update to offer moving the configs or, alternatively, include a highlighted note in the subsequent changelog.