### PR TITLE
Add useful utilities to reduce need for libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 node_modules
 .env
+.idea/

--- a/preload/src/api/electron.js
+++ b/preload/src/api/electron.js
@@ -1,4 +1,4 @@
-import {ipcRenderer as IPC, shell} from "electron";
+import {ipcRenderer as IPC, shell, webUtils} from "electron";
 
 export const ipcRenderer = {
     send: IPC.send.bind(IPC),
@@ -9,4 +9,4 @@ export const ipcRenderer = {
     off: IPC.off.bind(IPC)
 };
 
-export {shell};
+export {shell, webUtils};

--- a/renderer/src/data/changelog.js
+++ b/renderer/src/data/changelog.js
@@ -1,7 +1,7 @@
 // fixed, improved, added, progress
 export default {
     video: "https://www.youtube.com/embed/evyvq9eQTqA?si=opmzjGjUArT4VLrj&vq=hd720p&hd=1&rel=0&showinfo=0&mute=1&loop=1&autohide=1",
-    description: "A hotfix to get things going again. Plugins and Themes will take time to update.",
+    blurb: "A hotfix to get things going again. Plugins and Themes will take time to update.",
     changes: [
         {
             title: "Bugs Squashed",

--- a/renderer/src/data/changelog.js
+++ b/renderer/src/data/changelog.js
@@ -1,6 +1,11 @@
+import config from "./config";
+
 // fixed, improved, added, progress
 export default {
+    title: "BetterDiscord",
+    subtitle: `v${config.version}`,
     video: "https://www.youtube.com/embed/evyvq9eQTqA?si=opmzjGjUArT4VLrj&vq=hd720p&hd=1&rel=0&showinfo=0&mute=1&loop=1&autohide=1",
+    banner: "https://i.imgur.com/wuh5yMK.png",
     blurb: "A hotfix to get things going again. Plugins and Themes will take time to update.",
     changes: [
         {

--- a/renderer/src/modules/api/index.js
+++ b/renderer/src/modules/api/index.js
@@ -26,6 +26,7 @@ import SearchInput from "@ui/settings/components/search";
 import SliderInput from "@ui/settings/components/slider";
 import SwitchInput from "@ui/settings/components/switch";
 import TextInput from "@ui/settings/components/textbox";
+import SettingGroup from "@ui/settings/group";
 
 const bounded = new Map();
 const PluginAPI = new AddonAPI(PluginManager);
@@ -79,6 +80,7 @@ export default class BdApi {
         get SliderInput() {return SliderInput;},
         get SwitchInput() {return SwitchInput;},
         get TextInput() {return TextInput;},
+        get SettingGroup() {return SettingGroup;}
     };
     Net = {fetch}; 
 }

--- a/renderer/src/modules/api/index.js
+++ b/renderer/src/modules/api/index.js
@@ -27,6 +27,7 @@ import SliderInput from "@ui/settings/components/slider";
 import SwitchInput from "@ui/settings/components/switch";
 import TextInput from "@ui/settings/components/textbox";
 import SettingGroup from "@ui/settings/group";
+import ErrorBoundary from "@ui/errorboundary";
 
 const bounded = new Map();
 const PluginAPI = new AddonAPI(PluginManager);
@@ -80,7 +81,8 @@ export default class BdApi {
         get SliderInput() {return SliderInput;},
         get SwitchInput() {return SwitchInput;},
         get TextInput() {return TextInput;},
-        get SettingGroup() {return SettingGroup;}
+        get SettingGroup() {return SettingGroup;},
+        get ErrorBoundary() {return ErrorBoundary;},
     };
     Net = {fetch}; 
 }

--- a/renderer/src/modules/api/index.js
+++ b/renderer/src/modules/api/index.js
@@ -1,4 +1,4 @@
-import Logger from "@common/logger";
+import BDLogger from "@common/logger";
 
 import PluginManager from "@modules/pluginmanager";
 import ThemeManager from "@modules/thememanager";
@@ -15,6 +15,7 @@ import Webpack from "./webpack";
 import * as Legacy from "./legacy";
 import ContextMenu from "./contextmenu";
 import fetch from "./fetch";
+import Logger from "./logger";
 
 import ColorInput from "@ui/settings/components/color";
 import DropdownInput from "@ui/settings/components/dropdown";
@@ -36,6 +37,7 @@ const PatcherAPI = new Patcher();
 const DataAPI = new Data();
 const DOMAPI = new DOM();
 const ContextMenuAPI = new ContextMenu();
+const DefaultLogger = new Logger();
 
 /**
  * `BdApi` is a globally (`window.BdApi`) accessible object for use by plugins and developers to make their lives easier.
@@ -46,7 +48,7 @@ export default class BdApi {
         if (!pluginName) return BdApi;
         if (bounded.has(pluginName)) return bounded.get(pluginName);
         if (typeof(pluginName) !== "string") {
-            Logger.error("BdApi", "Plugin name not a string, returning generic API!");
+            BDLogger.error("BdApi", "Plugin name not a string, returning generic API!");
             return BdApi;
         }
 
@@ -57,6 +59,7 @@ export default class BdApi {
         this.Patcher = new Patcher(pluginName);
         this.Data = new Data(pluginName);
         this.DOM = new DOM(pluginName);
+        this.Logger = new Logger(pluginName);
 
         bounded.set(pluginName, this);
     }
@@ -175,6 +178,12 @@ BdApi.Components = {
  * @type Net
  */
 BdApi.Net = {fetch};
+
+/**
+ * An instance of {@link Logger} for logging information.
+ * @type Logger
+ */
+BdApi.Logger = DefaultLogger;
 
 Object.freeze(BdApi);
 Object.freeze(BdApi.Net);

--- a/renderer/src/modules/api/index.js
+++ b/renderer/src/modules/api/index.js
@@ -69,22 +69,6 @@ export default class BdApi {
     get UI() {return UI;}
     get ReactUtils() {return ReactUtils;}
     get ContextMenu() {return ContextMenuAPI;}
-    Components = {
-        get Tooltip() {return DiscordModules.Tooltip;},
-        get ColorInput() {return ColorInput;},
-        get DropdownInput() {return DropdownInput;},
-        get SettingItem() {return SettingItem;},
-        get KeybindInput() {return KeybindInput;},
-        get NumberInput() {return NumberInput;},
-        get RadioInput() {return RadioInput;},
-        get SearchInput() {return SearchInput;},
-        get SliderInput() {return SliderInput;},
-        get SwitchInput() {return SwitchInput;},
-        get TextInput() {return TextInput;},
-        get SettingGroup() {return SettingGroup;},
-        get ErrorBoundary() {return ErrorBoundary;},
-    };
-    Net = {fetch}; 
 }
 
 // Add legacy functions
@@ -150,10 +134,30 @@ BdApi.DOM = DOMAPI;
  */
 BdApi.ContextMenu = ContextMenuAPI;
 
+/**
+ * An set of react components plugins can make use of.
+ * @type Components
+ */
 BdApi.Components = {
-    get Tooltip() {return DiscordModules.Tooltip;}
+    get Tooltip() {return DiscordModules.Tooltip;},
+    get ColorInput() {return ColorInput;},
+    get DropdownInput() {return DropdownInput;},
+    get SettingItem() {return SettingItem;},
+    get KeybindInput() {return KeybindInput;},
+    get NumberInput() {return NumberInput;},
+    get RadioInput() {return RadioInput;},
+    get SearchInput() {return SearchInput;},
+    get SliderInput() {return SliderInput;},
+    get SwitchInput() {return SwitchInput;},
+    get TextInput() {return TextInput;},
+    get SettingGroup() {return SettingGroup;},
+    get ErrorBoundary() {return ErrorBoundary;},
 };
 
+/**
+ * An instance of {@link Net} for using network related tools.
+ * @type Net
+ */
 BdApi.Net = {fetch};
 
 Object.freeze(BdApi);

--- a/renderer/src/modules/api/index.js
+++ b/renderer/src/modules/api/index.js
@@ -16,6 +16,17 @@ import * as Legacy from "./legacy";
 import ContextMenu from "./contextmenu";
 import fetch from "./fetch";
 
+import ColorInput from "@ui/settings/components/color";
+import DropdownInput from "@ui/settings/components/dropdown";
+import SettingItem from "@ui/settings/components/item";
+import KeybindInput from "@ui/settings/components/keybind";
+import NumberInput from "@ui/settings/components/number";
+import RadioInput from "@ui/settings/components/radio";
+import SearchInput from "@ui/settings/components/search";
+import SliderInput from "@ui/settings/components/slider";
+import SwitchInput from "@ui/settings/components/switch";
+import TextInput from "@ui/settings/components/textbox";
+
 const bounded = new Map();
 const PluginAPI = new AddonAPI(PluginManager);
 const ThemeAPI = new AddonAPI(ThemeManager);
@@ -57,7 +68,17 @@ export default class BdApi {
     get ReactUtils() {return ReactUtils;}
     get ContextMenu() {return ContextMenuAPI;}
     Components = {
-        get Tooltip() {return DiscordModules.Tooltip;}
+        get Tooltip() {return DiscordModules.Tooltip;},
+        get ColorInput() {return ColorInput;},
+        get DropdownInput() {return DropdownInput;},
+        get SettingItem() {return SettingItem;},
+        get KeybindInput() {return KeybindInput;},
+        get NumberInput() {return NumberInput;},
+        get RadioInput() {return RadioInput;},
+        get SearchInput() {return SearchInput;},
+        get SliderInput() {return SliderInput;},
+        get SwitchInput() {return SwitchInput;},
+        get TextInput() {return TextInput;},
     };
     Net = {fetch}; 
 }

--- a/renderer/src/modules/api/index.js
+++ b/renderer/src/modules/api/index.js
@@ -69,6 +69,22 @@ export default class BdApi {
     get UI() {return UI;}
     get ReactUtils() {return ReactUtils;}
     get ContextMenu() {return ContextMenuAPI;}
+    Components = {
+        get Tooltip() {return DiscordModules.Tooltip;},
+        get ColorInput() {return ColorInput;},
+        get DropdownInput() {return DropdownInput;},
+        get SettingItem() {return SettingItem;},
+        get KeybindInput() {return KeybindInput;},
+        get NumberInput() {return NumberInput;},
+        get RadioInput() {return RadioInput;},
+        get SearchInput() {return SearchInput;},
+        get SliderInput() {return SliderInput;},
+        get SwitchInput() {return SwitchInput;},
+        get TextInput() {return TextInput;},
+        get SettingGroup() {return SettingGroup;},
+        get ErrorBoundary() {return ErrorBoundary;},
+    };
+    Net = {fetch}; 
 }
 
 // Add legacy functions

--- a/renderer/src/modules/api/logger.js
+++ b/renderer/src/modules/api/logger.js
@@ -1,0 +1,125 @@
+/**
+ * Simple logger for the lib and plugins.
+ *
+ * @module Logger
+ * @version 0.1.0
+ */
+
+/* eslint-disable no-console */
+
+/**
+ * List of logging types.
+ */
+
+const LogTypes = {
+    error: "error",
+    debug: "debug",
+    log: "log",
+    warn: "warn",
+    info: "info"
+};
+
+const parseType = type => LogTypes[type] || "log";
+
+
+/**
+ * `Logger` is a helper class to log data in a nice and consistent way. An instance is available on {@link BdApi}.
+ * @type Logger
+ * @summary {@link Logger} is a simple utility for logging information.
+ * @name Logger
+ */
+class Logger {
+
+    #pluginName = "";
+    #nameStyle = "color: #3a71c1; font-weight: 700;";
+    #messageStyle = "";
+
+    /**
+     * @param {string} pluginName - Name of the plugin
+     * @param {string} nameStyle - CSS to style the plugin name
+     * @param {string} messageStyle - CSS to style the main message
+     * @returns 
+     */
+    constructor(pluginName, nameStyle, messageStyle) {
+        if (!pluginName) return;
+        this.#pluginName = pluginName;
+        if (nameStyle) this.#nameStyle = nameStyle;
+        if (messageStyle) this.#messageStyle = messageStyle;
+    }
+
+    /**
+     * Logs an error using a collapsed error group with stacktrace.
+     *
+     * @param {string} pluginName - Name of the calling module.
+     * @param {string} message - Message or error to have logged.
+     * @param {Error} error - Error object to log with the message.
+     */
+    stacktrace(pluginName, message, error) {
+        console.error(`%c[${pluginName}]%c ${message}\n\n%c`, this.#nameStyle, "color: red; font-weight: 700;", "color: red;", error);
+    }
+
+    /**
+     * Logs an error message.
+     * 
+     * @param {string} pluginName Name of the calling module
+     * @param  {...any} message Messages to have logged.
+     */
+    error(pluginName, ...message) {this.#_log(pluginName, message, "error");}
+
+    /**
+     * Logs a warning message.
+     *
+     * @param {string} module - Name of the calling module.
+     * @param {...any} message - Messages to have logged.
+     */
+    warn(pluginName, ...message) {this.#_log(pluginName, message, "warn");}
+
+    /**
+     * Logs an informational message.
+     *
+     * @param {string} module - Name of the calling module.
+     * @param {...any} message - Messages to have logged.
+     */
+    info(pluginName, ...message) {this.#_log(pluginName, message, "info");}
+
+    /**
+     * Logs used for debugging purposes.
+     *
+     * @param {string} module - Name of the calling module.
+     * @param {...any} message - Messages to have logged.
+     */
+    debug(pluginName, ...message) {this.#_log(pluginName, message, "debug");}
+
+    /**
+     * Logs used for basic loggin.
+     *
+     * @param {string} module - Name of the calling module.
+     * @param {...any} message - Messages to have logged.
+     */
+    log(pluginName, ...message) {this.#_log(pluginName, message);}
+
+    /**
+     * Logs strings using different console levels and a module label.
+     *
+     * @param {string} module - Name of the calling module.
+     * @param {any|Array<any>} message - Messages to have logged.
+     * @param {module:Logger.LogTypes} type - Type of log to use in console.
+     */
+    #_log(pluginName, message, type = "log") {
+        type = parseType(type);
+
+        // Normalize messages to be an array for later spreading
+        if (!Array.isArray(message)) message = message ? [message] : [];
+
+        // If a name was set via constructor move the "name" to be part of the message
+        if (pluginName && this.#pluginName) message = [pluginName, ...message];
+        
+        const displayName = this.#pluginName || pluginName;
+        console[type](`%c[${displayName}]%c`, this.#nameStyle, this.#messageStyle, ...message);
+    }
+}
+
+
+Object.freeze(Logger);
+Object.freeze(Logger.prototype);
+export default Logger;

--- a/renderer/src/modules/api/logger.js
+++ b/renderer/src/modules/api/logger.js
@@ -55,6 +55,11 @@ class Logger {
      * @param {Error} error - Error object to log with the message.
      */
     stacktrace(pluginName, message, error) {
+        if (this.#pluginName) {
+            error = message;
+            message = pluginName;
+            pluginName = this.#pluginName;
+        }
         console.error(`%c[${pluginName}]%c ${message}\n\n%c`, this.#nameStyle, "color: red; font-weight: 700;", "color: red;", error);
     }
 

--- a/renderer/src/modules/api/ui.js
+++ b/renderer/src/modules/api/ui.js
@@ -155,7 +155,7 @@ const UI = {
      * @param {ReactElement} [setting.children] Only used for "custom" type
      * @param {CallableFunction} [setting.onChange] Callback when the value changes (only argument is new value)
      * @param {boolean} [setting.disabled=false] Whether this setting is disabled
-     * @param {boolean} [setting.inline=true] Whether the input should render inline with the name (this is false by default only for radio type)
+     * @param {boolean} [setting.inline=true] Whether the input should render inline with the name (this is false by default for slider, color, and radio types)
      * @returns A SettingItem with a an input as the child
      */
     buildSetting(setting) {

--- a/renderer/src/modules/api/ui.js
+++ b/renderer/src/modules/api/ui.js
@@ -155,10 +155,10 @@ const UI = {
      * @param {ReactElement} [setting.children] Only used for "custom" type
      * @param {CallableFunction} [setting.onChange] Callback when the value changes (only argument is new value)
      * @param {boolean} [setting.disabled=false] Whether this setting is disabled
-     * @param {boolean} [setting.inline=true] Whether the input should render inline with the name (this is false by default for slider, color, and radio types)
+     * @param {boolean} [setting.inline=true] Whether the input should render inline with the name (this is false by default for radio type)
      * @returns A SettingItem with a an input as the child
      */
-    buildSetting(setting) {
+    buildSettingItem(setting) {
         return buildSetting(setting);
     },
 

--- a/renderer/src/modules/api/ui.js
+++ b/renderer/src/modules/api/ui.js
@@ -146,13 +146,15 @@ const UI = {
      * The shape of the object should match the props of the component you want to render, check the
      * `BdApi.Components` section for details. Shown below are ones common to all setting types.
      * @param {object} setting 
+     * @param {string} setting.type One of: dropdown, number, switch, text, slider, radio, keybind, color, custom
      * @param {string} setting.id Identifier to used for callbacks
      * @param {string} setting.name Visual name to display
      * @param {string} setting.note Visual description to display
      * @param {any} setting.value Current value of the setting
+     * @param {ReactElement} [setting.children] Only used for "custom" type
      * @param {CallableFunction} [setting.onChange] Callback when the value changes (only argument is new value)
-     * @param {boolean} [setting.disabled] Whether this setting is disabled
-
+     * @param {boolean} [setting.disabled=false] Whether this setting is disabled
+     * @param {boolean} [setting.inline=true] Whether the input should render inline with the name (this is false by default only for radio type)
      * @returns A SettingItem with a an input as the child
      */
     buildSetting(setting) {

--- a/renderer/src/modules/api/ui.js
+++ b/renderer/src/modules/api/ui.js
@@ -58,6 +58,34 @@ const UI = {
     },
 
     /**
+     * Shows a changelog modal in a similar style to Discord's. Customizable with images, videos, colored sections and supports markdown.
+     * 
+     * The changes option is a array of objects that have this typing:
+     * ```ts
+     * interface Changes {
+     *     title: string;
+     *     type: "fixed" | "added" | "progress" | "changed";
+     *     items: Array<string>;
+     *     blurb?: string;
+     * }
+     * ```
+     * 
+     * @param {object} options Information to display in the modal
+     * @param {string} options.title Title to show in the modal header
+     * @param {string} options.subtitle Title to show below the main header
+     * @param {string} [options.blurb] Text to show in the body of the modal before the list of changes
+     * @param {string} [options.banner] URL to an image to display as the banner of the modal
+     * @param {string} [options.video] Youtube link or url of a video file to use as the banner
+     * @param {string} [options.poster] URL to use for the video freeze-frame poster
+     * @param {string|ReactElement|Array<string|ReactElement>} [options.footer] What to show in the modal footer
+     * @param {Array<object>} [options.changes] List of changes to show (see description for details)
+     * @returns {string} The key used for this modal.
+     */
+    showChangelogModal(options) {
+        return Modals.showChangelogModal(options);
+    },
+
+    /**
      * This shows a toast similar to android towards the bottom of the screen.
      *
      * @param {string} content The string to show in the toast

--- a/renderer/src/modules/api/ui.js
+++ b/renderer/src/modules/api/ui.js
@@ -163,16 +163,16 @@ const UI = {
      * Creates a settings panel (react element) based on json-like data.
      * 
      * The `settings` array here is an array of the same settings types described in `buildSetting` above.
-     * However, this API allows one additional setting "type" called `group`. This has the same properties
-     * as the React Component found under the `Components` API.
+     * However, this API allows one additional setting "type" called `category`. This has the same properties
+     * as the Group React Component found under the `Components` API.
      * 
-     * `onChange` will always be given 3 arguments: group id, setting id, and setting value. In the case
-     * that you have settings on the "root" of the panel, the group id is `null`.
+     * `onChange` will always be given 3 arguments: category id, setting id, and setting value. In the case
+     * that you have settings on the "root" of the panel, the category id is `null`.
      * 
-     * `onDrawerToggle` is given 2 arguments: group id, and the current shown state. You can use this to
+     * `onDrawerToggle` is given 2 arguments: category id, and the current shown state. You can use this to
      * save drawer states.
      * 
-     * `getDrawerState` is given 2 arguments: group id, and the default shown state. You can use this to
+     * `getDrawerState` is given 2 arguments: category id, and the default shown state. You can use this to
      * recall a saved drawer state.
      * 
      * @param {object} props 
@@ -186,14 +186,14 @@ const UI = {
         if (!settings?.length) throw new Error("No settings provided!");
         if (typeof(onChange) !== "function") throw new Error("No change listener provided!");
         return React.createElement(React.Fragment, null, settings.map(setting => {
-            if (setting.type === "group") {
+            if (setting.type === "category") {
                 const shownByDefault = setting.hasOwnProperty("shown") ? setting.shown : true;
-                const groupProps = Object.assign({}, setting, {
+                const categoryProps = Object.assign({}, setting, {
                     onChange,
                     onDrawerToggle: state => onDrawerToggle?.(setting.id, state),
                     shown: getDrawerState?.(setting.id, shownByDefault) ?? shownByDefault
                 });
-                return React.createElement(Group, groupProps);
+                return React.createElement(Group, categoryProps);
             }
             return buildSetting(Object.assign({}, setting, {onChange: value => onChange(null, setting.id, value)}));
         }));

--- a/renderer/src/modules/api/utils.js
+++ b/renderer/src/modules/api/utils.js
@@ -1,4 +1,5 @@
 import Utilities from "@modules/utilities";
+import {comparator} from "@structs/semver";
 
 
 /**
@@ -71,6 +72,27 @@ const Utils = {
      */
     className() {
         return Utilities.className(...arguments);
+    },
+
+    /**
+     * Gets a nested value (if it exists) of an object safely. keyPath should be something like `key.key2.key3`.
+     * Numbers can be used for arrays as well like `key.key2.array.0.id`.
+     * @param {object} obj - object to get nested value from
+     * @param {string} keyPath - key path to the desired value
+     */
+    getNestedValue(obj, keyPath) {
+        return Utilities.getNestedValue(obj, keyPath);
+    },
+
+    /**
+     * This works on semantic versioning e.g. "1.0.0".
+     * 
+     * @param {string} currentVersion
+     * @param {string} newVersion
+     * @returns {number} 0 indicates equal, -1 indicates left hand greater, 1 indicates right hand greater
+     */
+    semverCompare(currentVersion, newVersion) {
+        return comparator(currentVersion, newVersion);
     }
 };
 

--- a/renderer/src/modules/core.js
+++ b/renderer/src/modules/core.js
@@ -86,13 +86,7 @@ export default new class Core {
 
         const previousVersion = DataStore.getBDData("version");
         if (Config.version !== previousVersion) {
-            Modals.showChangelogModal(Object.assign({
-                banner: "https://i.imgur.com/wuh5yMK.png",
-                blurb: "",
-                changes: [],
-                title: "BetterDiscord",
-                subtitle: `v${Config.version}`
-            }, Changelog));
+            Modals.showChangelogModal(Changelog);
             DataStore.setBDData("version", Config.version);
         }
     }

--- a/renderer/src/modules/core.js
+++ b/renderer/src/modules/core.js
@@ -86,7 +86,13 @@ export default new class Core {
 
         const previousVersion = DataStore.getBDData("version");
         if (Config.version !== previousVersion) {
-            Modals.showChangelogModal(Changelog);
+            Modals.showChangelogModal(Object.assign({
+                banner: "https://i.imgur.com/wuh5yMK.png",
+                blurb: "",
+                changes: [],
+                title: "BetterDiscord",
+                subtitle: `v${Config.version}`
+            }, Changelog));
             DataStore.setBDData("version", Config.version);
         }
     }

--- a/renderer/src/modules/react.js
+++ b/renderer/src/modules/react.js
@@ -1,3 +1,5 @@
 import DiscordModules from "./discordmodules";
-export default DiscordModules.React;
+/** @type {import("react")} */
+const React = DiscordModules.React;
+export default React;
 export const ReactDOM = DiscordModules.ReactDOM;

--- a/renderer/src/modules/utilities.js
+++ b/renderer/src/modules/utilities.js
@@ -216,4 +216,16 @@ export default class Utilities {
 
         return classes.join(" ");
     }
+
+    /**
+     * Gets a nested value (if it exists) safely. Path should be something like `prop.prop2.prop3`.
+     * Numbers can be used for arrays as well like `prop.prop2.array.0.id`.
+     * @param {Object} obj - object to get nested value of
+     * @param {string} path - representation of the key path to obtain
+     */
+    static getNestedValue(obj, path) {
+        return path.split(".").reduce(function(ob, prop) {
+            return ob && ob[prop];
+        }, obj);
+    }
 }

--- a/renderer/src/modules/webpackmodules.js
+++ b/renderer/src/modules/webpackmodules.js
@@ -119,8 +119,8 @@ export class Filters {
      * @returns {module:WebpackModules.Filters~filter} - Combinatory filter of all arguments
      */
     static combine(...filters) {
-        return module => {
-            return filters.every(filter => filter(module));
+        return (exports, module, id) => {
+            return filters.every(filter => filter(exports, module, id));
         };
     }
 }
@@ -515,7 +515,7 @@ export default class WebpackModules {
 
                     const listeners = [...this.listeners];
                     for (let i = 0; i < listeners.length; i++) {
-                        try {listeners[i](exports);}
+                        try {listeners[i](exports, module, module.id);}
                         catch (error) {
                             Logger.stacktrace("WebpackModules", "Could not fire callback listener:", error);
                         }
@@ -525,7 +525,7 @@ export default class WebpackModules {
                     Logger.stacktrace("WebpackModules", "Could not patch pushed module", error);
                 }
                 finally {
-                	require.m[moduleId] = originalModule;
+                    require.m[moduleId] = originalModule;
                 }
             };
 

--- a/renderer/src/modules/webpackmodules.js
+++ b/renderer/src/modules/webpackmodules.js
@@ -398,7 +398,7 @@ export default class WebpackModules {
 
         return new Promise((resolve) => {
             const cancel = () => this.removeListener(listener);
-            const listener = function(exports) {
+            const listener = function(exports, module, id) {
                 if (!exports || exports === window || exports === document.documentElement || exports[Symbol.toStringTag] === "DOMTokenList") return;
 
                 let foundModule = null;
@@ -407,14 +407,14 @@ export default class WebpackModules {
                         foundModule = null;
                         const wrappedExport = exports[key];
                         if (!wrappedExport) continue;
-                        if (wrappedFilter(wrappedExport)) foundModule = wrappedExport;
+                        if (wrappedFilter(wrappedExport, module, id)) foundModule = wrappedExport;
                     }
                 }
                 else {
-                    if (exports.Z && wrappedFilter(exports.Z)) foundModule = defaultExport ? exports.Z : exports;
-                    if (exports.ZP && wrappedFilter(exports.ZP)) foundModule = defaultExport ? exports.ZP : exports;
-                    if (exports.__esModule && exports.default && wrappedFilter(exports.default)) foundModule = defaultExport ? exports.default : exports;
-                    if (wrappedFilter(exports)) foundModule = exports;
+                    if (exports.Z && wrappedFilter(exports.Z, module, id)) foundModule = defaultExport ? exports.Z : exports;
+                    if (exports.ZP && wrappedFilter(exports.ZP, module, id)) foundModule = defaultExport ? exports.ZP : exports;
+                    if (exports.__esModule && exports.default && wrappedFilter(exports.default, module, id)) foundModule = defaultExport ? exports.default : exports;
+                    if (wrappedFilter(exports, module, id)) foundModule = exports;
 
                 }
                 

--- a/renderer/src/styles/ui/bdsettings.css
+++ b/renderer/src/styles/ui/bdsettings.css
@@ -48,6 +48,11 @@
     transition: 150ms ease border-color;
 }
 
+.bd-select.bd-select-disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
 .bd-select:hover,
 .bd-select.menu-open {
     border-color: var(--background-tertiary);
@@ -123,7 +128,7 @@
 
 .bd-setting-header label {
     font-weight: 500;
-    cursor: pointer;
+    /* cursor: pointer; */
     overflow: hidden;
     word-wrap: break-word;
     font-size: 16px;

--- a/renderer/src/styles/ui/colorpicker.css
+++ b/renderer/src/styles/ui/colorpicker.css
@@ -2,6 +2,16 @@
     display: flex;
 }
 
+.bd-color-picker-container.bd-color-picker-disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+.bd-color-picker-container.bd-color-picker-disabled > .bd-color-picker-controls,
+.bd-color-picker-container.bd-color-picker-disabled > .bd-color-picker-swatch {
+    pointer-events: none;
+}
+
 .bd-color-picker-controls {
     padding-left: 1px;
     padding-top: 2px;

--- a/renderer/src/styles/ui/colorpicker.css
+++ b/renderer/src/styles/ui/colorpicker.css
@@ -1,5 +1,6 @@
 .bd-color-picker-container {
     display: flex;
+    justify-content: center;
 }
 
 .bd-color-picker-container.bd-color-picker-disabled {
@@ -20,8 +21,8 @@
 
 .bd-color-picker-default {
     cursor: pointer;
-    width: 72px;
-    height: 54px;
+    width: 75px;
+    height: 60px;
     border-radius: 4px;
     margin-right: 9px;
     display: flex;
@@ -39,13 +40,14 @@
     position: absolute;
     top: 5px;
     right: 5px;
+    pointer-events: none;
 }
 
 .bd-color-picker {
     outline: none;
-    width: 70px;
+    width: 75px;
     border: none;
-    height: 54px;
+    height: 60px;
     margin-top: 1px;
     border-radius: 4px;
     cursor: pointer;
@@ -60,16 +62,35 @@
     flex-wrap: wrap;
     align-content: flex-start;
     margin-left: 5px !important;
-    max-width: 340px;
+    max-width: 330px;
 }
 
 .bd-color-picker-swatch-item {
     cursor: pointer;
     border-radius: 4px;
-    width: 23px;
-    height: 23px;
+    width: 15px;
+    height: 15px;
     margin: 4px;
     display: flex;
     align-items: center;
     justify-content: center;
+}
+
+
+.bd-setting-item.inline .bd-color-picker-swatch {
+    max-width: 220px;
+    margin-top: 1px;
+}
+
+
+.bd-setting-item.inline .bd-color-picker-default,
+.bd-setting-item.inline .bd-color-picker {
+    width: 50px;
+    height: 40px
+}
+
+.bd-setting-item.inline .bd-color-picker-swatch-item {
+    height: 18px;
+    width: 18px;
+    margin: 2px 2px;
 }

--- a/renderer/src/styles/ui/file.css
+++ b/renderer/src/styles/ui/file.css
@@ -1,48 +1,54 @@
+.bd-setting-item.inline .bd-file-input-wrap {
+    max-width: 300px;
+}
+
 .bd-file-input-wrap {
+    display: flex;
+    align-items: center;
+    gap: 5px;
     position: relative;
+    min-width: 250px;
+    box-sizing: border-box;
+    border-radius: 3px;
+    background-color: hsla(0, calc(var(--saturation-factor, 1)*0%), 0%, .1);
+    border: 1px solid hsla(0, calc(var(--saturation-factor, 1)*0%), 0%, .3);
+    padding: 0 4px;
+    height: 40px;
 }
 
 .bd-file-input {
+    flex: 1;
+    outline: none;
     color: var(--text-normal);
-    background-color: var(--input-background);
-    min-width: 250px;
-    width: 100%;
     font-size: 16px;
-    border-radius: 3px;
-    padding: 10px;
-    height: 40px;
-    box-sizing: border-box;
-    overflow: hidden;
-    border: none;
+    font-weight: 600;
+    width: 100%;
+    cursor: pointer;
 }
   
 .bd-file-input::-webkit-file-upload-button {
-    color: white;
-    background: #3E82E5;
-    outline: 0;
-    border: 0;
-    padding: 12px 16px!important;
-    margin-top: -10px;
-    margin-left: -10px;
-    margin-right: 10px;
-    bottom: 0;
-    border-radius: 3px 0 0 3px;
-    font-size: 14px;
-    font-weight: 500;
-    cursor: pointer;
+    height: 0;
+    width: 0;
+    padding: 0 !important;
+    margin: 0;
+    visibility: hidden;
     user-select: none;
+    pointer-events: none;
+}
+
+.bd-file-input-wrap .bd-file-input-browse {
+    padding: 7px 16px;
 }
 
 .bd-file-input-wrap .bd-file-input-clear {
-    position: absolute;
-    top: 50%;
-    right: 5px;
-    transform: translateY(-50%);
+    margin-left: 5px;
+    /* background: none!important; */
     opacity: 0.5;
+    padding-right: 4px!important;
 }
 
 .bd-file-input-wrap .bd-file-input-clear:hover {
-    background: none;
+    /* background: none; */
     opacity: 1;
 }
 
@@ -56,6 +62,7 @@
     opacity: 0.5;
 }
 
+.bd-file-input-wrap.bd-file-input-disabled .bd-file-input-browse,
 .bd-file-input-wrap.bd-file-input-disabled .bd-file-input,
 .bd-file-input-wrap.bd-file-input-disabled .bd-file-input-clear {
     pointer-events: none;

--- a/renderer/src/styles/ui/file.css
+++ b/renderer/src/styles/ui/file.css
@@ -1,0 +1,62 @@
+.bd-file-input-wrap {
+    position: relative;
+}
+
+.bd-file-input {
+    color: var(--text-normal);
+    background-color: var(--input-background);
+    min-width: 250px;
+    width: 100%;
+    font-size: 16px;
+    border-radius: 3px;
+    padding: 10px;
+    height: 40px;
+    box-sizing: border-box;
+    overflow: hidden;
+    border: none;
+}
+  
+.bd-file-input::-webkit-file-upload-button {
+    color: white;
+    background: #3E82E5;
+    outline: 0;
+    border: 0;
+    padding: 12px 16px!important;
+    margin-top: -10px;
+    margin-left: -10px;
+    margin-right: 10px;
+    bottom: 0;
+    border-radius: 3px 0 0 3px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    user-select: none;
+}
+
+.bd-file-input-wrap .bd-file-input-clear {
+    position: absolute;
+    top: 50%;
+    right: 5px;
+    transform: translateY(-50%);
+    opacity: 0.5;
+}
+
+.bd-file-input-wrap .bd-file-input-clear:hover {
+    background: none;
+    opacity: 1;
+}
+
+.bd-file-input-wrap .bd-file-input-clear svg {
+    width: 18px !important;
+    height: 18px !important;
+}
+
+.bd-file-input-wrap.bd-file-input-disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+.bd-file-input-wrap.bd-file-input-disabled .bd-file-input,
+.bd-file-input-wrap.bd-file-input-disabled .bd-file-input-clear {
+    pointer-events: none;
+}

--- a/renderer/src/styles/ui/keybind.css
+++ b/renderer/src/styles/ui/keybind.css
@@ -1,11 +1,14 @@
 .bd-keybind-wrap {
+    display: flex;
+    align-items: center;
+    gap: 5px;
     position: relative;
     min-width: 250px;
     box-sizing: border-box;
     border-radius: 3px;
     background-color: hsla(0, calc(var(--saturation-factor, 1)*0%), 0%, .1);
     border: 1px solid hsla(0, calc(var(--saturation-factor, 1)*0%), 0%, .3);
-    padding: 10px;
+    padding: 0 4px;
     height: 40px;
     cursor: pointer;
 }
@@ -20,6 +23,7 @@
 }
 
 .bd-keybind-wrap input {
+    flex: 1;
     outline: none;
     border: none;
     pointer-events: none;
@@ -27,7 +31,11 @@
     background: none;
     font-size: 16px;
     text-transform: uppercase;
-    font-weight: 700;
+    font-weight: 600;
+}
+
+.bd-keybind-wrap input::placeholder {
+    text-transform: capitalize;
 }
 
 .bd-keybind-wrap.recording {
@@ -38,28 +46,23 @@
     box-shadow: 0 0 6px hsla(359, calc(var(--saturation-factor, 1)*82.6%), 59.4%, .3);
 }
 
-.bd-keybind-controls {
-    position: absolute;
-    right: 5px;
-    top: 3px;
-    display: flex;
-    align-items: center;
-    gap: 5px;
+.bd-keybind-wrap.recording input {
+    color: hsl(359, calc(var(--saturation-factor, 1)*82.6%), 59.4%)
 }
 
-.bd-keybind-controls .bd-keybind-record {
-    padding: 4px 8px;
+.bd-keybind-wrap .bd-keybind-record {
+    padding: 3px 8px;
 }
 
 .bd-keybind-clear {
     margin-left: 5px;
-    background: none!important;
+    /* background: none!important; */
     opacity: 0.5;
     padding-right: 4px!important;
 }
 
 .bd-keybind-clear:hover {
-    background: none;
+    /* background: none; */
     opacity: 1;
 }
 

--- a/renderer/src/styles/ui/keybind.css
+++ b/renderer/src/styles/ui/keybind.css
@@ -10,6 +10,15 @@
     cursor: pointer;
 }
 
+.bd-keybind-wrap.bd-keybind-disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+.bd-keybind-wrap.bd-keybind-disabled .bd-keybind-controls {
+    pointer-events: none;
+}
+
 .bd-keybind-wrap input {
     outline: none;
     border: none;

--- a/renderer/src/styles/ui/modal.css
+++ b/renderer/src/styles/ui/modal.css
@@ -112,19 +112,23 @@
     white-space: pre-wrap;
     word-wrap: break-word;
     width: 490px;
-    max-height: 800px;
+    max-height: min(800px, 60vh);
 }
 
 .bd-modal-medium {
     width: 600px;
-    max-height: 800px;
+    max-height: min(800px, 60vh);
     min-height: 400px;
 }
 
 .bd-modal-large {
     width: 800px;
-    max-height: 960px;
+    max-height: min(960px, 70vh);
     min-height: 400px;
+}
+
+.bd-addon-modal {
+    min-height: 0;
 }
 
 .bd-modal-header,

--- a/renderer/src/styles/ui/number.css
+++ b/renderer/src/styles/ui/number.css
@@ -14,3 +14,8 @@
     border-radius: 3px;
     width: 70px;
 }
+
+.bd-number-input:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+}

--- a/renderer/src/styles/ui/radio.css
+++ b/renderer/src/styles/ui/radio.css
@@ -5,7 +5,8 @@
 .bd-radio-option {
     display: flex;
     align-items: center;
-    padding: 10px;
+    border-left: 3px solid transparent;
+    padding: 10px 10px 10px 7px;
     margin-bottom: 8px;
     cursor: pointer;
     user-select: none;

--- a/renderer/src/styles/ui/radio.css
+++ b/renderer/src/styles/ui/radio.css
@@ -14,6 +14,15 @@
     color: var(--interactive-normal);
 }
 
+.bd-radio-group.bd-radio-disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+.bd-radio-group.bd-radio-disabled .bd-radio-option {
+    pointer-events: none;
+}
+
 .bd-radio-option:hover {
     background-color: var(--background-modifier-hover);
 }

--- a/renderer/src/styles/ui/slider.css
+++ b/renderer/src/styles/ui/slider.css
@@ -2,7 +2,16 @@
     display: flex;
     color: var(--text-normal);
     align-items: center;
-  }
+}
+
+.bd-slider-wrap.bd-slider-disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+.bd-slider-wrap.bd-slider-disabled .bd-slider-input {
+    pointer-events: none;
+}
   
   .bd-slider-label {
     background: var(--brand-experiment);

--- a/renderer/src/styles/ui/slider.css
+++ b/renderer/src/styles/ui/slider.css
@@ -115,3 +115,7 @@
     left: calc(50% - 1px);
     z-index: -1;
 }
+
+.bd-setting-item.inline:first-child:has(.bd-slider-wrap) {
+    padding-top: 50px;
+}

--- a/renderer/src/styles/ui/slider.css
+++ b/renderer/src/styles/ui/slider.css
@@ -1,43 +1,66 @@
+.bd-setting-item:not(.inline) .bd-slider-wrap {
+    margin-top: 10px;
+}
+
 .bd-slider-wrap {
     display: flex;
+    flex-direction: column;
+    justify-content: center;
     color: var(--text-normal);
     align-items: center;
+    position: relative;
+    margin: 0 10px;
 }
+
+.bd-slider-wrap.bd-slider-markers {
+    padding-bottom: 10px;
+    margin-bottom: 10px;
+}
+
 
 .bd-slider-wrap.bd-slider-disabled {
     cursor: not-allowed;
     opacity: 0.5;
 }
 
-.bd-slider-wrap.bd-slider-disabled .bd-slider-input {
+.bd-slider-wrap.bd-slider-disabled > .bd-slider-input,
+.bd-slider-wrap.bd-slider-disabled > .bd-slider-label,
+.bd-slider-wrap.bd-slider-disabled > .bd-slider-track,
+.bd-slider-wrap.bd-slider-disabled > .bd-slider-marker-container,
+.bd-slider-wrap.bd-slider-disabled > .bd-slider-input::-webkit-slider-thumb {
     pointer-events: none;
 }
   
-  .bd-slider-label {
-    background: var(--brand-experiment);
+.bd-slider-label {
+    background: black;
     font-weight: 700;
-    padding: 5px;
-    margin-right: 10px;
+    padding: 5px 7px;
     border-radius: 5px;
-  }
+    opacity: 0;
+    pointer-events: none;
+    position: absolute;
+    top: -45px;
+}
+
+.bd-slider-input:hover + .bd-slider-label {
+    opacity: 1;
+}
   
-  .bd-slider-input {
-    /* -webkit-appearance: none;  */
-    height: 8px;
-    border-radius: 4px;
+.bd-slider-input {
+    /* height: 8px; */
     appearance: none;
-    min-width: 350px;
-    border-radius: 5px;   
-    background: hsl(217,calc(var(--saturation-factor, 1)*7.6%),33.5%);
+    /* min-width: 350px; */
+    /* border-radius: 5px; */
     outline: none;
-    transition: opacity .2s;
-    background-image: linear-gradient(var(--brand-experiment), var(--brand-experiment));
-    background-size: 70% 100%;
-    background-repeat: no-repeat;
-  }
+    pointer-events: none;
+    position: absolute;
+    background: none;
+    width: 100%;
+    z-index: 2;
+}
   
   /* The slider handle (use -webkit- (Chrome, Opera, Safari, Edge) and -moz- (Firefox) to override default look) */
-  .bd-slider-input::-webkit-slider-thumb {
+.bd-slider-input::-webkit-slider-thumb {
     appearance: none;
     width: 10px;
     height: 24px;
@@ -48,4 +71,47 @@
     -webkit-box-shadow: 0 3px 1px 0 hsla(0,calc(var(--saturation-factor, 1)*0%),0%,.05),0 2px 2px 0 hsla(0,calc(var(--saturation-factor, 1)*0%),0%,.1),0 3px 3px 0 hsla(0,calc(var(--saturation-factor, 1)*0%),0%,.05);
     box-shadow: 0 3px 1px 0 hsla(0,calc(var(--saturation-factor, 1)*0%),0%,.05),0 2px 2px 0 hsla(0,calc(var(--saturation-factor, 1)*0%),0%,.1),0 3px 3px 0 hsla(0,calc(var(--saturation-factor, 1)*0%),0%,.05);
     cursor: ew-resize;
-  }
+    /* z-index: 3; */
+    pointer-events: all;
+}
+
+.bd-slider-track {
+    height: 8px;
+    border-radius: 4px;
+    min-width: 350px;
+    border-radius: 5px;   
+    background: hsl(217,calc(var(--saturation-factor, 1)*7.6%),33.5%);
+    transition: opacity .2s;
+    background-image: linear-gradient(#3E82E5, #3E82E5);
+    background-size: 70% 100%;
+    background-repeat: no-repeat;
+    cursor: pointer;
+    width: 100%;
+    z-index: 1;
+}
+
+.bd-slider-marker-container {
+    display: flex;
+    width: 98%;
+    justify-content: space-between;
+    position: absolute;
+    bottom: 0;
+}
+
+.bd-slider-marker {
+    position: absolute;
+    transform: translateX(-50%);
+    font-size: 12px;
+    cursor: pointer;
+}
+
+.bd-slider-marker::before {
+    content: "";
+    position: absolute;
+    width: 2px;
+    height: 24px;
+    background: rgba(255, 255, 255, 0.2);
+    top: -26px;
+    left: calc(50% - 1px);
+    z-index: -1;
+}

--- a/renderer/src/styles/ui/textbox.css
+++ b/renderer/src/styles/ui/textbox.css
@@ -8,4 +8,9 @@
     border: none;
     padding: 10px;
     height: 40px;
-  }
+}
+
+.bd-text-input:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+}

--- a/renderer/src/ui/customcss/editor.jsx
+++ b/renderer/src/ui/customcss/editor.jsx
@@ -24,7 +24,7 @@ function makeButton(button, value) {
 function makeSwitch(control) {
     return <Flex align={Flex.Align.CENTER} style={{gap: "10px"}}>
                 <Text>{control.label}</Text>
-                <Switch onChange={control.onChange} checked={control.checked} />
+                <Switch onChange={control.onChange} value={control.checked} />
             </Flex>;
 }
 

--- a/renderer/src/ui/modals.js
+++ b/renderer/src/ui/modals.js
@@ -1,5 +1,3 @@
-import Config from "@data/config";
-
 import FormattableString from "@structs/string";
 
 import Logger from "@common/logger";
@@ -221,8 +219,6 @@ export default class Modals {
     }
 
     static showChangelogModal(options = {}) {
-        options = Object.assign({image: "https://i.imgur.com/wuh5yMK.png", description: "", changes: [], title: "BetterDiscord", subtitle: `v${Config.version}`}, options);
-
         const key = this.openModal(props => {
             return React.createElement(ErrorBoundary, null, React.createElement(ChangelogModal, Object.assign(options, props)));
         });

--- a/renderer/src/ui/modals/changelog.jsx
+++ b/renderer/src/ui/modals/changelog.jsx
@@ -57,7 +57,7 @@ function Video({src, poster}) {
 }
 
 
-export default function ChangelogModal({transitionState, footer, title, subtitle, onClose, video, poster, image, description, changes}) {
+export default function ChangelogModal({transitionState, footer, title, subtitle, onClose, video, poster, banner, blurb, changes}) {
 
     const ChangelogHeader = useMemo(() => <Header justify={Flex.Justify.BETWEEN}>
         <Flex direction={Flex.Direction.VERTICAL}>
@@ -78,19 +78,19 @@ export default function ChangelogModal({transitionState, footer, title, subtitle
     </Footer>, [footer]);
 
     const changelogItems = useMemo(() => {
-        const items = [video ? <Video src={video} poster={poster} /> : <img src={image} className="bd-changelog-poster" />];
-        if (description) items.push(<p>{SimpleMarkdownExt.parseToReact(description)}</p>);
+        const items = [video ? <Video src={video} poster={poster} /> : <img src={banner} className="bd-changelog-poster" />];
+        if (blurb) items.push(<p>{SimpleMarkdownExt.parseToReact(blurb)}</p>);
         for (let c = 0; c < changes.length; c++) {
             const entry = changes[c];
             const type = "bd-changelog-" + entry.type;
             const margin = c == 0 ? " bd-changelog-first" : "";
             items.push(<h1 className={`bd-changelog-title ${type}${margin}`}>{entry.title}</h1>);
-            if (entry.description) items.push(<p>{SimpleMarkdownExt.parseToReact(entry.description)}</p>);
+            if (entry.blurb) items.push(<p>{SimpleMarkdownExt.parseToReact(entry.blurb)}</p>);
             const list = <ul>{entry.items.map(i => <li>{SimpleMarkdownExt.parseToReact(i)}</li>)}</ul>;
             items.push(list);
         }
         return items;
-    }, [description, video, image, poster, changes]);
+    }, [blurb, video, banner, poster, changes]);
 
     return <Root className="bd-changelog-modal" transitionState={transitionState} size={Root.Sizes.MEDIUM} style={Root.Styles.STANDARD}>
         {ChangelogHeader}

--- a/renderer/src/ui/modals/changelog.jsx
+++ b/renderer/src/ui/modals/changelog.jsx
@@ -78,9 +78,13 @@ export default function ChangelogModal({transitionState, footer, title, subtitle
     </Footer>, [footer]);
 
     const changelogItems = useMemo(() => {
-        const items = [video ? <Video src={video} poster={poster} /> : <img src={banner} className="bd-changelog-poster" />];
+        const items = [];
+        if (video) items.push(<Video src={video} poster={poster} />);
+        else if (banner) items.push(<img src={banner} className="bd-changelog-poster" />);
+
         if (blurb) items.push(<p>{SimpleMarkdownExt.parseToReact(blurb)}</p>);
-        for (let c = 0; c < changes.length; c++) {
+
+        for (let c = 0; c < changes?.length; c++) {
             const entry = changes[c];
             const type = "bd-changelog-" + entry.type;
             const margin = c == 0 ? " bd-changelog-first" : "";
@@ -95,6 +99,6 @@ export default function ChangelogModal({transitionState, footer, title, subtitle
     return <Root className="bd-changelog-modal" transitionState={transitionState} size={Root.Sizes.MEDIUM} style={Root.Styles.STANDARD}>
         {ChangelogHeader}
         <Content>{changelogItems}</Content>
-        {ChangelogFooter}
+        {(footer || title === "BetterDiscord") && ChangelogFooter}
     </Root>;
 }

--- a/renderer/src/ui/settings/addoncard.jsx
+++ b/renderer/src/ui/settings/addoncard.jsx
@@ -170,7 +170,7 @@ export default function AddonCard({addon, prefix, type, disabled, enabled: initi
                 <div className="bd-addon-header">
                         {type === "plugin" ? <ExtIcon size="18px" className="bd-icon" /> : <ThemeIcon size="18px" className="bd-icon" />}
                         <div className="bd-title">{title}</div>
-                        <Switch internalState={false} disabled={disabled} checked={isEnabled} onChange={onChange} />
+                        <Switch internalState={false} disabled={disabled} value={isEnabled} onChange={onChange} />
                 </div>
                 <div className="bd-description-wrap">
                     {disabled && <div className="banner banner-danger"><ErrorIcon className="bd-icon" />{`An error was encountered while trying to load this ${type}.`}</div>}

--- a/renderer/src/ui/settings/components/color.jsx
+++ b/renderer/src/ui/settings/components/color.jsx
@@ -68,7 +68,7 @@ export default function Color({value: initialValue, onChange, colors = defaultCo
     const intValue = resolveColor(value, false);
     return <div className={`bd-color-picker-container ${disabled ? "bd-color-picker-disabled" : ""}`}>
         <div className="bd-color-picker-controls">
-            <DiscordModules.Tooltip text="Default" position="bottom">
+            {defaultValue && <DiscordModules.Tooltip text="Default" position="bottom">
                 {props => (
                     <div {...props} className="bd-color-picker-default" style={{backgroundColor: resolveColor(defaultValue)}} onClick={() => change({target: {value: defaultValue}})}>
                         {intValue === resolveColor(defaultValue, false)
@@ -77,7 +77,7 @@ export default function Color({value: initialValue, onChange, colors = defaultCo
                         }
                     </div>
                 )}
-            </DiscordModules.Tooltip>
+            </DiscordModules.Tooltip>}
             <DiscordModules.Tooltip text={Strings.Settings.customColor} position="bottom">
                 {props => (
                     <div className="bd-color-picker-custom">
@@ -87,7 +87,7 @@ export default function Color({value: initialValue, onChange, colors = defaultCo
                 )}
             </DiscordModules.Tooltip>
         </div>
-        <div className="bd-color-picker-swatch">
+        {colors?.length > 0 && <div className="bd-color-picker-swatch">
             {
                 colors.map((int, index) => (
                     <div key={index} className="bd-color-picker-swatch-item" style={{backgroundColor: resolveColor(int)}} onClick={() => change({target: {value: int}})}>
@@ -98,6 +98,6 @@ export default function Color({value: initialValue, onChange, colors = defaultCo
                     </div>
                 ))
             }
-        </div>
+        </div>}
     </div>;
 }

--- a/renderer/src/ui/settings/components/color.jsx
+++ b/renderer/src/ui/settings/components/color.jsx
@@ -57,15 +57,16 @@ const getContrastColor = (color) => {
 };
 
 
-export default function Color({value: initialValue, onChange, colors = defaultColors, defaultValue}) {
+export default function Color({value: initialValue, onChange, colors = defaultColors, defaultValue, disabled}) {
     const [value, setValue] = useState(initialValue);
     const change = useCallback((e) => {
+        if (disabled) return;
         onChange?.(resolveColor(e.target.value));
         setValue(e.target.value);
-    }, [onChange]);
+    }, [onChange, disabled]);
 
     const intValue = resolveColor(value, false);
-    return <div className="bd-color-picker-container">
+    return <div className={`bd-color-picker-container ${disabled ? "bd-color-picker-disabled" : ""}`}>
         <div className="bd-color-picker-controls">
             <DiscordModules.Tooltip text="Default" position="bottom">
                 {props => (
@@ -81,7 +82,7 @@ export default function Color({value: initialValue, onChange, colors = defaultCo
                 {props => (
                     <div className="bd-color-picker-custom">
                         <Dropper color={getContrastColor(resolveColor(value, true))} />
-                        <input {...props} style={{backgroundColor: resolveColor(value)}} type="color" className="bd-color-picker" value={resolveColor(value)} onChange={change} />
+                        <input {...props} style={{backgroundColor: resolveColor(value)}} type="color" className="bd-color-picker" value={resolveColor(value)} onChange={change} disabled={disabled} />
                     </div>
                 )}
             </DiscordModules.Tooltip>

--- a/renderer/src/ui/settings/components/dropdown.jsx
+++ b/renderer/src/ui/settings/components/dropdown.jsx
@@ -5,7 +5,7 @@ import Arrow from "@ui/icons/downarrow";
 const {useState, useCallback} = React;
 
 
-export default function Select({value: initialValue, options, style, onChange}) {
+export default function Select({value: initialValue, options, style, onChange, disabled}) {
     const [value, setValue] = useState(initialValue ?? options[0].value);
     const change = useCallback((val) => {
         onChange?.(val);
@@ -23,11 +23,13 @@ export default function Select({value: initialValue, options, style, onChange}) 
         event.preventDefault();
         event.stopPropagation();
 
+        if (disabled) return;
+
         const next = !open;
         setOpen(next);
         if (!next) return;
         document.addEventListener("click", hideMenu);
-    }, [hideMenu, open]);
+    }, [hideMenu, open, disabled]);
 
 
     // ?? options[0] provides a double failsafe
@@ -40,7 +42,8 @@ export default function Select({value: initialValue, options, style, onChange}) 
 
     const styleClass = style == "transparent" ? " bd-select-transparent" : "";
     const isOpen = open ? " menu-open" : "";
-    return <div className={`bd-select${styleClass}${isOpen}`} onClick={showMenu}>
+    const isDisabled = disabled ? " bd-select-disabled" : "";
+    return <div className={`bd-select${styleClass}${isOpen}${isDisabled}`} onClick={showMenu}>
                 <div className="bd-select-value">{selected.label}</div>
                 <Arrow className="bd-select-arrow" />
                 {open && optionComponents}

--- a/renderer/src/ui/settings/components/file.jsx
+++ b/renderer/src/ui/settings/components/file.jsx
@@ -1,0 +1,35 @@
+import {webUtils} from "electron";
+import React from "@modules/react";
+import Button from "@ui/base/button";
+import Close from "@ui/icons/close";
+
+const {useRef, useCallback, useEffect} = React;
+
+
+export default function Filepicker({multiple, accept, clearable, onChange, disabled, actions}) {
+    const inputRef = useRef(null);
+
+    const change = useCallback((e) => {
+        if (disabled) return;
+        const files = [];
+        for (const file of e.target.files) {
+            files.push(webUtils.getPathForFile(file));
+        }
+        onChange?.(multiple ? files : files[0]);
+    }, [onChange, disabled, multiple]);
+
+    const clear = useCallback(() => {
+        inputRef.current.value = "";
+        onChange?.(multiple ? [] : "");
+    }, [onChange, multiple]);
+
+    useEffect(() => {
+        if (!actions) return;
+        actions.clear = clear;
+    }, [clear, actions]);
+
+    return <div className={`bd-file-input-wrap ${disabled ? "bd-file-input-disabled" : ""}`}>
+        <input onChange={change} type="file" className="bd-file-input" multiple={multiple} accept={accept} disabled={disabled} ref={inputRef} />
+        {clearable && <Button size={Button.Sizes.ICON} look={Button.Looks.BLANK} onClick={clear} className="bd-file-input-clear"><Close size="24px" /></Button>}
+        </div>;
+}

--- a/renderer/src/ui/settings/components/file.jsx
+++ b/renderer/src/ui/settings/components/file.jsx
@@ -28,7 +28,12 @@ export default function Filepicker({multiple, accept, clearable, onChange, disab
         actions.clear = clear;
     }, [clear, actions]);
 
+    const onClick = useCallback(() => {
+        inputRef.current?.click();
+    }, []);
+
     return <div className={`bd-file-input-wrap ${disabled ? "bd-file-input-disabled" : ""}`}>
+        <Button size={Button.Sizes.ICON} look={Button.Looks.FILLED} color={Button.Colors.PRIMARY} className="bd-file-input-browse" onClick={onClick}>Browse</Button>
         <input onChange={change} type="file" className="bd-file-input" multiple={multiple} accept={accept} disabled={disabled} ref={inputRef} />
         {clearable && <Button size={Button.Sizes.ICON} look={Button.Looks.BLANK} onClick={clear} className="bd-file-input-clear"><Close size="24px" /></Button>}
         </div>;

--- a/renderer/src/ui/settings/components/keybind.jsx
+++ b/renderer/src/ui/settings/components/keybind.jsx
@@ -7,7 +7,7 @@ import Close from "@ui/icons/close";
 const {useState, useCallback, useEffect} = React;
 
 
-export default function Keybind({value: initialValue, onChange, max = 4, clearable = true, disabled}) {
+export default function Keybind({value: initialValue, onChange, max = 4, clearable = false, disabled}) {
     const [state, setState] = useState({value: initialValue, isRecording: false, accum: []});
 
     useEffect(() => {
@@ -60,12 +60,10 @@ export default function Keybind({value: initialValue, onChange, max = 4, clearab
     }, [state, clearKeybind, disabled]);
 
 
-    const displayValue = state.isRecording ? "Recording..." : !state.value.length ? "N/A" : state.value.join(" + ");
+    const displayValue = !state.value.length ? "" : state.value.map(k => k === "Control" ? "Ctrl" : k).join(" + ");
     return <div className={"bd-keybind-wrap" + (state.isRecording ? " recording" : "") + (disabled ? " bd-keybind-disabled" : "")} onClick={onClick}>
-            <input readOnly={true} type="text" className="bd-keybind-input" value={displayValue} disabled={disabled} />
-            <div className="bd-keybind-controls">
-                <Button size={Button.Sizes.ICON} look={Button.Looks.FILLED} color={state.isRecording ? Button.Colors.RED : Button.Colors.BRAND} className="bd-keybind-record" onClick={onClick}><Keyboard size="24px" /></Button>
-                {clearable && <Button size={Button.Sizes.ICON} look={Button.Looks.BLANK} onClick={clearKeybind} className="bd-keybind-clear"><Close size="24px" /></Button>}
-            </div>
+            <Button size={Button.Sizes.ICON} look={Button.Looks.FILLED} color={state.isRecording ? Button.Colors.RED : Button.Colors.PRIMARY} className="bd-keybind-record" onClick={onClick}><Keyboard size="24px" /></Button>
+            <input readOnly={true} type="text" className="bd-keybind-input" value={displayValue} placeholder="No keybind set" disabled={disabled} />
+            {clearable && <Button size={Button.Sizes.ICON} look={Button.Looks.BLANK} onClick={clearKeybind} className="bd-keybind-clear"><Close size="24px" /></Button>}
         </div>;
 }

--- a/renderer/src/ui/settings/components/keybind.jsx
+++ b/renderer/src/ui/settings/components/keybind.jsx
@@ -7,15 +7,19 @@ import Close from "@ui/icons/close";
 const {useState, useCallback, useEffect} = React;
 
 
-export default function Keybind({value: initialValue, onChange, max = 2, clearable = true, disabled}) {
+export default function Keybind({value: initialValue, onChange, max = 4, clearable = true, disabled}) {
     const [state, setState] = useState({value: initialValue, isRecording: false, accum: []});
 
     useEffect(() => {
-        window.addEventListener("keydown", keyHandler, true);
-        return () => window.removeEventListener("keydown", keyHandler, true);
+        window.addEventListener("keydown", keyDownHandler, true);
+        window.addEventListener("keyup", keyUpHandler, true);
+        return () => {
+            window.removeEventListener("keydown", keyDownHandler, true);
+            window.removeEventListener("keyup", keyUpHandler, true);
+        };
     });
 
-    const keyHandler = useCallback((event) => {
+    const keyDownHandler = useCallback((event) => {
         if (!state.isRecording) return;
         event.stopImmediatePropagation();
         event.stopPropagation();
@@ -28,6 +32,15 @@ export default function Keybind({value: initialValue, onChange, max = 2, clearab
             setState({value: state.accum.slice(0), isRecording: false, accum: []});
         }
     }, [state, max, onChange]);
+
+    const keyUpHandler = useCallback((event) => {
+        if (!state.isRecording) return;
+        event.stopImmediatePropagation();
+        event.stopPropagation();
+        event.preventDefault();
+
+        if (event.key === state.accum[0]) setState({value: state.accum.slice(0), isRecording: false, accum: []});
+    }, [state]);
 
     const clearKeybind = useCallback((event) => {
         event.stopPropagation();

--- a/renderer/src/ui/settings/components/keybind.jsx
+++ b/renderer/src/ui/settings/components/keybind.jsx
@@ -7,7 +7,7 @@ import Close from "@ui/icons/close";
 const {useState, useCallback, useEffect} = React;
 
 
-export default function Keybind({value: initialValue, onChange, max = 2, clearable = true}) {
+export default function Keybind({value: initialValue, onChange, max = 2, clearable = true, disabled}) {
     const [state, setState] = useState({value: initialValue, isRecording: false, accum: []});
 
     useEffect(() => {
@@ -32,19 +32,21 @@ export default function Keybind({value: initialValue, onChange, max = 2, clearab
     const clearKeybind = useCallback((event) => {
         event.stopPropagation();
         event.preventDefault();
+        if (disabled) return;
         if (onChange) onChange([]);
         setState({...state, isRecording: false, value: [], accum: []});
-    }, [onChange, state]);
+    }, [onChange, state, disabled]);
 
     const onClick = useCallback((e) => {
+        if (disabled) return;
         if (e.target?.className?.includes?.("bd-keybind-clear") || e.target?.closest(".bd-button")?.className?.includes("bd-keybind-clear")) return clearKeybind(e);
         setState({...state, isRecording: !state.isRecording});
-    }, [state, clearKeybind]);
+    }, [state, clearKeybind, disabled]);
 
 
     const displayValue = state.isRecording ? "Recording..." : !state.value.length ? "N/A" : state.value.join(" + ");
-    return <div className={"bd-keybind-wrap" + (state.isRecording ? " recording" : "")} onClick={onClick}>
-            <input readOnly={true} type="text" className="bd-keybind-input" value={displayValue} />
+    return <div className={"bd-keybind-wrap" + (state.isRecording ? " recording" : "") + (disabled ? " bd-keybind-disabled" : "")} onClick={onClick}>
+            <input readOnly={true} type="text" className="bd-keybind-input" value={displayValue} disabled={disabled} />
             <div className="bd-keybind-controls">
                 <Button size={Button.Sizes.ICON} look={Button.Looks.FILLED} color={state.isRecording ? Button.Colors.RED : Button.Colors.BRAND} className="bd-keybind-record" onClick={onClick}><Keyboard size="24px" /></Button>
                 {clearable && <Button size={Button.Sizes.ICON} look={Button.Looks.BLANK} onClick={clearKeybind} className="bd-keybind-clear"><Close size="24px" /></Button>}

--- a/renderer/src/ui/settings/components/keybind.jsx
+++ b/renderer/src/ui/settings/components/keybind.jsx
@@ -39,8 +39,11 @@ export default function Keybind({value: initialValue, onChange, max = 4, clearab
         event.stopPropagation();
         event.preventDefault();
 
-        if (event.key === state.accum[0]) setState({value: state.accum.slice(0), isRecording: false, accum: []});
-    }, [state]);
+        if (event.key === state.accum[0]) {
+            onChange?.(state.accum);
+            setState({value: state.accum.slice(0), isRecording: false, accum: []});
+        }
+    }, [state, onChange]);
 
     const clearKeybind = useCallback((event) => {
         event.stopPropagation();

--- a/renderer/src/ui/settings/components/number.jsx
+++ b/renderer/src/ui/settings/components/number.jsx
@@ -3,12 +3,12 @@ import React from "@modules/react";
 const {useState, useCallback} = React;
 
 
-export default function Number({value: initialValue, min, max, step, onChange}) {
+export default function Number({value: initialValue, min, max, step, onChange, disabled}) {
     const [value, setValue] = useState(initialValue);
     const change = useCallback((e) => {
         onChange?.(e.target.value);
         setValue(e.target.value);
     }, [onChange]);
 
-    return <input onChange={change} type="number" className="bd-number-input" min={min} max={max} step={step} value={value} />;
+    return <input onChange={change} type="number" className="bd-number-input" min={min} max={max} step={step} value={value} disabled={disabled} />;
 }

--- a/renderer/src/ui/settings/components/radio.jsx
+++ b/renderer/src/ui/settings/components/radio.jsx
@@ -5,19 +5,20 @@ import RadioIcon from "@ui/icons/radio";
 const {useState, useCallback} = React;
 
 
-export default function Radio({name, value, options, onChange}) {
+export default function Radio({name, value, options, onChange, disabled}) {
     const [index, setIndex] = useState(options.findIndex(o => o.value === value));
     const change = useCallback((e) => {
+        if (disabled) return;
         const newIndex = parseInt(e.target.value);
         const newValue = options[newIndex].value;
         onChange?.(newValue);
         setIndex(newIndex);
-    }, [options, onChange]);
+    }, [options, onChange, disabled]);
 
     function renderOption(opt, i) {
         const isSelected = index === i;
         return <label className={"bd-radio-option" + (isSelected ? " bd-radio-selected" : "")}>
-                <input onChange={change} type="radio" name={name} checked={isSelected} value={i} />
+                <input onChange={change} type="radio" name={name} checked={isSelected} value={i} disabled={disabled} />
                 {/* <span className="bd-radio-button"></span> */}
                 <RadioIcon className="bd-radio-icon" size="24" checked={isSelected} />
                 <div className="bd-radio-label-wrap">
@@ -27,5 +28,5 @@ export default function Radio({name, value, options, onChange}) {
             </label>;
     }
 
-    return <div className="bd-radio-group">{options.map(renderOption)}</div>;
+    return <div className={`bd-radio-group ${disabled ? "bd-radio-disabled" : ""}`}>{options.map(renderOption)}</div>;
 }

--- a/renderer/src/ui/settings/components/radio.jsx
+++ b/renderer/src/ui/settings/components/radio.jsx
@@ -17,7 +17,7 @@ export default function Radio({name, value, options, onChange, disabled}) {
 
     function renderOption(opt, i) {
         const isSelected = index === i;
-        return <label className={"bd-radio-option" + (isSelected ? " bd-radio-selected" : "")}>
+        return <label className={"bd-radio-option" + (isSelected ? " bd-radio-selected" : "")} style={{borderColor: opt.color ?? "transparent"}}>
                 <input onChange={change} type="radio" name={name} checked={isSelected} value={i} disabled={disabled} />
                 {/* <span className="bd-radio-button"></span> */}
                 <RadioIcon className="bd-radio-icon" size="24" checked={isSelected} />

--- a/renderer/src/ui/settings/components/slider.jsx
+++ b/renderer/src/ui/settings/components/slider.jsx
@@ -1,17 +1,61 @@
 import React from "@modules/react";
 
-const {useState, useCallback} = React;
+const {useState, useCallback, useMemo, useRef} = React;
 
 
-export default function Slider({value: initialValue, min, max, step, onChange, disabled}) {
+export default function Slider({value: initialValue, min, max, step, onChange, disabled, units = "", markers = []}) {
     const [value, setValue] = useState(initialValue);
+    const inputRef = useRef(null);
+
     const change = useCallback((e) => {
         if (disabled) return;
         onChange?.(e.target.value);
         setValue(e.target.value);
     }, [onChange, disabled]);
 
-    return <div className={`bd-slider-wrap ${disabled ? "bd-slider-disabled" : ""}`}>
-        <div className="bd-slider-label">{value}</div><input onChange={change} type="range" className="bd-slider-input" min={min} max={max} step={step} value={value} style={{backgroundSize: (value - min) * 100 / (max - min) + "% 100%"}} disabled={disabled} />
+    const jumpToValue = useCallback(val => {
+        if (disabled) return;
+        onChange?.(val);
+        setValue(val);
+    }, [onChange, disabled]);
+
+    const percent = useCallback(val => {
+        return (val - min) * 100 / (max - min);
+    }, [min, max]);
+
+    const labelOffset = useMemo(() => {
+        const slope = (-62.5 - -25) / (max - min);
+        const offset = (value * slope) + -25;
+        if (offset < -62.5) return -62.5;
+        return offset;
+    }, [value, min, max]);
+
+    const trackClick = useCallback(e => {
+        const bounds = e.target.getBoundingClientRect();
+        const offsetX = e.clientX - bounds.left;
+        const offsetPercent = (offsetX / bounds.width);
+        const newValue = (offsetPercent * (max - min)) + min;
+        inputRef.current.value = newValue;
+        jumpToValue(inputRef.current?.value);
+
+    }, [max, min, jumpToValue, inputRef]);
+
+    return <div className={`bd-slider-wrap ${disabled ? "bd-slider-disabled" : ""} ${markers.length > 0 ? "bd-slider-markers" : ""}`}>
+        <input onChange={change} type="range" className="bd-slider-input" min={min} max={max} step={step} value={value} disabled={disabled} ref={inputRef} />
+        <div className="bd-slider-label" style={{left: `${percent(value)}%`, transform: `translateX(${labelOffset}%)`}}>{value}{units}</div>
+        <div className="bd-slider-track" style={{backgroundSize: percent(value) + "% 100%"}} onClick={trackClick}></div>
+        {markers?.length > 0 && <div className="bd-slider-marker-container">
+            {markers.map(m => <div className="bd-slider-marker" style={{left: percent(m) + "%"}} onClick={() => jumpToValue(m)}>{m}{units}</div>)}
+        </div>}
     </div>;
 }
+
+
+
+/**
+ * label offset left:
+ * 
+ * value - min
+ * -----------   x 100
+ *  max - min
+ */

--- a/renderer/src/ui/settings/components/slider.jsx
+++ b/renderer/src/ui/settings/components/slider.jsx
@@ -3,14 +3,15 @@ import React from "@modules/react";
 const {useState, useCallback} = React;
 
 
-export default function Slider({value: initialValue, min, max, step, onChange}) {
+export default function Slider({value: initialValue, min, max, step, onChange, disabled}) {
     const [value, setValue] = useState(initialValue);
     const change = useCallback((e) => {
+        if (disabled) return;
         onChange?.(e.target.value);
         setValue(e.target.value);
-    }, [onChange]);
+    }, [onChange, disabled]);
 
-    return <div className="bd-slider-wrap">
-        <div className="bd-slider-label">{value}</div><input onChange={change} type="range" className="bd-slider-input" min={min} max={max} step={step} value={value} style={{backgroundSize: (value - min) * 100 / (max - min) + "% 100%"}} />
+    return <div className={`bd-slider-wrap ${disabled ? "bd-slider-disabled" : ""}`}>
+        <div className="bd-slider-label">{value}</div><input onChange={change} type="range" className="bd-slider-input" min={min} max={max} step={step} value={value} style={{backgroundSize: (value - min) * 100 / (max - min) + "% 100%"}} disabled={disabled} />
     </div>;
 }

--- a/renderer/src/ui/settings/components/switch.jsx
+++ b/renderer/src/ui/settings/components/switch.jsx
@@ -3,7 +3,7 @@ import React from "@modules/react";
 const {useState, useCallback} = React;
 
 
-export default function Switch({id, checked: initialValue, disabled, onChange, internalState = true}) {
+export default function Switch({id, value: initialValue, disabled, onChange, internalState = true}) {
     const [checked, setChecked] = useState(initialValue);
     const change = useCallback(() => {
         onChange?.(!checked);

--- a/renderer/src/ui/settings/components/textbox.jsx
+++ b/renderer/src/ui/settings/components/textbox.jsx
@@ -3,12 +3,13 @@ import React from "@modules/react";
 const {useState, useCallback} = React;
 
 
-export default function Textbox({value: initialValue, maxLength, placeholder, onKeyDown, onChange}) {
+export default function Textbox({value: initialValue, maxLength, placeholder, onKeyDown, onChange, disabled}) {
     const [value, setValue] = useState(initialValue);
     const change = useCallback((e) => {
+        if (disabled) return;
         onChange?.(e.target.value);
         setValue(e.target.value);
-    }, [onChange]);
+    }, [onChange, disabled]);
 
-    return <input onChange={change} onKeyDown={onKeyDown} type="text" className="bd-text-input" placeholder={placeholder} maxLength={maxLength} value={value} />;
+    return <input onChange={change} onKeyDown={onKeyDown} type="text" className="bd-text-input" placeholder={placeholder} maxLength={maxLength} value={value} disabled={disabled} />;
 }

--- a/renderer/src/ui/settings/group.jsx
+++ b/renderer/src/ui/settings/group.jsx
@@ -31,15 +31,16 @@ export default function Group({onChange, id, name, button, shown, onDrawerToggle
 
 
 export function buildSetting(setting) {
-    let component = null;
-    if (setting.type == "dropdown") component = <Dropdown disabled={setting.disabled} id={setting.id} options={setting.options} value={setting.value} onChange={setting.onChange} />;
-    if (setting.type == "number") component = <Number disabled={setting.disabled} id={setting.id} min={setting.min} max={setting.max} step={setting.step} value={setting.value} onChange={setting.onChange} />;
-    if (setting.type == "switch") component = <Switch disabled={setting.disabled} id={setting.id} checked={setting.value} onChange={setting.onChange} />;
-    if (setting.type == "text") component = <Textbox disabled={setting.disabled} id={setting.id} value={setting.value} onChange={setting.onChange} />;
-    if (setting.type == "slider") component = <Slider disabled={setting.disabled} id={setting.id} min={setting.min} max={setting.max} step={setting.step} value={setting.value} onChange={setting.onChange} />;
-    if (setting.type == "radio") component = <Radio disabled={setting.disabled} id={setting.id} name={setting.id} options={setting.options} value={setting.value} onChange={setting.onChange} />;
-    if (setting.type == "keybind") component = <Keybind disabled={setting.disabled} id={setting.id} value={setting.value} max={setting.max} onChange={setting.onChange} />;
-    if (setting.type == "color") component = <Color disabled={setting.disabled} id={setting.id} value={setting.value} defaultValue={setting.defaultValue} colors={setting.colors} onChange={setting.onChange} />;
-    if (!component) return null;
-    return <Item id={setting.id} inline={setting.type !== "radio"} key={setting.id} name={setting.name} note={setting.note}>{component}</Item>;
+    let children = null;
+    if (setting.type == "dropdown") children = <Dropdown disabled={setting.disabled} id={setting.id} options={setting.options} value={setting.value} onChange={setting.onChange} />;
+    if (setting.type == "number") children = <Number disabled={setting.disabled} id={setting.id} min={setting.min} max={setting.max} step={setting.step} value={setting.value} onChange={setting.onChange} />;
+    if (setting.type == "switch") children = <Switch disabled={setting.disabled} id={setting.id} value={setting.value} onChange={setting.onChange} />;
+    if (setting.type == "text") children = <Textbox disabled={setting.disabled} id={setting.id} value={setting.value} onChange={setting.onChange} />;
+    if (setting.type == "slider") children = <Slider disabled={setting.disabled} id={setting.id} min={setting.min} max={setting.max} step={setting.step} value={setting.value} onChange={setting.onChange} />;
+    if (setting.type == "radio") children = <Radio disabled={setting.disabled} id={setting.id} name={setting.id} options={setting.options} value={setting.value} onChange={setting.onChange} />;
+    if (setting.type == "keybind") children = <Keybind disabled={setting.disabled} id={setting.id} value={setting.value} max={setting.max} onChange={setting.onChange} />;
+    if (setting.type == "color") children = <Color disabled={setting.disabled} id={setting.id} value={setting.value} defaultValue={setting.defaultValue} colors={setting.colors} onChange={setting.onChange} />;
+    if (setting.type == "custom") children = setting.children;
+    if (!children) return null;
+    return <Item id={setting.id} inline={setting.hasOwnProperty("inline") ? setting.inline : setting.type !== "radio"} key={setting.id} name={setting.name} note={setting.note}>{children}</Item>;
 }

--- a/renderer/src/ui/settings/group.jsx
+++ b/renderer/src/ui/settings/group.jsx
@@ -10,6 +10,7 @@ import Slider from "./components/slider";
 import Radio from "./components/radio";
 import Keybind from "./components/keybind";
 import Color from "./components/color";
+import Filepicker from "./components/file";
 
 const {useCallback} = React;
 
@@ -35,14 +36,15 @@ export default function Group({onChange, id, name, button, shown, onDrawerToggle
 
 export function buildSetting(setting) {
     let children = null;
-    if (setting.type == "dropdown") children = <Dropdown disabled={setting.disabled} id={setting.id} options={setting.options} value={setting.value} onChange={setting.onChange} />;
-    if (setting.type == "number") children = <Number disabled={setting.disabled} id={setting.id} min={setting.min} max={setting.max} step={setting.step} value={setting.value} onChange={setting.onChange} />;
-    if (setting.type == "switch") children = <Switch disabled={setting.disabled} id={setting.id} value={setting.value} onChange={setting.onChange} />;
-    if (setting.type == "text") children = <Textbox disabled={setting.disabled} id={setting.id} value={setting.value} onChange={setting.onChange} />;
-    if (setting.type == "slider") children = <Slider disabled={setting.disabled} id={setting.id} min={setting.min} max={setting.max} step={setting.step} value={setting.value} onChange={setting.onChange} units={setting.units} markers={setting.markers} />;
-    if (setting.type == "radio") children = <Radio disabled={setting.disabled} id={setting.id} name={setting.id} options={setting.options} value={setting.value} onChange={setting.onChange} />;
-    if (setting.type == "keybind") children = <Keybind disabled={setting.disabled} id={setting.id} value={setting.value} max={setting.max} onChange={setting.onChange} />;
-    if (setting.type == "color") children = <Color disabled={setting.disabled} id={setting.id} value={setting.value} defaultValue={setting.defaultValue} colors={setting.colors} onChange={setting.onChange} />;
+    if (setting.type == "dropdown") children = <Dropdown {...setting} />;
+    if (setting.type == "number") children = <Number {...setting} />;
+    if (setting.type == "switch") children = <Switch {...setting} />;
+    if (setting.type == "text") children = <Textbox {...setting} />;
+    if (setting.type == "file") children = <Filepicker {...setting} />;
+    if (setting.type == "slider") children = <Slider {...setting} />;
+    if (setting.type == "radio") children = <Radio {...setting} />;
+    if (setting.type == "keybind") children = <Keybind {...setting} />;
+    if (setting.type == "color") children = <Color {...setting} />;
     if (setting.type == "custom") children = setting.children;
     if (!children) return null;
     return <Item id={setting.id} inline={setting.hasOwnProperty("inline") ? setting.inline : setting.type !== "radio" && setting.type !== "color" && setting.type !== "slider"} key={setting.id} name={setting.name} note={setting.note}>{children}</Item>;

--- a/renderer/src/ui/settings/group.jsx
+++ b/renderer/src/ui/settings/group.jsx
@@ -47,5 +47,5 @@ export function buildSetting(setting) {
     if (setting.type == "color") children = <Color {...setting} />;
     if (setting.type == "custom") children = setting.children;
     if (!children) return null;
-    return <Item id={setting.id} inline={setting.hasOwnProperty("inline") ? setting.inline : setting.type !== "radio" && setting.type !== "color" && setting.type !== "slider"} key={setting.id} name={setting.name} note={setting.note}>{children}</Item>;
+    return <Item id={setting.id} inline={setting.hasOwnProperty("inline") ? setting.inline : setting.type !== "radio"} key={setting.id} name={setting.name} note={setting.note}>{children}</Item>;
 }

--- a/renderer/src/ui/settings/group.jsx
+++ b/renderer/src/ui/settings/group.jsx
@@ -14,26 +14,32 @@ import Color from "./components/color";
 const {useCallback} = React;
 
 
-export default function Group({onChange, id, name, button, shown, onDrawerToggle, showDivider, collapsible, settings}) {
+export default function Group({onChange, id, name, button, shown, onDrawerToggle, showDivider, collapsible, settings, children}) {
     const change = useCallback((settingId, value) => {
         if (id) onChange?.(id, settingId, value);
         else onChange?.(settingId, value);
     }, [id, onChange]);
 
     return <Drawer collapsible={collapsible} name={name} button={button} shown={shown} onDrawerToggle={onDrawerToggle} showDivider={showDivider}>
-                {settings.filter(s => !s.hidden).map((setting) => {
-                    let component = null;
+                {settings.length && settings.filter(s => !s.hidden).map((setting) => {
                     const callback = value => change(setting.id, value);
-                    if (setting.type == "dropdown") component = <Dropdown disabled={setting.disabled} id={setting.id} options={setting.options} value={setting.value} onChange={callback} />;
-                    if (setting.type == "number") component = <Number disabled={setting.disabled} id={setting.id} min={setting.min} max={setting.max} step={setting.step} value={setting.value} onChange={callback} />;
-                    if (setting.type == "switch") component = <Switch disabled={setting.disabled} id={setting.id} checked={setting.value} onChange={callback} />;
-                    if (setting.type == "text") component = <Textbox disabled={setting.disabled} id={setting.id} value={setting.value} onChange={callback} />;
-                    if (setting.type == "slider") component = <Slider disabled={setting.disabled} id={setting.id} min={setting.min} max={setting.max} step={setting.step} value={setting.value} onChange={callback} />;
-                    if (setting.type == "radio") component = <Radio disabled={setting.disabled} id={setting.id} name={setting.id} options={setting.options} value={setting.value} onChange={callback} />;
-                    if (setting.type == "keybind") component = <Keybind disabled={setting.disabled} id={setting.id} value={setting.value} max={setting.max} onChange={callback} />;
-                    if (setting.type == "color") component = <Color disabled={setting.disabled} id={setting.id} value={setting.value} defaultValue={setting.defaultValue} colors={setting.colors} onChange={callback} />;
-                    if (!component) return null;
-                    return <Item id={setting.id} inline={setting.type !== "radio"} key={setting.id} name={setting.name} note={setting.note}>{component}</Item>;
+                    return buildSetting({...setting, onChange: callback});
                 })}
+                {children}
             </Drawer>;
+}
+
+
+export function buildSetting(setting) {
+    let component = null;
+    if (setting.type == "dropdown") component = <Dropdown disabled={setting.disabled} id={setting.id} options={setting.options} value={setting.value} onChange={setting.onChange} />;
+    if (setting.type == "number") component = <Number disabled={setting.disabled} id={setting.id} min={setting.min} max={setting.max} step={setting.step} value={setting.value} onChange={setting.onChange} />;
+    if (setting.type == "switch") component = <Switch disabled={setting.disabled} id={setting.id} checked={setting.value} onChange={setting.onChange} />;
+    if (setting.type == "text") component = <Textbox disabled={setting.disabled} id={setting.id} value={setting.value} onChange={setting.onChange} />;
+    if (setting.type == "slider") component = <Slider disabled={setting.disabled} id={setting.id} min={setting.min} max={setting.max} step={setting.step} value={setting.value} onChange={setting.onChange} />;
+    if (setting.type == "radio") component = <Radio disabled={setting.disabled} id={setting.id} name={setting.id} options={setting.options} value={setting.value} onChange={setting.onChange} />;
+    if (setting.type == "keybind") component = <Keybind disabled={setting.disabled} id={setting.id} value={setting.value} max={setting.max} onChange={setting.onChange} />;
+    if (setting.type == "color") component = <Color disabled={setting.disabled} id={setting.id} value={setting.value} defaultValue={setting.defaultValue} colors={setting.colors} onChange={setting.onChange} />;
+    if (!component) return null;
+    return <Item id={setting.id} inline={setting.type !== "radio"} key={setting.id} name={setting.name} note={setting.note}>{component}</Item>;
 }

--- a/renderer/src/ui/settings/group.jsx
+++ b/renderer/src/ui/settings/group.jsx
@@ -21,8 +21,11 @@ export default function Group({onChange, id, name, button, shown, onDrawerToggle
     }, [id, onChange]);
 
     return <Drawer collapsible={collapsible} name={name} button={button} shown={shown} onDrawerToggle={onDrawerToggle} showDivider={showDivider}>
-                {settings.length && settings.filter(s => !s.hidden).map((setting) => {
-                    const callback = value => change(setting.id, value);
+                {settings?.length > 0 && settings.filter(s => !s.hidden).map((setting) => {
+                    const callback = value => {
+                        setting?.onChange?.(value);
+                        change(setting.id, value);
+                    };
                     return buildSetting({...setting, onChange: callback});
                 })}
                 {children}
@@ -42,5 +45,5 @@ export function buildSetting(setting) {
     if (setting.type == "color") children = <Color disabled={setting.disabled} id={setting.id} value={setting.value} defaultValue={setting.defaultValue} colors={setting.colors} onChange={setting.onChange} />;
     if (setting.type == "custom") children = setting.children;
     if (!children) return null;
-    return <Item id={setting.id} inline={setting.hasOwnProperty("inline") ? setting.inline : setting.type !== "radio"} key={setting.id} name={setting.name} note={setting.note}>{children}</Item>;
+    return <Item id={setting.id} inline={setting.hasOwnProperty("inline") ? setting.inline : setting.type !== "radio" && setting.type !== "color"} key={setting.id} name={setting.name} note={setting.note}>{children}</Item>;
 }

--- a/renderer/src/ui/settings/group.jsx
+++ b/renderer/src/ui/settings/group.jsx
@@ -39,11 +39,11 @@ export function buildSetting(setting) {
     if (setting.type == "number") children = <Number disabled={setting.disabled} id={setting.id} min={setting.min} max={setting.max} step={setting.step} value={setting.value} onChange={setting.onChange} />;
     if (setting.type == "switch") children = <Switch disabled={setting.disabled} id={setting.id} value={setting.value} onChange={setting.onChange} />;
     if (setting.type == "text") children = <Textbox disabled={setting.disabled} id={setting.id} value={setting.value} onChange={setting.onChange} />;
-    if (setting.type == "slider") children = <Slider disabled={setting.disabled} id={setting.id} min={setting.min} max={setting.max} step={setting.step} value={setting.value} onChange={setting.onChange} />;
+    if (setting.type == "slider") children = <Slider disabled={setting.disabled} id={setting.id} min={setting.min} max={setting.max} step={setting.step} value={setting.value} onChange={setting.onChange} units={setting.units} markers={setting.markers} />;
     if (setting.type == "radio") children = <Radio disabled={setting.disabled} id={setting.id} name={setting.id} options={setting.options} value={setting.value} onChange={setting.onChange} />;
     if (setting.type == "keybind") children = <Keybind disabled={setting.disabled} id={setting.id} value={setting.value} max={setting.max} onChange={setting.onChange} />;
     if (setting.type == "color") children = <Color disabled={setting.disabled} id={setting.id} value={setting.value} defaultValue={setting.defaultValue} colors={setting.colors} onChange={setting.onChange} />;
     if (setting.type == "custom") children = setting.children;
     if (!children) return null;
-    return <Item id={setting.id} inline={setting.hasOwnProperty("inline") ? setting.inline : setting.type !== "radio" && setting.type !== "color"} key={setting.id} name={setting.name} note={setting.note}>{children}</Item>;
+    return <Item id={setting.id} inline={setting.hasOwnProperty("inline") ? setting.inline : setting.type !== "radio" && setting.type !== "color" && setting.type !== "slider"} key={setting.id} name={setting.name} note={setting.note}>{children}</Item>;
 }

--- a/renderer/src/ui/tooltip.js
+++ b/renderer/src/ui/tooltip.js
@@ -81,7 +81,7 @@ export default class Tooltip {
         /** Don't reshow if already active */
         if (this.active) return;
         this.active = true;
-        this.labelElement.textContent = this.label;
+        // this.labelElement.textContent = this.label;
         this.container.append(this.element);
  
         if (this.side == "top") {


### PR DESCRIPTION
This adds notable utilities from ZLib requested from the community:
- getNestedProp as getNestedValue
- semverCompare
- showChangelogModal

It also adds a stop-gap solution for changelog modals by exposing the API above.

Lastly, it exposes all of BD's settings components to be available for plugins and also creates a settings builder similar to ZLib. It also adds a logger.