### PR TITLE
Make addon error modal accessible

### DIFF
--- a/renderer/src/builtins/developer/reactdevtools.js
+++ b/renderer/src/builtins/developer/reactdevtools.js
@@ -23,7 +23,7 @@ export default new class ReactDevTools extends Builtin {
     initialize() {
         super.initialize();
 
-        let originalType = window.$type;
+        let originalType = window.$type?.__originalFunction || window.$type;
         
         Object.defineProperty(window, "$type", {
             get: () => {

--- a/renderer/src/styles/index.css
+++ b/renderer/src/styles/index.css
@@ -31,6 +31,7 @@
 .bd-divider {
     width: 100%;
     height: 1px;
+    margin: 0;
+    border: none;
     border-top: thin solid var(--background-modifier-accent);
-    margin-bottom: 1em;
 }

--- a/renderer/src/styles/ui/bdsettings.css
+++ b/renderer/src/styles/ui/bdsettings.css
@@ -148,11 +148,8 @@
     margin-bottom: 10px;
 }
 
-.bd-setting-divider {
-    width: 100%;
-    height: 1px;
+.bd-divider.bd-setting-divider {
     margin-top: 20px;
-    border-bottom: thin solid var(--background-modifier-accent);
 }
 
 .bd-settings-container {

--- a/renderer/src/styles/ui/errormodal.css
+++ b/renderer/src/styles/ui/errormodal.css
@@ -1,3 +1,8 @@
+.bd-error-modal-header {
+    flex-direction: column;
+    align-items: flex-start;
+}
+
 .bd-addon-errors {
     margin-top: 16px;
 }
@@ -22,8 +27,14 @@
 .bd-addon-error-header {
     display: flex;
     align-items: center;
+    border-radius: 5px;
     padding: 20px 16px;
     cursor: pointer;
+    outline: none;
+}
+
+.bd-addon-error-header:focus-visible {
+    box-shadow: 0 0 0 4px var(--focus-primary);
 }
 
 .bd-addon-error-icon {
@@ -45,17 +56,18 @@
 }
 
 .bd-addon-error-expander {
+    transform: rotate(-90deg);
     color: var(--interactive-normal);
     transition: transform 0.2s ease;
+}
+
+.bd-addon-error[open] .bd-addon-error-expander {
+    transform: none;
 }
 
 .bd-addon-error-expander,
 .bd-addon-error-icon {
     flex: 0 0 auto;
-}
-
-.bd-addon-error.collapsed .bd-addon-error-expander {
-    transform: rotate(90deg);
 }
 
 .bd-addon-error-header-inner {
@@ -68,6 +80,10 @@
     padding: 0 16px 24px;
 }
 
+.bd-addon-error-body .bd-divider {
+    margin-bottom: 24px;
+}
+
 .bd-addon-error-stack code {
     user-select: text;
     font-size: 0.875rem;
@@ -78,6 +94,26 @@
     scrollbar-color: var(--background-tertiary) var(--background-secondary);
     background: var(--background-secondary);
     border: 1px solid var(--background-tertiary);
+}
+
+.bd-addon-error-stack pre {
+    position: relative;
+}
+
+.bd-addon-error-stack pre [class^="codeActions"] {
+    position: absolute;
+    display: none;
+    right: 4px;
+    top: 8px;
+    color: var(--text-normal);
+}
+
+.bd-addon-error-stack pre:hover [class^="codeActions"] {
+    display: block;
+}
+
+.bd-addon-error-stack pre [class^="codeActions"] > div {
+    cursor: pointer;
 }
 
 .bd-addon-error-details {

--- a/renderer/src/ui/divider.jsx
+++ b/renderer/src/ui/divider.jsx
@@ -1,4 +1,4 @@
 import React from "@modules/react";
 
 
-export default ({className}) => <div className={`bd-divider ${className || ""}`}></div>;
+export default ({className, ...props}) => <hr {...props} className={`bd-divider ${className || ""}`} />;

--- a/renderer/src/ui/modals/addonerrormodal.jsx
+++ b/renderer/src/ui/modals/addonerrormodal.jsx
@@ -37,8 +37,8 @@ function AddonError({err, index}) {
         </div>;
     }
 
-    return <div key={`${err.type}-${index}`} className={joinClassNames("bd-addon-error", (expanded) ? "expanded" : "collapsed")}>
-        <div className="bd-addon-error-header" onClick={toggle} >
+    return <details key={`${err.type}-${index}`} className={joinClassNames("bd-addon-error", (expanded) ? "expanded" : "collapsed")}>
+        <summary className="bd-addon-error-header" onClick={toggle} >
             <div className="bd-addon-error-icon">
                 {err.type == "plugin" ? <Extension /> : <ThemeIcon />}
             </div>
@@ -54,9 +54,9 @@ function AddonError({err, index}) {
             <svg className="bd-addon-error-expander" width="24" height="24" viewBox="0 0 24 24">
                 <path fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" d="M7 10L12 15 17 10" aria-hidden="true"></path>
             </svg>
-        </div>
+        </summary>
         {renderErrorBody(err)}
-    </div>;
+    </details>;
 }
 
 

--- a/renderer/src/ui/settings/components/item.jsx
+++ b/renderer/src/ui/settings/components/item.jsx
@@ -1,4 +1,5 @@
 import React from "@modules/react";
+import Divider from "@ui/divider";
 
 
 export default function SettingItem({id, name, note, inline, children}) {
@@ -9,6 +10,6 @@ export default function SettingItem({id, name, note, inline, children}) {
                 </div>
                 <div className={"bd-setting-note"}>{note}</div>
                 {!inline && children}
-                <div className={"bd-setting-divider"} />
+                <Divider className="bd-setting-divider" />
             </div>;
 }


### PR DESCRIPTION
This is a port (with some adjustments*) of #1326 so this closes #1326 once merged.

*adjustments include
- consistency with settings dividers
- fix for the floating copy code button
- small unrelated bugfix in rdt
- adjustment of classes and components used

![image](https://github.com/user-attachments/assets/5127ed2f-9c0a-46d8-a9a1-1660ec265b62)
