### PR TITLE
Add some default built-in commands

### DIFF
--- a/assets/locales/en-us.json
+++ b/assets/locales/en-us.json
@@ -29,6 +29,10 @@
                 "themeAttributes": {
                     "name": "Theme Attributes",
                     "note": "Adds attributes to various elements to assist in theming."
+                },
+                "defaultCommands": {
+                    "name": "Default Commands",
+                    "note": "Shows BetterDiscord commands in your slash command menu."
                 }
             },
             "store": {

--- a/injector/src/modules/ipc.js
+++ b/injector/src/modules/ipc.js
@@ -38,9 +38,9 @@ const openPath = (event, path) => {
     else shell.openPath(path);
 };
 
-const relaunch = () => {
+const relaunch = (event, args = []) => {
+    app.relaunch({args: process.argv.slice(1).concat(Array.isArray(args) ? args : [args])});
     app.quit();
-    app.relaunch();
 };
 
 const runScript = async (event, script) => {

--- a/renderer/jsconfig.json
+++ b/renderer/jsconfig.json
@@ -1,19 +1,18 @@
 {
-    "compilerOptions": {
-      "target": "es2020",
-      "allowSyntheticDefaultImports": false,
-      "baseUrl": "./",
-      "paths": {
-        "@assets/*": ["../assets/*"],
-        "@common/*": ["../common/*"],
-        "@builtins/*": ["./src/builtins/*"],
-        "@data/*": ["./src/data/*"],
-        "@modules/*": ["./src/modules/*"],
-        "@polyfill/*": ["./src/polyfill/*"],
-        "@structs/*": ["./src/structs/*"],
-        "@styles/*": ["./src/styles/*"],
-        "@ui/*": ["./src/ui/*"]
-      }
-    },
-    "include": ["node_modules"]
-  }
+  "compilerOptions": {
+    "target": "es2020",
+    "allowSyntheticDefaultImports": false,
+    "baseUrl": "./",
+    "paths": {
+      "@assets/*": ["../assets/*"],
+      "@common/*": ["../common/*"],
+      "@builtins/*": ["./src/builtins/*"],
+      "@data/*": ["./src/data/*"],
+      "@modules/*": ["./src/modules/*"],
+      "@polyfill/*": ["./src/polyfill/*"],
+      "@structs/*": ["./src/structs/*"],
+      "@styles/*": ["./src/styles/*"],
+      "@ui/*": ["./src/ui/*"]
+    }
+  },
+}

--- a/renderer/src/builtins/builtins.js
+++ b/renderer/src/builtins/builtins.js
@@ -6,6 +6,7 @@ export {default as VoiceDisconnect} from "./general/voicedisconnect";
 export {default as MediaKeys} from "./general/mediakeys";
 export {default as BDContextMenu} from "./general/contextmenu";
 export {default as ThemeAttributes} from "./general/themeattributes";
+export {default as DefaultCommands} from "./commands/defaultcommands";
 
 export {default as AddonStore} from "./store/addonstore";
 

--- a/renderer/src/builtins/commands/addons.js
+++ b/renderer/src/builtins/commands/addons.js
@@ -10,7 +10,7 @@ export default (type) => {
     return {
         id: `${type}s`,
         name: `${type}s`,
-        description: `Toggle or view your ${type}s`,
+        description: `Enable, disable, or view your ${type}s`,
         options: [
             {
                 type: OptionTypes.STRING,
@@ -18,7 +18,6 @@ export default (type) => {
                 description: "Action to take",
                 required: true,
                 choices: [
-                    {name: "Toggle", value: "toggle"},
                     {name: "Enable", value: "enable"},
                     {name: "Disable", value: "disable"},
                     {name: "Show Info", value: "info"},
@@ -43,11 +42,6 @@ export default (type) => {
             const addonId = data.find(o => o.name === "name").value;
             const addon = manager.getAddon(addonId);
             const isEnabled = manager.isEnabled(addon.id);
-    
-            if (action === "toggle") {
-                manager.toggleAddon(addon.id);
-                return {content: `${addon.name} has been toggled!`};
-            }
 
             if (action === "enable") {
                 if (isEnabled) return {content: `${addon.name} is already enabled!`};

--- a/renderer/src/builtins/commands/addons.js
+++ b/renderer/src/builtins/commands/addons.js
@@ -1,0 +1,96 @@
+import {OptionTypes} from "@modules/commandmanager";
+import Plugins from "@modules/pluginmanager";
+import Themes from "@modules/thememanager";
+import WebpackModules from "@modules/webpackmodules";
+
+
+const MessageUtils = WebpackModules.getByProps("sendMessage");
+
+export default (type) => {
+    const manager = type === "plugin" ? Plugins : Themes;
+
+    return {
+        id: `${type}s`,
+        name: `${type}s`,
+        description: `Toggle or view your ${type}s`,
+        options: [
+            {
+                type: OptionTypes.STRING,
+                name: "action",
+                description: "Action to take",
+                required: true,
+                choices: [
+                    {name: "Toggle", value: "toggle"},
+                    {name: "Enable", value: "enable"},
+                    {name: "Disable", value: "disable"},
+                    {name: "Show Info", value: "info"},
+                    {name: "Share In Chat", value: "share"}
+                ]
+            },
+            {
+                type: OptionTypes.STRING,
+                name: "name",
+                description: `Name of the ${type}`,
+                required: true,
+                get choices() {
+                    return manager.addonList.map(p => ({
+                        name: p.name,
+                        value: p.id
+                    }));
+                }
+            }
+        ],
+        execute: async (data, {channel}) => {
+            const action = data.find(o => o.name === "action").value;
+            const addonId = data.find(o => o.name === "name").value;
+            const addon = manager.getAddon(addonId);
+            const isEnabled = manager.isEnabled(addon.id);
+    
+            if (action === "toggle") {
+                manager.toggleAddon(addon.id);
+                return {content: `${addon.name} has been toggled!`};
+            }
+
+            if (action === "enable") {
+                if (isEnabled) return {content: `${addon.name} is already enabled!`};
+
+                manager.enableAddon(addon.id);
+                return {content: `${addon.name} has been enabled!`};
+            }
+
+            if (action === "disable") {
+                if (!isEnabled) return {content: `${addon.name} is already disabled!`};
+
+                manager.disableAddon(addon.id);
+                return {content: `${addon.name} has been disabled!`};
+            }
+
+            if (action === "info") {
+                const fields = [
+                    {name: "Author", value: addon.authorLink ? `[${addon.author}](${addon.authorLink})` : addon.author, inline: true},
+                    {name: "Version", value: `v${addon.version}`, inline: true},
+                    {name: "Enabled", value: isEnabled ? "✅" : "❌", inline: true},
+                ];
+
+                if (addon.source) fields.push({name: "Source", value: `[GitHub](${addon.source})`, inline: true});
+                if (addon.invite) fields.push({name: "Support", value: `[Discord](https://discord.gg/${addon.invite})`, inline: true});
+                if (addon.donate) fields.push({name: "Donate", value: `[Link](${addon.donate})`, inline: true});
+                
+                return {embeds: [{
+                    color: 4096741,
+                    title: addon.name,
+                    description: addon.description,
+                    fields: fields,
+                    footer: {
+                        text: "Last updated"
+                    },
+                    timestamp: (new Date(addon.modified)).toISOString()
+                }]};
+            }
+
+            if (action === "share") {
+                MessageUtils.sendMessage(channel.id, {content: `<betterdiscord://store/${addon.name}>`});
+            }
+        }
+    };
+};

--- a/renderer/src/builtins/commands/addons.js
+++ b/renderer/src/builtins/commands/addons.js
@@ -1,10 +1,8 @@
 import {OptionTypes} from "@modules/commandmanager";
+import DiscordModules from "@modules/discordmodules";
 import Plugins from "@modules/pluginmanager";
 import Themes from "@modules/thememanager";
-import WebpackModules from "@modules/webpackmodules";
 
-
-const MessageUtils = WebpackModules.getByProps("sendMessage");
 
 export default (type) => {
     const manager = type === "plugin" ? Plugins : Themes;
@@ -89,7 +87,7 @@ export default (type) => {
             }
 
             if (action === "share") {
-                MessageUtils.sendMessage(channel.id, {content: `<betterdiscord://store/${addon.name}>`});
+                DiscordModules.MessageUtils.sendMessage(channel.id, {content: `<betterdiscord://store/${addon.name}>`});
             }
         }
     };

--- a/renderer/src/builtins/commands/customcss.js
+++ b/renderer/src/builtins/commands/customcss.js
@@ -1,20 +1,10 @@
 import CustomCSS from "@builtins/customcss";
 import {OptionTypes} from "@modules/commandmanager";
+import DiscordModules from "@modules/discordmodules";
 import Settings from "@modules/settingsmanager";
-import WebpackModules from "@modules/webpackmodules";
 
 
-const MessageUtils = WebpackModules.getByProps("sendMessage");
-
-const enterEvent = new KeyboardEvent("keydown", {
-    key: "Enter",
-    code: "Enter",
-    keyCode: 13,
-    which: 13,
-    bubbles: true, // Make sure the event bubbles
-    cancelable: false,
-});
-
+// TODO: consider moving this into the CustomCSS builtin rather than importing it
 export default {
     id: "customcss",
     name: "customcss",
@@ -64,15 +54,12 @@ export default {
 
         if (action === "share") {
             const css = CustomCSS.savedCss;
-            const codeblocked = `\`\`\`css\n${css}\n\`\`\``;
-            if (codeblocked.length > 2000) {
-                window?.DiscordNative?.clipboard?.copy?.(css);
-                window?.DiscordNative?.clipboard?.paste?.();
-                const textArea = document.querySelector(`[class*="slateTextArea_"]`);
-                if (textArea) return setTimeout(() => textArea.dispatchEvent(enterEvent), 75);
-                return {content: "The CustomCSS was too big to send automatically! It has been attached as a text file instead."};
-            }
-            MessageUtils.sendMessage(channel.id, {content: `\`\`\`css\n${css}\n\`\`\``});
+            const file = new File([css], "custom.css", {type: "text/css"});
+
+            // Use a timeout because this doesn't work if you do it within the context of a slash command
+            if (DiscordModules.promptToUpload) return setTimeout(() => DiscordModules.promptToUpload?.([file], channel, 0), 1);
+
+           return {content: "Unable to attach your Custom CSS as a file. Please report this issue to BetterDiscord's [GitHub](https://github.com/BetterDiscord/BetterDiscord) if no one else has already done so!"};
         }
     }
 };

--- a/renderer/src/builtins/commands/customcss.js
+++ b/renderer/src/builtins/commands/customcss.js
@@ -8,7 +8,7 @@ import Settings from "@modules/settingsmanager";
 export default {
     id: "customcss",
     name: "customcss",
-    description: `Toggle, open, or share your CustomCSS`,
+    description: `Enable, disable, open, or share your CustomCSS`,
     options: [
         {
             type: OptionTypes.STRING,
@@ -16,7 +16,6 @@ export default {
             description: "Action to take",
             required: true,
             choices: [
-                {name: "Toggle", value: "toggle"},
                 {name: "Enable", value: "enable"},
                 {name: "Disable", value: "disable"},
                 {name: "Open Editor", value: "open"},
@@ -27,11 +26,6 @@ export default {
     execute: async (data, {channel}) => {
         const action = data.find(o => o.name === "action").value;
         const isEnabled = Settings.get("customcss", "customcss");
-
-        if (action === "toggle") {
-            Settings.set("customcss", "customcss", !isEnabled);
-            return {content: `CustomCSS has been toggled!`};
-        }
 
         if (action === "enable") {
             if (isEnabled) return {content: `CustomCSS is already enabled!`};

--- a/renderer/src/builtins/commands/customcss.js
+++ b/renderer/src/builtins/commands/customcss.js
@@ -18,7 +18,7 @@ const enterEvent = new KeyboardEvent("keydown", {
 export default {
     id: "customcss",
     name: "customcss",
-    description: `Toggle or view your CustomCSS`,
+    description: `Toggle, open, or share your CustomCSS`,
     options: [
         {
             type: OptionTypes.STRING,
@@ -36,24 +36,24 @@ export default {
     ],
     execute: async (data, {channel}) => {
         const action = data.find(o => o.name === "action").value;
-        const isEnabled = Settings.get("settings", "customcss", "customcss");
+        const isEnabled = Settings.get("customcss", "customcss");
 
         if (action === "toggle") {
-            Settings.set("settings", "customcss", "customcss", !isEnabled);
+            Settings.set("customcss", "customcss", !isEnabled);
             return {content: `CustomCSS has been toggled!`};
         }
 
         if (action === "enable") {
             if (isEnabled) return {content: `CustomCSS is already enabled!`};
 
-            Settings.set("settings", "customcss", "customcss", true);
+            Settings.set("customcss", "customcss", true);
             return {content: `CustomCSS has been enabled!`};
         }
 
         if (action === "disable") {
             if (!isEnabled) return {content: `CustomCSS is already disabled!`};
 
-            Settings.set("settings", "customcss", "customcss", false);
+            Settings.set("customcss", "customcss", false);
             return {content: `CustomCSS has been disabled!`};
         }
 

--- a/renderer/src/builtins/commands/customcss.js
+++ b/renderer/src/builtins/commands/customcss.js
@@ -6,6 +6,15 @@ import WebpackModules from "@modules/webpackmodules";
 
 const MessageUtils = WebpackModules.getByProps("sendMessage");
 
+const enterEvent = new KeyboardEvent("keydown", {
+    key: "Enter",
+    code: "Enter",
+    keyCode: 13,
+    which: 13,
+    bubbles: true, // Make sure the event bubbles
+    cancelable: false,
+});
+
 export default {
     id: "customcss",
     name: "customcss",
@@ -57,8 +66,11 @@ export default {
             const css = CustomCSS.savedCss;
             const codeblocked = `\`\`\`css\n${css}\n\`\`\``;
             if (codeblocked.length > 2000) {
-                window?.DiscordNative?.clipboard?.copy(css);
-                return {content: "Your CustomCSS was too big to send automatically! Instead, the css has been copied to your clipboard. Paste (ctrl+v) the css in the textbox below and Discord will automatically attach it as a text file."};
+                window?.DiscordNative?.clipboard?.copy?.(css);
+                window?.DiscordNative?.clipboard?.paste?.();
+                const textArea = document.querySelector(`[class*="slateTextArea_"]`);
+                if (textArea) return setTimeout(() => textArea.dispatchEvent(enterEvent), 75);
+                return {content: "The CustomCSS was too big to send automatically! It has been attached as a text file instead."};
             }
             MessageUtils.sendMessage(channel.id, {content: `\`\`\`css\n${css}\n\`\`\``});
         }

--- a/renderer/src/builtins/commands/customcss.js
+++ b/renderer/src/builtins/commands/customcss.js
@@ -1,0 +1,66 @@
+import CustomCSS from "@builtins/customcss";
+import {OptionTypes} from "@modules/commandmanager";
+import Settings from "@modules/settingsmanager";
+import WebpackModules from "@modules/webpackmodules";
+
+
+const MessageUtils = WebpackModules.getByProps("sendMessage");
+
+export default {
+    id: "customcss",
+    name: "customcss",
+    description: `Toggle or view your CustomCSS`,
+    options: [
+        {
+            type: OptionTypes.STRING,
+            name: "action",
+            description: "Action to take",
+            required: true,
+            choices: [
+                {name: "Toggle", value: "toggle"},
+                {name: "Enable", value: "enable"},
+                {name: "Disable", value: "disable"},
+                {name: "Open Editor", value: "open"},
+                {name: "Share In Chat", value: "share"}
+            ]
+        }
+    ],
+    execute: async (data, {channel}) => {
+        const action = data.find(o => o.name === "action").value;
+        const isEnabled = Settings.get("settings", "customcss", "customcss");
+
+        if (action === "toggle") {
+            Settings.set("settings", "customcss", "customcss", !isEnabled);
+            return {content: `CustomCSS has been toggled!`};
+        }
+
+        if (action === "enable") {
+            if (isEnabled) return {content: `CustomCSS is already enabled!`};
+
+            Settings.set("settings", "customcss", "customcss", true);
+            return {content: `CustomCSS has been enabled!`};
+        }
+
+        if (action === "disable") {
+            if (!isEnabled) return {content: `CustomCSS is already disabled!`};
+
+            Settings.set("settings", "customcss", "customcss", false);
+            return {content: `CustomCSS has been disabled!`};
+        }
+
+        if (action === "open") {
+            if (!isEnabled) return {content: `You cannot open CustomCSS if it's disabled!`};
+            CustomCSS.open();
+        }
+
+        if (action === "share") {
+            const css = CustomCSS.savedCss;
+            const codeblocked = `\`\`\`css\n${css}\n\`\`\``;
+            if (codeblocked.length > 2000) {
+                window?.DiscordNative?.clipboard?.copy(css);
+                return {content: "Your CustomCSS was too big to send automatically! Instead, the css has been copied to your clipboard. Paste (ctrl+v) the css in the textbox below and Discord will automatically attach it as a text file."};
+            }
+            MessageUtils.sendMessage(channel.id, {content: `\`\`\`css\n${css}\n\`\`\``});
+        }
+    }
+};

--- a/renderer/src/builtins/commands/debug.js
+++ b/renderer/src/builtins/commands/debug.js
@@ -76,7 +76,7 @@ export default {
         if (!shouldSend) return {content: info};
         if (info.length > 2000) {
             nativeModule.copy(info);
-            return {content: "The debug info was too long to send automatically! Instead, has been copied to your clipboard. Paste (ctrl+v) the info in the textbox below and Discord will automatically attach it as a text file."};
+            return {content: "The debug info was too long to send automatically! Instead, the info has been copied to your clipboard. Paste (ctrl+v) the info in the textbox below and Discord will automatically attach it as a text file."};
         }
         MessageUtils.sendMessage(channel.id, {content: info});
     }

--- a/renderer/src/builtins/commands/debug.js
+++ b/renderer/src/builtins/commands/debug.js
@@ -1,0 +1,83 @@
+import Config from "@data/config";
+import {OptionTypes} from "@modules/commandmanager";
+import PluginManager from "@modules/pluginmanager";
+import ThemeManager from "@modules/thememanager";
+import WebpackModules from "@modules/webpackmodules";
+
+
+const MessageUtils = WebpackModules.getByProps("sendMessage");
+
+let osModule;
+let nativeModule;
+function getDiscordInfo() {
+    if (!osModule) osModule = WebpackModules.getByProps("os", "layout");
+    if (!nativeModule) nativeModule = WebpackModules.getByProps("setBadge");
+
+    const releaseChannel = nativeModule.releaseChannel;
+    const hostVersion = nativeModule.version.join(".");
+    const hostBuildNumber = nativeModule.buildNumber;
+    const osArch = nativeModule.architecture;
+    const osVersion = window?.DiscordNative?.os?.release;
+    let osName = osModule.os.toString();
+
+    // eslint-disable-next-line no-unused-vars
+    const [macVer, _, winVer] = nativeModule.parsedOSRelease;
+
+    if (osName.includes("Windows 10") && winVer >= 22e3) osName = osName.replace("Windows 10", "Windows 11");
+    if (osName.includes("OS X 10.15.7") && macVer >= 20) osName = "macOS ".concat(macVer - 9);
+
+    const lines = [
+        releaseChannel,
+        `Host ${hostVersion} ${osArch} (${hostBuildNumber})`,
+        `${osName} (${osVersion})`
+    ];
+
+    return lines.join("\n");
+}
+
+/**
+ * 
+ * @param {string} type plugin or theme
+ * @returns {{total: number, enabled: number}}
+ */
+function getAddonCount(type) {
+    if (type === "theme") return {total: ThemeManager.addonList.length, enabled: ThemeManager.addonList.filter(p => ThemeManager.isEnabled(p.id)).length};
+    if (type === "plugin") return {total: PluginManager.addonList.length, enabled: PluginManager.addonList.filter(p => PluginManager.isEnabled(p.id)).length};
+    return {total: 0, enabled: 0};
+}
+
+function getDebugInfo() {
+    const pluginCount = getAddonCount("plugin");
+    const themeCount = getAddonCount("theme");
+    const lines = ["```md", `## Discord Info\n${getDiscordInfo()}\n`];
+    lines.push(`## BetterDiscord`);
+    for (let l = 0; l < 500; l++) lines.push(`stable ${Config.version}\n`);
+    lines.push(`### ${pluginCount.total} Plugins (${pluginCount.enabled} Enabled):\n${PluginManager.addonList.map(a => `- ${a.name}${PluginManager.isEnabled(a.id) ? " (Enabled)" : ""}`).join("\n")}\n`);
+    lines.push(`### ${themeCount.total} Themes (${themeCount.enabled} Enabled):\n${ThemeManager.addonList.map(a => `- ${a.name}${ThemeManager.isEnabled(a.id) ? " (Enabled)" : ""}`).join("\n")}`);
+    lines.push("```");
+    return lines.join("\n");
+}
+
+export default {
+    id: "debug",
+    name: "debug",
+    description: "Gets debug information useful for support",
+    options: [
+        {
+            type: OptionTypes.BOOLEAN,
+            name: "send",
+            description: "Should the info be sent in public chat?",
+            required: true
+        },
+    ],
+    execute: async (data, {channel}) => {
+        const shouldSend = data.find(o => o.name === "send").value;
+        const info = getDebugInfo();
+        if (!shouldSend) return {content: info};
+        if (info.length > 2000) {
+            nativeModule.copy(info);
+            return {content: "The debug info was too long to send automatically! Instead, has been copied to your clipboard. Paste (ctrl+v) the info in the textbox below and Discord will automatically attach it as a text file."};
+        }
+        MessageUtils.sendMessage(channel.id, {content: info});
+    }
+};

--- a/renderer/src/builtins/commands/defaultcommands.js
+++ b/renderer/src/builtins/commands/defaultcommands.js
@@ -3,6 +3,7 @@ import buildAddonCommand from "./addons";
 import DebugCommand from "./debug";
 import RestartCommand from "./restart";
 import SupportCommand from "./support";
+import CustomCSSCommand from "./customcss";
 
 
 export default new class DefaultCommands extends Builtin {
@@ -16,7 +17,8 @@ export default new class DefaultCommands extends Builtin {
             buildAddonCommand("theme"),
             DebugCommand,
             RestartCommand,
-            SupportCommand
+            SupportCommand,
+            CustomCSSCommand
         );
     }
 

--- a/renderer/src/builtins/commands/defaultcommands.js
+++ b/renderer/src/builtins/commands/defaultcommands.js
@@ -1,6 +1,7 @@
 import Builtin from "@structs/builtin";
 import buildAddonCommand from "./addons";
 import DebugCommand from "./debug";
+import RestartCommand from "./restart";
 
 
 export default new class DefaultCommands extends Builtin {
@@ -12,7 +13,8 @@ export default new class DefaultCommands extends Builtin {
         this.addCommands(
             buildAddonCommand("plugin"),
             buildAddonCommand("theme"),
-            DebugCommand
+            DebugCommand,
+            RestartCommand
         );
     }
 

--- a/renderer/src/builtins/commands/defaultcommands.js
+++ b/renderer/src/builtins/commands/defaultcommands.js
@@ -2,6 +2,7 @@ import Builtin from "@structs/builtin";
 import buildAddonCommand from "./addons";
 import DebugCommand from "./debug";
 import RestartCommand from "./restart";
+import SupportCommand from "./support";
 
 
 export default new class DefaultCommands extends Builtin {
@@ -14,7 +15,8 @@ export default new class DefaultCommands extends Builtin {
             buildAddonCommand("plugin"),
             buildAddonCommand("theme"),
             DebugCommand,
-            RestartCommand
+            RestartCommand,
+            SupportCommand
         );
     }
 

--- a/renderer/src/builtins/commands/defaultcommands.js
+++ b/renderer/src/builtins/commands/defaultcommands.js
@@ -1,5 +1,6 @@
 import Builtin from "@structs/builtin";
 import buildAddonCommand from "./addons";
+import DebugCommand from "./debug";
 
 
 export default new class DefaultCommands extends Builtin {
@@ -10,7 +11,8 @@ export default new class DefaultCommands extends Builtin {
     enabled() {
         this.addCommands(
             buildAddonCommand("plugin"),
-            buildAddonCommand("theme")
+            buildAddonCommand("theme"),
+            DebugCommand
         );
     }
 

--- a/renderer/src/builtins/commands/defaultcommands.js
+++ b/renderer/src/builtins/commands/defaultcommands.js
@@ -1,0 +1,20 @@
+import Builtin from "@structs/builtin";
+import buildAddonCommand from "./addons";
+
+
+export default new class DefaultCommands extends Builtin {
+    get name() {return "DefaultCommands";}
+    get category() {return "general";}
+    get id() {return "defaultCommands";}
+
+    enabled() {
+        this.addCommands(
+            buildAddonCommand("plugin"),
+            buildAddonCommand("theme")
+        );
+    }
+
+    disabled() {
+        this.removeCommands();
+    }
+};

--- a/renderer/src/builtins/commands/defaultcommands.js
+++ b/renderer/src/builtins/commands/defaultcommands.js
@@ -4,6 +4,7 @@ import DebugCommand from "./debug";
 import RestartCommand from "./restart";
 import SupportCommand from "./support";
 import CustomCSSCommand from "./customcss";
+import SettingsCommand from "./settings";
 
 
 export default new class DefaultCommands extends Builtin {
@@ -18,7 +19,8 @@ export default new class DefaultCommands extends Builtin {
             DebugCommand,
             RestartCommand,
             SupportCommand,
-            CustomCSSCommand
+            CustomCSSCommand,
+            SettingsCommand
         );
     }
 

--- a/renderer/src/builtins/commands/restart.js
+++ b/renderer/src/builtins/commands/restart.js
@@ -1,0 +1,21 @@
+import {OptionTypes} from "@modules/commandmanager";
+import ipc from "@modules/ipc";
+
+
+export default {
+    id: "restart",
+    name: "restart",
+    description: "Restart Discord with or without BetterDiscord",
+    options: [
+        {
+            type: OptionTypes.BOOLEAN,
+            name: "vanilla",
+            description: "Should Discord be relaunched without BetterDiscord?",
+            required: true,
+        },
+    ],
+    execute: async (data) => {
+        const vanilla = data.find(o => o.name === "vanilla").value;
+        ipc.relaunch(vanilla ? ["--vanilla"] : []);
+    }
+};

--- a/renderer/src/builtins/commands/settings.js
+++ b/renderer/src/builtins/commands/settings.js
@@ -1,0 +1,61 @@
+import {OptionTypes} from "@modules/commandmanager";
+import Settings from "@modules/settingsmanager";
+
+
+export default {
+    id: "settings",
+    name: "settings",
+    description: `Toggle or open your settings`,
+    options: [
+        {
+            type: OptionTypes.STRING,
+            name: "action",
+            description: "Action to take",
+            required: true,
+            choices: [
+                {name: "Toggle", value: "toggle"},
+                {name: "Enable", value: "enable"},
+                {name: "Disable", value: "disable"}
+            ]
+        },
+        {
+            type: OptionTypes.STRING,
+            name: "setting",
+            description: `Which setting to modify?`,
+            required: true,
+            get choices() {
+                return Settings.collections[0].settings.map(c => {
+                    const switches = c.settings.filter(s => s.type === "switch");
+                    return switches.map(s => ({name: s.name, value: `${c.id}-${s.id}-${s.name}`}));
+                }).flat();
+            }
+        }
+    ],
+    execute: async (data) => {
+        const action = data.find(o => o.name === "action").value;
+        const settingData = data.find(o => o.name === "setting").value.split("-");
+        const catId = settingData[0];
+        const id = settingData[1];
+        const name = settingData[2];
+        const isEnabled = Settings.get(catId, id);
+
+        if (action === "toggle") {
+            Settings.set(catId, id, !isEnabled);
+            return {content: `${name} has been toggled!`};
+        }
+
+        if (action === "enable") {
+            if (isEnabled) return {content: `${name} is already enabled!`};
+
+            Settings.set(catId, id, true);
+            return {content: `${name} has been enabled!`};
+        }
+
+        if (action === "disable") {
+            if (!isEnabled) return {content: `${name} is already disabled!`};
+
+            Settings.set(catId, id, false);
+            return {content: `${name} has been disabled!`};
+        }
+    }
+};

--- a/renderer/src/builtins/commands/settings.js
+++ b/renderer/src/builtins/commands/settings.js
@@ -5,7 +5,7 @@ import Settings from "@modules/settingsmanager";
 export default {
     id: "settings",
     name: "settings",
-    description: `Toggle or open your settings`,
+    description: `Enable or disable your settings`,
     options: [
         {
             type: OptionTypes.STRING,
@@ -13,7 +13,6 @@ export default {
             description: "Action to take",
             required: true,
             choices: [
-                {name: "Toggle", value: "toggle"},
                 {name: "Enable", value: "enable"},
                 {name: "Disable", value: "disable"}
             ]
@@ -38,11 +37,6 @@ export default {
         const id = settingData[1];
         const name = settingData[2];
         const isEnabled = Settings.get(catId, id);
-
-        if (action === "toggle") {
-            Settings.set(catId, id, !isEnabled);
-            return {content: `${name} has been toggled!`};
-        }
 
         if (action === "enable") {
             if (isEnabled) return {content: `${name} is already enabled!`};

--- a/renderer/src/builtins/commands/support.js
+++ b/renderer/src/builtins/commands/support.js
@@ -1,0 +1,12 @@
+import Utilities from "@modules/utilities";
+
+
+export default {
+    id: "support",
+    name: "support",
+    description: "Get help and support for BetterDiscord",
+    options: [],
+    execute: async () => {
+        Utilities.showGuildJoinModal("rC8b2H6SCt");
+    }
+};

--- a/renderer/src/builtins/customcss.js
+++ b/renderer/src/builtins/customcss.js
@@ -121,6 +121,13 @@ export default new class CustomCSS extends Builtin {
         DataStore.saveCustomCSS(this.savedCss);
     }
 
+    open() {
+        if (this.isDetached) return;
+        if (this.nativeOpen) return this.openNative();
+        else if (this.startDetached) return this.openDetached(this.savedCss);
+        return UserSettings?.open?.(this.id);
+    }
+
     openNative() {
         electron.shell.openExternal(`file://${DataStore.customCSS}`);
     }

--- a/renderer/src/builtins/developer/recovery.js
+++ b/renderer/src/builtins/developer/recovery.js
@@ -8,6 +8,7 @@ import Builtin from "@structs/builtin";
 import Settings from "@modules/settingsmanager";
 import pluginmanager from "@modules/pluginmanager";
 import Toasts from "@ui/toasts";
+import Utilities from "@modules/utilities";
 
 const Dispatcher = DiscordModules.Dispatcher;
 
@@ -89,7 +90,7 @@ const ErrorDetails = ({componentStack, pluginInfo, stack, instance}) => {
         if (pluginInfo?.invite) {
             attemptRecovery();
             instance.setState({info: null, error: null});
-            DiscordModules.InviteActions.acceptInviteAndTransitionToInviteChannel({inviteKey: pluginInfo?.invite});
+            if (pluginInfo.invite) Utilities.showGuildJoinModal(pluginInfo.invite);
         }
     };
 

--- a/renderer/src/data/settings.js
+++ b/renderer/src/data/settings.js
@@ -8,7 +8,8 @@ export default [
             {type: "switch", id: "showToasts", value: true},
             {type: "switch", id: "mediaKeys", value: false},
             {type: "switch", id: "bdContextMenu", value: true},
-            {type: "switch", id: "themeAttributes", value: true}
+            {type: "switch", id: "themeAttributes", value: true},
+            {type: "switch", id: "defaultCommands", value: true},
         ]
     },
     {

--- a/renderer/src/modules/api/commands.js
+++ b/renderer/src/modules/api/commands.js
@@ -1,4 +1,4 @@
-import CommandManager, {CommandTypes, InputTypes, MessageEmbedTypes, OptionTypes} from "@modules/commandsmanager";
+import CommandManager, {CommandTypes, InputTypes, MessageEmbedTypes, OptionTypes} from "@modules/commandmanager";
 
 /**
  * `CommandAPI` is a utility class for managing commands. Instance is accessible through the BdApi.

--- a/renderer/src/modules/api/commands.js
+++ b/renderer/src/modules/api/commands.js
@@ -59,6 +59,7 @@ class CommandAPI {
      * @private
      */
     #validateRegistration(caller, command) {
+        if (caller === "BetterDiscord") throw new Error("Plugins cannot register commands as BetterDiscord");
         return typeof caller === "string" && typeof command === "object" && command?.id && command?.name && command?.execute;
     }
 

--- a/renderer/src/modules/commandmanager.js
+++ b/renderer/src/modules/commandmanager.js
@@ -102,7 +102,7 @@ class CommandManager {
     static #patchSidebarModule() {
         const SidebarModule = Webpack.getByStrings(".BUILT_IN?", "categoryListRef:", {defaultExport: false});
 
-        Patcher.after("CommandsManager", SidebarModule, "Z", (that, [props], res) => {
+        Patcher.after("CommandManager", SidebarModule, "Z", (that, [props], res) => {
             if (!this.#sections.size) return;            
 
             const child = res.props.children;
@@ -136,7 +136,7 @@ class CommandManager {
     static #patchIndexStore() {        
         const [mod, key] = Webpack.getWithKey(Filters.byStrings(".getScoreWithoutLoadingLatest"));
 
-        Patcher.after("CommandsManager", mod, key, (that, args, res) => {
+        Patcher.after("CommandManager", mod, key, (that, args, res) => {
             if (!args[2].commandTypes.includes(CommandTypes.CHAT_INPUT)) return res;
 
             for (const sectionedCommand of res.sectionedCommands) {
@@ -158,7 +158,6 @@ class CommandManager {
                     res.commands.push(...commands);
                 }
             }
-
             return res;
         });
     }
@@ -196,7 +195,7 @@ class CommandManager {
             target: Webpack.getModule((e, m) => Webpack.modules[m.id].toString().includes("hasSpaceTerminator:"))
         });
 
-        Patcher.after("CommandsManager", mod, key, (that, [{id}], res) => {
+        Patcher.after("CommandManager", mod, key, (that, [{id}], res) => {
             const getIconUrl = () => {
                 const metadataIcon = pluginmanager.getAddon(id)?.icon ?? null;
                 const sectionIcon = this.#sections.has(id) ? this.#sections.get(id)?.icon : null;
@@ -338,11 +337,11 @@ class CommandManager {
 
     static #patchExecuteFunction(originalExecute) {
         return (data, {channel, guild}) => {
-            const result = originalExecute(data, {channel, guild});
+                const result = originalExecute(data, {channel, guild});
 
-            this.sendBotMessage(result, {channel, guild});
+                this.sendBotMessage(result, {channel, guild});
 
-            return result;
+                return result;
         };
     }
 

--- a/renderer/src/modules/core.js
+++ b/renderer/src/modules/core.js
@@ -24,7 +24,7 @@ import AddonStore from "./addonstore";
 import Styles from "@styles/index.css";
 import Modals from "@ui/modals";
 import FloatingWindows from "@ui/floatingwindows";
-import CommandManager from "./commandsmanager";
+import CommandManager from "./commandmanager";
 
 export default new class Core {
     async startup() {

--- a/renderer/src/modules/discordmodules.js
+++ b/renderer/src/modules/discordmodules.js
@@ -9,7 +9,7 @@ import Utilities from "./utilities";
 import WebpackModules, {Filters} from "./webpackmodules";
 
 
-export default Utilities.memoizeObject({
+const DiscordModules = Utilities.memoizeObject({
     get React() {return WebpackModules.getByProps("createElement", "cloneElement");},
     get ReactDOM() {return WebpackModules.getByProps("render", "findDOMNode");},
     get ChannelActions() {return WebpackModules.getByProps("selectChannel");},
@@ -24,5 +24,11 @@ export default Utilities.memoizeObject({
         const fallback = props => props.children?.({}) ?? null;
 
         return WebpackModules.getModule(Filters.byPrototypeKeys(["renderTooltip"]), {searchExports: true}) ?? fallback;
-    }
+    },
+    get promptToUpload() {return WebpackModules.getModule(Filters.byStrings("getUploadCount", "instantBatchUpload"), {searchExports: true});},
+    get RemoteModule() {return WebpackModules.getByProps("setBadge");},
+    get UserAgent() {return WebpackModules.getByProps("os", "layout");},
+    get MessageUtils() {return WebpackModules.getByProps("sendMessage");},
 });
+
+export default DiscordModules;

--- a/renderer/src/modules/ipc.js
+++ b/renderer/src/modules/ipc.js
@@ -25,8 +25,8 @@ export default new class IPCRenderer {
         return ipc.send(IPCEvents.TOGGLE_DEVTOOLS);
     }
 
-    relaunch() {
-        return ipc.send(IPCEvents.RELAUNCH);
+    relaunch(args) {
+        return ipc.send(IPCEvents.RELAUNCH, args);
     }
 
     runScript(script) {

--- a/renderer/src/modules/utilities.js
+++ b/renderer/src/modules/utilities.js
@@ -196,6 +196,7 @@ export default class Utilities {
 
     /**
      * Shows the guild join modal, to join invites
+     * TODO: move this to the modals module
      * @param {string} code 
      */
     static async showGuildJoinModal(code) {

--- a/renderer/src/structs/builtin.js
+++ b/renderer/src/structs/builtin.js
@@ -3,10 +3,12 @@ import Logger from "@common/logger";
 import Events from "@modules/emitter";
 import Settings from "@modules/settingsmanager";
 import Patcher from "@modules/patcher";
+import CommandManager from "@modules/commandmanager";
 
 
 export default class BuiltinModule {
 
+    #commands = new Set();
     get name() {return "Unnamed Builtin";}
     get collection() {return "settings";}
     get category() {return "general";}
@@ -102,5 +104,16 @@ export default class BuiltinModule {
 
     unpatchAll() {
         return Patcher.unpatchAll(this.name);
+    }
+
+    addCommands(...commands) {
+        for (const command of commands) {
+            const unregister = CommandManager.registerCommand("BetterDiscord", command);
+            this.#commands.add(unregister);
+        }
+    }
+
+    removeCommands() {
+        for (const unregister of this.#commands) unregister();
     }
 }

--- a/renderer/src/styles/blankslates/emptyimage.css
+++ b/renderer/src/styles/blankslates/emptyimage.css
@@ -3,7 +3,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin: 100px auto 0 auto;
+    margin: 150px auto 0 auto;
 }
 
 .bd-empty-image-title {


### PR DESCRIPTION
This adds a few built-in BD commands to the slash command system:
- addons
- restart
- support
- debug
- settings
- customcss

These have been tested and have been functioning but there are still some concerns:
- [ ] The addons, customcss, and settings commands all have a `Toggle` option. Is this too confusing and should we just go with `enable` and `disable`?
- [x] ~~The debug and customcss commands have options to share to chat. If the content is too large for chat it will automatically paste the content in chat (causing discord to attach it as `message.txt`) and then press enter to send. I think automatically pasting to attach is fine for sure, but is it okay to also then simulate an `Enter` keypress to send the attachment?~~

Things left I want to do before merge:
- [ ] Decide on the items from above
- [x] ~~Move several of the module searches to `DiscordModules` so it gets caches/proxied to avoid the multiple searching overhead~~
- [ ] (maybe) move the commands into relevant modules like moving the customcss command into that built-in

@doggybootsy @zrodevkaan pinging here since it's 2025 and GitHub still doesn't support requesting reviews from non-org members...