### PR TITLE
Interval Checking & Fix for 502 Error overwriting plugin files (#1822)

### DIFF
--- a/assets/locales/en-us.json
+++ b/assets/locales/en-us.json
@@ -79,6 +79,10 @@
                         "system": "System Editor"
                     }
                 },
+                "checkForUpdates": {
+                    "name": "Automatically Check For Updates",
+                    "note": "Periodically checks for updates to your addons and core BD"
+                },
                 "updateInterval": {
                     "name": "Update Check Interval",
                     "note": "How often to check for addon/core updates",

--- a/assets/locales/en-us.json
+++ b/assets/locales/en-us.json
@@ -78,6 +78,19 @@
                         "detached": "Detached Window",
                         "system": "System Editor"
                     }
+                },
+                "updateInterval": {
+                    "name": "Update Check Interval",
+                    "note": "How often to check for addon/core updates",
+                    "options": {
+                        "0": "Off",
+                        "1": "Every 1 hour",
+                        "2": "Every 2 hours",
+                        "3": "Every 3 hours",
+                        "4": "Every 4 hours",
+                        "5": "Every 5 hours",
+                        "6": "Every 6 hours"
+                    }
                 }
             },
             "customcss": {

--- a/assets/locales/en-us.json
+++ b/assets/locales/en-us.json
@@ -85,16 +85,7 @@
                 },
                 "updateInterval": {
                     "name": "Update Check Interval",
-                    "note": "How often to check for addon/core updates",
-                    "options": {
-                        "0": "Off",
-                        "1": "Every 1 hour",
-                        "2": "Every 2 hours",
-                        "3": "Every 3 hours",
-                        "4": "Every 4 hours",
-                        "5": "Every 5 hours",
-                        "6": "Every 6 hours"
-                    }
+                    "note": "How often to check for addon/core updates"
                 }
             },
             "customcss": {
@@ -318,6 +309,7 @@
         "updateAvailable": "BetterDiscord has a new update (v{{version}})",
         "addonUpdatesAvailable": "BetterDiscord has found updates for {{count}} of your {{type}}s!",
         "addonUpdated": "{{name}} has been updated to version {{version}}!",
+        "addonUpdateFailed": "Failed to update {{name}}. Please try again later.",
         "checking": "Checking for updates!",
         "finishedChecking": "Finished checking for updates!",
         "checkForUpdates": "Check For Updates!",

--- a/renderer/src/data/settings.js
+++ b/renderer/src/data/settings.js
@@ -18,7 +18,16 @@ export default [
         shown: false,
         settings: [
             {type: "switch", id: "addonErrors", value: true},
-            {type: "dropdown", id: "editAction", value: "detached", options: [{value: "detached"}, {value: "system"}]}
+            {type: "dropdown", id: "editAction", value: "detached", options: [{value: "detached"}, {value: "system"}]},
+            {type: "dropdown", id: "updateInterval", value: "2", options: [
+                {value: "0"},
+                {value: "1"},
+                {value: "2"},
+                {value: "3"},
+                {value: "4"},
+                {value: "5"},
+                {value: "6"}
+            ]}
         ]
     },
     {

--- a/renderer/src/data/settings.js
+++ b/renderer/src/data/settings.js
@@ -19,15 +19,8 @@ export default [
         settings: [
             {type: "switch", id: "addonErrors", value: true},
             {type: "dropdown", id: "editAction", value: "detached", options: [{value: "detached"}, {value: "system"}]},
-            {type: "dropdown", id: "updateInterval", value: "2", options: [
-                {value: "0"},
-                {value: "1"},
-                {value: "2"},
-                {value: "3"},
-                {value: "4"},
-                {value: "5"},
-                {value: "6"}
-            ]}
+            {type: "switch", id: "checkForUpdates", value: true},
+            {type: "slider", id: "updateInterval", value: 4, min: 2, max: 12, step: 1, markers: [2, 4, 6, 8, 10, 12], units: "hrs", enableWith: "checkForUpdates"}
         ]
     },
     {

--- a/renderer/src/modules/updater.js
+++ b/renderer/src/modules/updater.js
@@ -181,7 +181,9 @@ class AddonUpdater {
             this.checkAll();
         }
         Events.on(`${this.type}-loaded`, addon => {
-            this.checkForUpdate(addon.filename, addon.version);
+            if (!Settings.get("addons", "checkForUpdates")) {
+                this.checkForUpdate(addon.filename, addon.version);
+            }
         });
 
         Events.on(`${this.type}-unloaded`, addon => {

--- a/renderer/src/modules/updater.js
+++ b/renderer/src/modules/updater.js
@@ -60,7 +60,7 @@ export default class Updater {
             CoreUpdater.initialize();
             PluginUpdater.initialize();
             ThemeUpdater.initialize();
-        }, 3000);
+        }, 3000); // this is to try to combat that weird bug I spotted a few months back where the banner would instantly disappear sometimes. The small delay should help.
 
         const updateInterval = Settings.get("addons", "updateInterval");
         if (updateInterval !== "0") {

--- a/renderer/src/modules/updater.js
+++ b/renderer/src/modules/updater.js
@@ -56,11 +56,9 @@ export default class Updater {
             }
         });
 
-        setTimeout(() => {
-            CoreUpdater.initialize();
-            PluginUpdater.initialize();
-            ThemeUpdater.initialize();
-        }, 3000); // this is to try to combat that weird bug I spotted a few months back where the banner would instantly disappear sometimes. The small delay should help.
+        CoreUpdater.initialize();
+        PluginUpdater.initialize();
+        ThemeUpdater.initialize();
 
         if (Settings.get("addons", "checkForUpdates")) {
             this.startUpdateInterval();
@@ -97,8 +95,9 @@ export class CoreUpdater {
     static apiData = {};
     static remoteVersion = "";
 
-    static async initialize(checkUpdates = true) {
-        if (checkUpdates) {
+    static async initialize() {
+        const shouldCheck = Settings.get("addons", "checkForUpdates");
+        if (shouldCheck) {
             this.checkForUpdate();
         }
     }
@@ -175,9 +174,10 @@ class AddonUpdater {
         this.pending = [];
     }
 
-    async initialize(checkUpdates = true) {    
+    async initialize() {    
         await this.updateCache();
-        if (checkUpdates) {
+        const shouldCheck = Settings.get("addons", "checkForUpdates");
+        if (shouldCheck) {
             this.checkAll();
         }
         Events.on(`${this.type}-loaded`, addon => {
@@ -222,7 +222,7 @@ class AddonUpdater {
         request(Web.redirects.github(info.id), (error, response, body) => {
             if (error || response.statusCode !== 200) {
                 Logger.stacktrace("AddonUpdater", `Failed to download body for ${info.id}:`, error);
-                Toasts.error(Strings.Updater.updateFailed.format({name: info.name, version: info.version}));
+                Toasts.error(Strings.Updater.addonUpdateFailed.format({name: info.name, version: info.version}));
                 return;
             }
 

--- a/renderer/src/modules/updater.js
+++ b/renderer/src/modules/updater.js
@@ -62,13 +62,13 @@ export default class Updater {
             ThemeUpdater.initialize();
         }, 3000); // this is to try to combat that weird bug I spotted a few months back where the banner would instantly disappear sometimes. The small delay should help.
 
-        const updateInterval = Settings.get("addons", "updateInterval");
-        if (updateInterval !== "0") {
+        if (Settings.get("addons", "checkForUpdates")) {
             this.startUpdateInterval();
         }
 
         Events.on("setting-updated", (collection, category, id, value) => {
-            if (collection === "settings" && category === "addons" && id === "updateInterval") {
+            if (collection === "settings" && category === "addons" && 
+               (id === "updateInterval" || id === "checkForUpdates")) {
                 this.startUpdateInterval();
             }
         });
@@ -80,13 +80,9 @@ export default class Updater {
             this.updateCheckInterval = null;
         }
 
-        const updateInterval = Settings.get("addons", "updateInterval");
-        if (updateInterval === "0") {
-            return;
-        }
+        if (!Settings.get("addons", "checkForUpdates")) return;
 
-        const hours = parseInt(updateInterval);
-
+        const hours = Settings.get("addons", "updateInterval");
         this.updateCheckInterval = setInterval(() => {
             CoreUpdater.checkForUpdate();
             PluginUpdater.checkAll(true);

--- a/renderer/src/ui/updater.jsx
+++ b/renderer/src/ui/updater.jsx
@@ -109,8 +109,12 @@ export default function UpdaterPanel({coreUpdater, pluginUpdater, themeUpdater})
         await checkCoreUpdate();
         await checkAddons("plugins");
         await checkAddons("themes");
+        setUpdates({
+            plugins: pluginUpdater.pending.slice(0),
+            themes: themeUpdater.pending.slice(0)
+        });
         Toasts.info(Strings.Updater.finishedChecking);
-    }, [checkAddons, checkCoreUpdate]);
+    }, [checkAddons, checkCoreUpdate, pluginUpdater, themeUpdater]);
 
     const updateCore = useCallback(async () => {
         await coreUpdater.update();


### PR DESCRIPTION
Fixes overwriting plugins on 502 failed updates, and adds interval checkings, enabled by default on 2hrs, with options to configure