### PR TITLE
Save Addon State & Allow Command Searching

### DIFF
--- a/renderer/src/modules/addonstore.js
+++ b/renderer/src/modules/addonstore.js
@@ -301,6 +301,8 @@ class Addon {
 
                     if (shouldEnable) {
                         this.manager.state[this.name] = true;
+
+                        this.manager.saveState();
                     }
                     
                     fs.writeFileSync(path.join(this.manager.addonFolder, this.filename), text);


### PR DESCRIPTION
The Addon Store didn't save the addon manager state, so when reloading it would disable downloaded addons

The command manager didn't allow searching, so this fixes it. It also fixes the order in which commands are shown (Except when searching bd commands will be at the top)