### PR TITLE
Implement Native frame and in app traffic lights

### DIFF
--- a/assets/locales/en-us.json
+++ b/assets/locales/en-us.json
@@ -63,6 +63,10 @@
                 "frame": {
                     "name": "Window Frame",
                     "note": "Adds the native os window frame to the main window"
+                },
+                "inAppTrafficLights": {
+                    "name": "Use In App Traffic Lights",
+                    "note": "Instead of using the OS traffic lights it will use a in app one"
                 }
             },
             "addons": {

--- a/injector/src/modules/browserwindow.js
+++ b/injector/src/modules/browserwindow.js
@@ -16,9 +16,15 @@ class BrowserWindow extends electron.BrowserWindow {
             options.backgroundColor = "#00000000";
         }
 
-        // Only affect frame if it is *explicitly* set
-        // const shouldHaveFrame = BetterDiscord.getSetting("window", "frame");
-        // if (typeof(shouldHaveFrame) === "boolean") options.frame = shouldHaveFrame;
+
+        const inAppTrafficLights = Boolean(BetterDiscord.getSetting("window", "inAppTrafficLights") ?? false);
+
+        process.env.BETTERDISCORD_NATIVE_FRAME = options.frame = Boolean(BetterDiscord.getSetting("window", "frame") ?? options.frame);
+        process.env.BETTERDISCORD_IN_APP_TRAFFIC_LIGHTS = inAppTrafficLights;
+        
+        if (inAppTrafficLights) {
+            delete options.titleBarStyle;
+        }
 
         super(options);
         this.__originalPreload = originalPreload;

--- a/preload/src/api/index.js
+++ b/preload/src/api/index.js
@@ -12,15 +12,22 @@ export * as os from "os";
 
 import electron from "electron";
 import * as IPCEvents from "common/constants/ipcevents";
+import DiscordNativePatch from "../discordnativepatch";
 
 // Currently for the store, but can easily be changed later on
 const {BETTERDISCORD_PROTOCOL} = process.env;
 delete process.env.BETTERDISCORD_PROTOCOL;
 
+/** @param {(protocol: (url: string) => void)} callback  */
 export function setProtocolListener(callback) {
     if (BETTERDISCORD_PROTOCOL) {
         process.nextTick(() => callback(BETTERDISCORD_PROTOCOL));
     }
 
     electron.ipcRenderer.on(IPCEvents.HANDLE_PROTOCOL, (event, url) => callback(url));
+}
+
+/** @param {boolean} value  */
+export function setDevToolsWarningState(value) {
+    DiscordNativePatch.setDevToolsWarningState(value);
 }

--- a/preload/src/discordnativepatch.js
+++ b/preload/src/discordnativepatch.js
@@ -1,0 +1,115 @@
+import electron from "electron";
+import path from "path";
+
+import * as IPCEvents from "common/constants/ipcevents";
+
+let dataPath = "";
+if (process.platform === "win32" || process.platform === "darwin") dataPath = path.join(electron.ipcRenderer.sendSync(IPCEvents.GET_PATH, "userData"), "..");
+else dataPath = process.env.XDG_CONFIG_HOME ? process.env.XDG_CONFIG_HOME : path.join(process.env.HOME, ".config"); // This will help with snap packages eventually
+dataPath = path.join(dataPath, "BetterDiscord") + "/";
+
+let _settings;
+function getSetting(category, key) {
+    if (_settings) return _settings[category]?.[key];
+
+    try {
+        const settingsFile = path.resolve(dataPath, "data", process.env.DISCORD_RELEASE_CHANNEL, "settings.json");
+        _settings = __non_webpack_require__(settingsFile) ?? {};
+        return _settings[category]?.[key];
+    }
+    catch (_) {
+        _settings = {};
+        return _settings[category]?.[key];
+    }
+}
+
+const {exposeInMainWorld} = electron.contextBridge;
+
+// Hold the listeners
+let /** @type {Function} */ onOpened, /** @type {Function} */ onClosed;
+
+let isOpen = false;
+/** @type {boolean} */
+let patchDevtoolsCallbacks = getSetting("developer", "devToolsWarning");
+if (typeof patchDevtoolsCallbacks !== "boolean") patchDevtoolsCallbacks = false;
+
+const contextBridge = {
+    ...electron.contextBridge,
+    exposeInMainWorld(apiKey, api) {
+        if (apiKey === "DiscordNative") {
+            // On macOS check if native frame is enabled
+            // every other os say false
+            api.window.USE_OSX_NATIVE_TRAFFIC_LIGHTS = process.platform === "darwin" && process.env.BETTERDISCORD_IN_APP_TRAFFIC_LIGHTS === "false";
+
+            api.window.setDevtoolsCallbacks(
+                () => {                    
+                    isOpen = true;
+                    if (!patchDevtoolsCallbacks) onOpened?.();
+                },
+                () => {
+                    isOpen = false;
+                    if (!patchDevtoolsCallbacks) onClosed?.();
+                }
+            );
+
+            api.window.setDevtoolsCallbacks = (_onOpened, _onClosed) => {
+                onOpened = _onOpened;
+                onClosed = _onClosed;
+            };
+        }
+
+        exposeInMainWorld(apiKey, api);
+    }
+};
+
+class DiscordNativePatch {
+    static setDevToolsWarningState(value) {
+        patchDevtoolsCallbacks = value;
+
+        // If devtools is open
+        if (isOpen) {
+            // If you enable it, run the onClsoed function 
+            if (value) onClosed?.();
+            // If its disabled, run the onOpened function
+            else onOpened?.();
+        }
+    }
+
+    // For native frame
+    // document.body does not exist when this is ran. 
+    // so we have to wait for it
+    static injectCSS() {
+        if (process.env.BETTERDISCORD_NATIVE_FRAME === "false") return;
+        
+        // Have to use `global.` because the file is in node
+        const mutationObserver = new global.MutationObserver(() => {
+            if (global.document.body) {
+                mutationObserver.disconnect();
+
+                const style = global.document.createElement("style");
+                style.textContent = `
+                    #app-mount > div[class*=titleBar_] { display: none !important; }
+                    .platform-osx nav[class^=wrapper_][class*=guilds_] {margin-top: 0;}
+                    .platform-win div[class^=content_] > div[class^=sidebar_] {border-radius: 0;}
+                `;
+
+                global.document.body.append(style);
+            }
+        });
+
+        mutationObserver.observe(global.document, {childList: true, subtree: true});
+    }
+
+    static patch() {
+        const electronPath = __non_webpack_require__.resolve("electron");
+        delete __non_webpack_require__.cache[electronPath].exports; // If it didn't work, try to delete existing
+        __non_webpack_require__.cache[electronPath].exports = {...electron, contextBridge}; // Try to assign again after deleting
+    }
+
+    static init() {
+        this.injectCSS();
+        this.patch();
+    }
+}
+
+export default DiscordNativePatch;

--- a/preload/src/index.js
+++ b/preload/src/index.js
@@ -3,8 +3,10 @@ import patchDefine from "./patcher";
 import newProcess from "./process";
 import * as BdApi from "./api";
 import init from "./init";
+import DiscordNativePatch from "./discordnativepatch";
 
 patchDefine();
+DiscordNativePatch.init();
 
 let hasInitialized = false;
 contextBridge.exposeInMainWorld("process", newProcess);

--- a/renderer/src/builtins/builtins.js
+++ b/renderer/src/builtins/builtins.js
@@ -25,3 +25,4 @@ export {default as DebugLogs} from "./developer/debuglogs";
 
 export {default as WindowPrefs} from "./window/transparency";
 export {default as RemoveMinimumSize} from "./window/removeminimumsize";
+export {default as NativeFrame} from "./window/nativeframe";

--- a/renderer/src/builtins/developer/devtoolswarning.js
+++ b/renderer/src/builtins/developer/devtoolswarning.js
@@ -1,6 +1,7 @@
 import Builtin from "@structs/builtin";
 
 import WebpackModules from "@modules/webpackmodules";
+import RemoteAPI from "@polyfill/remote";
 
 export default new class StopDevToolsWarning extends Builtin {
     get name() {return "StopDevToolsWarning";}
@@ -10,6 +11,7 @@ export default new class StopDevToolsWarning extends Builtin {
     enabled() {
         // IPC.stopDevtoolsWarning();
         window?.DiscordNative?.window?.setDevtoolsCallbacks(null, null);
+        RemoteAPI.setDevToolsWarningState(true);
     }
 
     disabled() {
@@ -18,5 +20,6 @@ export default new class StopDevToolsWarning extends Builtin {
         const hideModule = WebpackModules.getModule(m => Object.keys(m).some(k => k.startsWith("hide")));
         if (!devtoolsModule || !stringModule || !hideModule) return;
         devtoolsModule(stringModule, hideModule, window?.DiscordNative);
+        RemoteAPI.setDevToolsWarningState(false);
     }
 };

--- a/renderer/src/builtins/window/nativeframe.js
+++ b/renderer/src/builtins/window/nativeframe.js
@@ -1,0 +1,43 @@
+import Builtin from "@structs/builtin";
+
+import IPC from "@modules/ipc";
+import Modals from "@ui/modals";
+import Strings from "@modules/strings";
+import Events from "@modules/emitter";
+
+export default new class NativeFrame extends Builtin {
+    get name() {return "NativeFrame";}
+    get category() {return "window";}
+    get id() {return "frame";}
+
+    initialize() {
+        Events.on("setting-updated", (collection, category, id) => {
+            if (collection != this.collection || category !== this.category || id !== "inAppTrafficLights") return;
+            this.showModal();
+        });
+
+        super.initialize();
+    }
+
+    enabled() {
+        document.body.classList.add("bd-frame");
+
+        this.showModal();
+    }
+
+    disabled() {
+        document.body.classList.remove("bd-frame");
+
+        this.showModal();
+    }
+
+    showModal() {
+        if (!this.initialized) return;
+        Modals.showConfirmationModal(Strings.Modals.additionalInfo, Strings.Modals.restartPrompt, {
+            confirmText: Strings.Modals.restartNow,
+            cancelText: Strings.Modals.restartLater,
+            danger: true,
+            onConfirm: () => IPC.relaunch()
+        });
+    }
+};

--- a/renderer/src/data/settings.js
+++ b/renderer/src/data/settings.js
@@ -66,7 +66,9 @@ export default [
         settings: [
             {type: "switch", id: "transparency", value: false},
             {type: "switch", id: "removeMinimumSize", value: false},
-            {type: "switch", id: "frame", value: false, hidden: true}
+            {type: "switch", id: "frame", value: process.platform === "linux"},
+            // MacOS exclusive
+            {type: "switch", id: "inAppTrafficLights", value: false, disabled: process.env.BETTERDISCORD_NATIVE_FRAME === "true", hidden: process.platform !== "darwin"}
         ]
     },
     {


### PR DESCRIPTION
Adds 2 settings. And makes the stop devtool warning builtin run at the very start.
It will also show the traffic lights when emulating the macOS UI on linux / windows 

## New Settings
### Window Frame
This will use the OS titlebar instead of Discord's builtin titlebar

### Use In App Traffic Lights
Instead of using the OS traffic lights it will use a in app one