### PR TITLE
Rewrite to use new webpack system

### DIFF
--- a/src/betterdiscord/api/contextmenu.js
+++ b/src/betterdiscord/api/contextmenu.js
@@ -6,7 +6,7 @@ import React from "@modules/react";
 
 let startupComplete = false;
 
-const ModulesBundle = getByKeys(["MenuItem", "Menu"]);
+const ModulesBundle = getByKeys(["MenuItem", "Menu"], {cacheId: "core-contextmenu-ModulesBundle"});
 const MenuComponents = {
     Separator: ModulesBundle?.MenuSeparator,
     CheckboxItem: ModulesBundle?.MenuCheckboxItem,
@@ -66,7 +66,7 @@ if (!startupComplete) {
         MenuComponents.Group ??= contextMenuComponents[match[1]];
     }
 
-    MenuComponents.Menu ??= getModule(Filters.byStrings("getContainerProps()", ".keyboardModeEnabled&&null!="), {searchExports: true});
+    MenuComponents.Menu ??= getModule(Filters.byStrings("getContainerProps()", ".keyboardModeEnabled&&null!="), {searchExports: true, cacheId: "core-contextmenu-Menu"});
 }
 
 startupComplete = Object.values(MenuComponents).every(v => v);
@@ -75,7 +75,7 @@ const ContextMenuActions = (() => {
     const out = {};
 
     try {
-        const ActionsModule = getModule((mod, target, id) => modules[id]?.toString().includes(`type:"CONTEXT_MENU_OPEN"`), {searchExports: false});
+        const ActionsModule = getModule((mod, target, id) => modules[id]?.toString().includes(`type:"CONTEXT_MENU_OPEN"`), {searchExports: false, cacheId: "core-contextmenu-Actions"});
 
         for (const key of Object.keys(ActionsModule)) {
             if (ActionsModule[key].toString().includes("CONTEXT_MENU_CLOSE")) {
@@ -110,7 +110,7 @@ class MenuPatcher {
         if (!startupComplete) return Logger.warn("ContextMenu~Patcher", "Startup wasn't successfully, aborting initialization.");
 
         const {module, key} = (() => {
-            const foundModule = getModule(m => Object.values(m).some(v => typeof v === "function" && v.toString().includes(`type:"CONTEXT_MENU_CLOSE"`)), {searchExports: false});
+            const foundModule = getModule(m => Object.values(m).some(v => typeof v === "function" && v.toString().includes(`type:"CONTEXT_MENU_CLOSE"`)), {searchExports: false, cacheId: "core-contextmenu-toPatch"});
             const foundKey = Object.keys(foundModule).find(k => foundModule[k].length === 3);
 
             return {module: foundModule, key: foundKey};

--- a/src/betterdiscord/api/webpack.ts
+++ b/src/betterdiscord/api/webpack.ts
@@ -1,4 +1,5 @@
 import Logger from "@common/logger";
+import DiscordModules from "@modules/discordmodules";
 import {Filters, getAllModules, getBulk, getLazy, getMangled, getModule, getStore, getWithKey, modules, Stores} from "@webpack";
 
 type WithOptions<T, B extends WebpackOptions> = [...T[], B] | T[];
@@ -14,9 +15,8 @@ const getOptions = <T, B extends Webpack.Options>(args: WithOptions<T, B>, defau
     return [ args as T[], defaultOptions ];
 };
 
-interface WebpackOptions extends Webpack.Options {
-    first?: boolean
-}
+type WebpackOptions = (Webpack.SingleOptions & { first?: true }) |
+    (Webpack.Options & { first: false });
 
 /**
  * `Webpack` is a utility class for getting internal webpack modules. Instance is accessible through the {@link BdApi}.
@@ -32,6 +32,8 @@ const Webpack = {
     modules: modules,
 
     Stores: Stores,
+
+    common: DiscordModules,
 
     /**
      * Series of {@link Filters} to be used for finding webpack modules.
@@ -87,7 +89,7 @@ const Webpack = {
         if (("searchExports" in options) && typeof(options.searchExports) !== "boolean") return Logger.error("BdApi.Webpack~getModule", "Invalid type for options.searchExports", options.searchExports, "Expected: boolean");
         if (("raw" in options) && typeof(options.raw) !== "boolean") return Logger.error("BdApi.Webpack~getModule", "Invalid type for options.raw", options.raw, "Expected: boolean");
         
-        if (options.first === false) return getAllModules(filter, options) as T;
+        if (options.first === false) return getAllModules(filter, options) as T;        
         return getModule<T>(filter, options);
     },
 

--- a/src/betterdiscord/builtins/customcss.js
+++ b/src/betterdiscord/builtins/customcss.js
@@ -18,7 +18,7 @@ import SettingsTitle from "@ui/settings/title";
 import {getByKeys} from "@webpack";
 
 
-const UserSettings = getByKeys(["updateAccount"]);
+const UserSettings = getByKeys(["updateAccount"], {cacheId: "core-customcss-UserSettings"});
 
 export default new class CustomCSS extends Builtin {
     get name() {return "Custom CSS";}

--- a/src/betterdiscord/builtins/developer/recovery.js
+++ b/src/betterdiscord/builtins/developer/recovery.js
@@ -8,7 +8,7 @@ import Settings from "@modules/settingsmanager";
 import pluginmanager from "@modules/pluginmanager";
 import Toasts from "@ui/toasts";
 import Modals from "@ui/modals";
-import {getByKeys, getByPrototypes, getByStrings} from "@webpack";
+import {getByPrototypes, getByStrings} from "@webpack";
 
 const Dispatcher = DiscordModules.Dispatcher;
 
@@ -142,7 +142,6 @@ export default new class Recovery extends Builtin {
 
     async enabled() {
         this.patchErrorBoundry();
-        this.parseModule = getByKeys(["defaultRules", "parse"]);
     }
 
     async disabled() {
@@ -166,7 +165,7 @@ export default new class Recovery extends Builtin {
     }
 
     patchErrorBoundry() {
-        const mod = getByPrototypes(["_handleSubmitReport"]);
+        const mod = getByPrototypes(["_handleSubmitReport"], {cacheId: "core-recovery-handleSubmitReport"});
 
         this.after(mod?.prototype, "render", (instance, args, retValue) => {
             if (!Settings.get(this.collection, this.category, this.id)) return;
@@ -175,7 +174,7 @@ export default new class Recovery extends Builtin {
             if (!buttons) return;
 
             const errorStack = instance.state;
-            const parsedError = errorStack ? this.parseModule.parse(`\`\`\`${errorStack.error?.stack}\n\n${errorStack.info?.componentStack}\`\`\``) : null;
+            const parsedError = errorStack ? DiscordModules.SimpleMarkdownWrapper.parse(`\`\`\`${errorStack.error?.stack}\n\n${errorStack.info?.componentStack}\`\`\``) : null;
 
             const foundIssue = /betterdiscord:\/\/(plugins)\/(.*?).(\w+).js/.exec(errorStack.error?.stack);
             let pluginInfo = null;

--- a/src/betterdiscord/builtins/general/contextmenu.js
+++ b/src/betterdiscord/builtins/general/contextmenu.js
@@ -9,11 +9,10 @@ import themeManager from "@modules/thememanager";
 import Utilities from "@modules/utilities";
 import React from "@modules/react";
 import DOMManager from "@modules/dommanager";
-import {getByKeys} from "@webpack";
+import DiscordModules from "@modules/discordmodules";
 
 
 const ContextMenu = new ContextMenuPatcher();
-const UserSettingsWindow = getByKeys(["open", "updateAccount"]);
 
 export default new class BDContextMenu extends Builtin {
     get name() {return "BDContextMenu";}
@@ -133,6 +132,6 @@ export default new class BDContextMenu extends Builtin {
 
     async openCategory(id) {
         ContextMenu.close();
-        UserSettingsWindow?.open?.(id);
+        DiscordModules.UserSettingsWindow?.open?.(id);
     }
 };

--- a/src/betterdiscord/builtins/general/themeattributes.js
+++ b/src/betterdiscord/builtins/general/themeattributes.js
@@ -2,9 +2,9 @@ import Builtin from "@structs/builtin";
 import Utilities from "@modules/utilities";
 import {getByStrings, getModule} from "@webpack";
 
-const MessageComponent = getByStrings([ "isSystemMessage", "hasReply" ], {defaultExport: false});
-const TabBarComponent = getByStrings([ "({getFocusableElements:()=>{let" ], {searchExports: true});
-const UserProfileComponent = getModule((m) => m.render?.toString?.().includes("pendingThemeColors"));
+const MessageComponent = getByStrings([ "isSystemMessage", "hasReply" ], {defaultExport: false, cacheId: "core-themeattributes-Message"});
+const TabBarComponent = getByStrings([ "({getFocusableElements:()=>{let" ], {searchExports: true, cacheId: "core-themeattributes-TabBar"});
+const UserProfileComponent = getModule((m) => m.render?.toString?.().includes("pendingThemeColors"), {cacheId: "core-themeattributes-UserProfile"});
 
 export default new class ThemeAttributes extends Builtin {
     get name() {return "ThemeAttributes";}

--- a/src/betterdiscord/builtins/store/addonstore.js
+++ b/src/betterdiscord/builtins/store/addonstore.js
@@ -12,9 +12,10 @@ import ErrorBoundary from "@ui/errorboundary";
 import Web from "@data/web";
 
 import RemoteAPI from "@polyfill/remote";
-import {Filters, getByKeys, getLazy} from "@webpack";
+import {Filters, getLazy} from "@webpack";
+import DiscordModules from "@modules/discordmodules";
 
-const SimpleMarkdownWrapper = getByKeys(["parse", "defaultRules"]);
+const SimpleMarkdownWrapper = DiscordModules.SimpleMarkdownWrapper;
 let MessageAccessories;
 
 const MAX_EMBEDS = 10;

--- a/src/betterdiscord/data/config.js
+++ b/src/betterdiscord/data/config.js
@@ -1,8 +1,9 @@
 let version = process.env.__VERSION__;
 
 let path = "";
-let appPath = "";
-let userData = "";
+let appPath = process.env.DISCORD_APP_PATH;
+let userData = process.env.DISCORD_USER_DATA;
+let dataPath = process.env.BETTERDISCORD_DATA_PATH;
 
 // TODO: refactor this away entirely
 export default {
@@ -18,4 +19,7 @@ export default {
 
     get userData() {return userData;},
     set userData(str) {userData = str;},
+
+    get dataPath() {return dataPath;},
+    set dataPath(str) {dataPath = str;},
 };

--- a/src/betterdiscord/modules/commandmanager.js
+++ b/src/betterdiscord/modules/commandmanager.js
@@ -53,8 +53,8 @@ export const MessageEmbedTypes = {
   };
 
 const iconClasses = {
-    ...getModule(x => x.wrapper && x.icon && x.selected && x.selectable && !x.mask),
-    builtInSeparator: getModule(x => x.builtInSeparator)?.builtInSeparator
+    ...getModule(x => x.wrapper && x.icon && x.selected && x.selectable && !x.mask, {cacheId: "core-commandmanager-iconClasses"}),
+    builtInSeparator: getModule(x => x.builtInSeparator, {cacheId: "core-commandmanager-builtInSeperator"})?.builtInSeparator
 };
 
 const getAcronym = (input) =>
@@ -80,10 +80,10 @@ class CommandManager {
 
     static #patchCommandSystem() {
 
-        this.User = getByStrings(["hasHadPremium(){"]);
-        this.createBotMessage = getByStrings([ "username:\"Clyde\"" ], {searchExports: true});
-        this.MessagesModule = getModule(x => x.receiveMessage);
-        this.IconsModule = getModule(x => x.BOT_AVATARS);
+        this.User = getByStrings(["hasHadPremium(){"], {cacheId: "core-commandmanager-User"});
+        this.createBotMessage = getByStrings([ "username:\"Clyde\"" ], {searchExports: true, cacheId: "core-commandmanager-createBotMessage"});
+        this.MessagesModule = getModule(x => x.receiveMessage, {cacheId: "core-commandmanager-Messages"});
+        this.IconsModule = getModule(x => x.BOT_AVATARS, {cacheId: "core-commandmanager-Icons"});
         
         this.localBDBot = new this.User({
             avatar: "betterdiscord",
@@ -194,7 +194,7 @@ class CommandManager {
 
     static #patchApplicationIcons() {
         const [mod, key] = getWithKey(Filters.byStrings(".type===", ".BUILT_IN?"), {
-            target: getModule((e, m) => modules[m.id].toString().includes("hasSpaceTerminator:"))
+            target: getModule((e, m) => modules[m.id].toString().includes("hasSpaceTerminator:"), {cacheId: "core-commandmanager-appIconsTarget"})
         });
 
         Patcher.after("CommandManager", mod, key, (that, [{id}], res) => {

--- a/src/betterdiscord/modules/core.js
+++ b/src/betterdiscord/modules/core.js
@@ -33,10 +33,6 @@ export default new class Core {
         if (this.hasStarted) return;
         this.hasStarted = true;
 
-        Config.appPath = process.env.DISCORD_APP_PATH;
-        Config.userData = process.env.DISCORD_USER_DATA;
-        Config.dataPath = process.env.BETTERDISCORD_DATA_PATH;
-
         IPC.getSystemAccentColor().then(value => DOMManager.injectStyle("bd-os-values", `:root {--os-accent-color: #${value};}`));
 
         // Load css early

--- a/src/betterdiscord/modules/datastore.js
+++ b/src/betterdiscord/modules/datastore.js
@@ -16,6 +16,7 @@ const releaseChannel = window?.DiscordNative?.app?.getReleaseChannel?.() ?? "sta
 //             -> settings.json
 //             -> plugins.json
 //             -> themes.json
+//             -> webpackCache.json
 
 export default new class DataStore {
     constructor() {
@@ -57,6 +58,7 @@ export default new class DataStore {
     get pluginFolder() {return this._pluginFolder || (this._pluginFolder = path.resolve(Config.dataPath, "plugins"));}
     get themeFolder() {return this._themeFolder || (this._themeFolder = path.resolve(Config.dataPath, "themes"));}
     get customCSS() {return this._customCSS || (this._customCSS = path.resolve(this.dataFolder, "custom.css"));}
+    get webpackCache() {return this._webpackCache || (this._webpackCache = path.resolve(this.dataFolder, "webpackCache.json"));}
     get baseFolder() {return this._baseFolder || (this._baseFolder = path.resolve(Config.dataPath, "data"));}
     get dataFolder() {return this._dataFolder || (this._dataFolder = path.resolve(this.baseFolder, `${releaseChannel}`));}
     getPluginFile(pluginName) {return path.resolve(Config.dataPath, "plugins", pluginName + ".config.json");}
@@ -133,5 +135,17 @@ export default new class DataStore {
         this.ensurePluginData(pluginName); // Ensure plugin data, if any, is cached
         delete this.pluginData[pluginName][key];
         fs.writeFileSync(this.getPluginFile(pluginName), JSON.stringify(this.pluginData[pluginName], null, 4));
+    }
+
+    getWebpackCache() {
+        return JSON.parse(fs.readFileSync(this.webpackCache) || "{}");
+    }
+
+    setWebpackCache(cache) {
+        if (this.saveWPCTimeout) clearTimeout(this.saveWPCTimeout);
+
+        this.saveWPCTimeout = setTimeout(() => {
+            fs.writeFileSync(this.webpackCache, JSON.stringify(cache, 4, null));
+        }, 100);
     }
 };

--- a/src/betterdiscord/modules/discordmodules.js
+++ b/src/betterdiscord/modules/discordmodules.js
@@ -5,30 +5,65 @@
  * @version 0.0.3
  */
 
-import Utilities from "./utilities";
-import {Filters, getByKeys, getByStrings, getModule} from "@webpack";
+import {Filters, getByKeys, getByPrototypes, getByStrings, getModule} from "@webpack";
 
 
-const DiscordModules = Utilities.memoizeObject({
-    get React() {return getByKeys(["createElement", "cloneElement"]);},
-    get ReactDOM() {return getByKeys(["render", "findDOMNode"]);},
-    get ChannelActions() {return getByKeys(["selectChannel"]);},
-    get LocaleStore() {return getByKeys(["locale", "initialize"]);},
-    get UserStore() {return getByKeys(["getCurrentUser", "getUser"]);},
-    get InviteActions() {return getByKeys(["createInvite"]);},
-    get SimpleMarkdown() {return getByKeys(["parseBlock", "parseInline", "defaultOutput"]);},
-    get Strings() {return getByKeys(["Messages"]).Messages;},
-    get Dispatcher() {return getByKeys(["dispatch", "subscribe", "register"]);},
+const DiscordModules = new Proxy({
+    // Modules used by core
+    get React() {return getByKeys(["createElement", "cloneElement"], {cacheId: "core-React"});},
+    get ReactDOM() {return getByKeys(["render", "findDOMNode"], {cacheId: "core-ReactDOM"});},
+    get ChannelActions() {return getByKeys(["selectChannel"], {cacheId: "core-ChannelActions"});},
+    get LocaleStore() {return getByKeys(["locale", "initialize"], {cacheId: "core-LocaleStore"});},
+    get UserStore() {return getByKeys(["getCurrentUser", "getUser"], {cacheId: "core-UserStore"});},
+    get InviteActions() {return getByKeys(["createInvite"], {cacheId: "core-InviteActions"});},
+    get SimpleMarkdown() {return getByKeys(["parseBlock", "parseInline", "defaultOutput"], {cacheId: "core-SimpleMarkdown"});},
+    get SimpleMarkdownWrapper() {return getByKeys(["defaultRules", "parse"], {cacheId: "core-MarkdownParser"});},
+    get Strings() {return getByKeys(["Messages"], {cacheId: "core-Strings"}).Messages;},
+    get Dispatcher() {return getByKeys(["dispatch", "subscribe", "register"], {cacheId: "core-Dispatcher"});},
     get Tooltip() {
         // Make fallback component just pass children, so it can at least render that.
         const fallback = props => props.children?.({}) ?? null;
 
-        return getModule(Filters.byPrototypeKeys(["renderTooltip"]), {searchExports: true}) ?? fallback;
+        return getByPrototypes(["renderTooltip"], {searchExports: true, cacheId: "core-Tooltip"}) ?? fallback;
     },
-    get promptToUpload() {return getByStrings([ "getUploadCount", "instantBatchUpload" ], {searchExports: true});},
-    get RemoteModule() {return getByKeys(["setBadge"]);},
-    get UserAgent() {return getByKeys(["os", "layout"]);},
-    get MessageUtils() {return getByKeys(["sendMessage"]);},
+    get promptToUpload() {return getModule(Filters.byStrings("getUploadCount", "instantBatchUpload"), {searchExports: true, cacheId: "core-promptToUpload"});},
+    get RemoteModule() {return getByKeys(["setBadge"], {cacheId: "core-RemoteModule"});},
+    get UserAgent() {return getByKeys(["os", "layout"], {cacheId: "core-UserAgent"});},
+    get MessageUtils() {return getByKeys(["sendMessage"], {cacheId: "core-MessageUtils"});},
+    get UserSettingsWindow() {return getByKeys(["open", "updateAccount"], {cacheId: "core-UserSettingsWindow"});},
+    get Spring() {return getByKeys(["useSpring", "animated"], {cacheId: "core-Spring"});},
+
+    // Commonly used modules in plugins
+    get ChannelClasses() {return getByKeys(["channel", "decorator"], {cacheId: "core-ChannelClasses"});},
+    get LayerClasses() {return getByKeys(["layerContainer"], {cacheId: "core-LayerClasses"});},
+    get WrapperClasses() {return getByKeys(["wrapperControlsHidden"], {cacheId: "core-WrapperClasses"});},
+    get TextareaClasses() {return getByKeys(["channelTextArea", "buttonContainer", "button"], {cacheId: "core-TextareaClasses"});},
+    get MessageClasses() {return getByKeys(["repliedTextPreview", "repliedTextContent"], {cacheId: "core-MessageClasses"});},
+    get SidebarClasses() {return getByKeys(["sidebar", "activityPanel", "sidebarListRounded"], {cacheId: "core-SidebarClasses"});},
+    get MarginClasses() {return getByKeys(["marginBottom4", "marginTop20"], {cacheId: "core-MarginClasses"});},
+    get MessageViewClasses() {return getByKeys(["ephemeral", "quotedChatMessage", "channelTextArea"], {cacheId: "core-MessageViewClasses"});},
+    get MessageActions() {return getByKeys(["jumpToMessage", "_sendMessage"], {cacheId: "core-MessageActions"});},
+    get transitionTo() {return getByStrings(["transitionTo - Transitioning to"], {searchExports: true, cacheId: "core-transitionTo"});},
+    get DiscordComponents() {return getByKeys(["ConfirmModal", "ToastPosition"], {cacheId: "core-DiscordComponents"});},
+    get FormSwitch() {return getModule(Filters.byStrings("note", "tooltipNote"), {searchExports: true, cacheId: "core-FormSwitch"});},
+    get Flux() {return getByKeys(["Store", "connectStores"], {cacheId: "core-Flux"});},
+    get Flex() {return getModule(mod => mod.defaultProps?.direction, {searchExports: true, cacheId: "core-Flex"});},
+    get UseStateFromStores() {return getByStrings(["useStateFromStores"], {searchExports: true, cacheId: "core-UseStateFromStores"});},
+    get i18n() {return getByKeys(["getLocale"], {cacheId: "core-i18n"});}
+}, {
+    get: function(obj, mod) {
+        if (!obj.hasOwnProperty(mod)) return undefined;
+        if (Object.getOwnPropertyDescriptor(obj, mod).get) {
+            const value = obj[mod];
+            delete obj[mod];
+            obj[mod] = value;
+        }
+        
+        return obj[mod];
+    },
+    set: function() {
+        throw new Error("[WebpackModules~common] trying to set module");
+    }
 });
 
 export default DiscordModules;

--- a/src/betterdiscord/modules/notification.jsx
+++ b/src/betterdiscord/modules/notification.jsx
@@ -1,10 +1,11 @@
-import {getBySource, getModule} from "@webpack";
+import {getBySource} from "@webpack";
 import Patcher from "@modules/patcher";
 import React from "@modules/react";
 import Button from "@ui/base/button";
 import Settings from "@modules/settingsmanager";
 import Text from "@ui/base/text";
 import {CircleAlertIcon, InfoIcon, TriangleAlertIcon, CircleCheckIcon} from "lucide-react";
+import DiscordModules from "./discordmodules";
 
 const Icon = ({type}) => {
     switch (type) {
@@ -27,7 +28,7 @@ const Icon = ({type}) => {
 class NotificationUI {
     static notifications = [];
     static setNotifications = null;
-    static patch = getBySource([ "\"Shakeable is shaken when not mounted\"" ], {searchDefault: false})?.Z;
+    static patch = getBySource([ "\"Shakeable is shaken when not mounted\"" ], {cacheID: "core-notification-patch", searchDefault: false})?.Z;
 
     static initialize() {
         Patcher.after("NotificationPatch", this?.patch, "type", (_, __, res) => {
@@ -148,8 +149,6 @@ const PersistentNotificationContainer = React.memo(() => {
     );
 });
 
-const spring = getModule(x => x?.animated?.div);
-
 const NotificationItem = ({notification, position}) => {
     const {
         id,
@@ -182,9 +181,9 @@ const NotificationItem = ({notification, position}) => {
         
     };
 
-    const slideProps = spring.useSpring(getSlideAnimation());
+    const slideProps = DiscordModules.Spring.useSpring(getSlideAnimation());
 
-    const progressProps = spring.useSpring({
+    const progressProps = DiscordModules.Spring.useSpring({
         width: "0%",
         from: {width: "100%"},
         config: {duration},
@@ -208,7 +207,7 @@ const NotificationItem = ({notification, position}) => {
     };
 
     return (
-        <spring.animated.div
+        <DiscordModules.Spring.animated.div
             onMouseEnter={() => setIsPaused(true)}
             onMouseLeave={() => setIsPaused(false)}
             onClick={(e) => {
@@ -259,7 +258,7 @@ const NotificationItem = ({notification, position}) => {
                     ))}
                 </div>
             )}
-            <spring.animated.div
+            <DiscordModules.Spring.animated.div
                 className="bd-notification-progress"
                 style={{
                     ...progressProps,
@@ -271,7 +270,7 @@ const NotificationItem = ({notification, position}) => {
                     }[type]
                 }}
             />
-        </spring.animated.div>
+        </DiscordModules.Spring.animated.div>
     );
 };
 

--- a/src/betterdiscord/modules/updater.js
+++ b/src/betterdiscord/modules/updater.js
@@ -22,9 +22,8 @@ import Notices from "@ui/notices";
 import Modals from "@ui/modals";
 import UpdaterPanel from "@ui/updater";
 import Web from "@data/web";
-import {getByKeys} from "@webpack";
+import DiscordModules from "./discordmodules";
 
-const UserSettingsWindow = getByKeys(["updateAccount"]);
 
 const getJSON = url => {
     return new Promise(resolve => {
@@ -126,7 +125,7 @@ export class CoreUpdater {
                 label: Strings.Notices.moreInfo,
                 onClick: () => {
                     close();
-                    UserSettingsWindow?.open?.("updates");
+                    DiscordModules.UserSettingsWindow?.open?.("updates");
                 }
             }]
         });
@@ -248,7 +247,7 @@ class AddonUpdater {
                 label: Strings.Notices.moreInfo,
                 onClick: () => {
                     close();
-                    UserSettingsWindow?.open?.("updates");
+                    DiscordModules.UserSettingsWindow?.open?.("updates");
                 }
             }]
         });

--- a/src/betterdiscord/ui/base/markdown.jsx
+++ b/src/betterdiscord/ui/base/markdown.jsx
@@ -6,7 +6,7 @@ import {getModule} from "@webpack";
 let DiscordMarkdown, rules;
 
 function setupMarkdown() {
-    DiscordMarkdown = getModule(m => m?.prototype?.render && m.rules);
+    DiscordMarkdown = getModule(m => m?.prototype?.render && m.rules, {cacheId: "core-markdown-DiscordMarkdown"});
     rules = {};
     if (DiscordMarkdown) {
         rules = {

--- a/src/betterdiscord/ui/customcss/mdinstallcss.jsx
+++ b/src/betterdiscord/ui/customcss/mdinstallcss.jsx
@@ -5,17 +5,17 @@ import React from "@modules/react";
 import Settings from "@modules/settingsmanager";
 import Strings from "@modules/strings";
 import {PackageOpenIcon} from "lucide-react";
-import {getModule} from "@webpack";
 import Logger from "@common/logger";
 import NotificationUI from "@modules/notification";
 import Toasts from "@ui/toasts.js";
 import Modals from "@ui/modals.js";
+import DiscordModules from "@modules/discordmodules";
 
 class InstallCSS {
     static activeNotifications = new Map();
 
     static initialize() {
-        const patch = getModule(m => m.defaultRules && m.parse).defaultRules.codeBlock;
+        const patch = DiscordModules.SimpleMarkdownWrapper.defaultRules.codeBlock;
         Patcher.after("InstallCSS", patch, "react", (_, [args], child) => {
             const isEnabled = Settings.get("customcss", "customcss");
             if (!isEnabled) return;

--- a/src/betterdiscord/ui/floatingwindows.js
+++ b/src/betterdiscord/ui/floatingwindows.js
@@ -7,7 +7,7 @@ import FloatingWindowContainer from "./floating/container";
 import {getByDisplayName} from "@webpack";
 
 
-const AppLayerProvider = getByDisplayName("AppLayerProvider");
+const AppLayerProvider = getByDisplayName("AppLayerProvider", {cacheId: "core-floatingwindows-AppLayerProvider"});
 
 let hasInitialized = false;
 export default class FloatingWindows {

--- a/src/betterdiscord/ui/modals.js
+++ b/src/betterdiscord/ui/modals.js
@@ -26,7 +26,7 @@ import ModalStack, {generateKey} from "./modals/stack";
 import {Filters, getMangled, getModule} from "@webpack";
 
 
-const native = getModule(m => m.minimize && m.architecture);
+const native = getModule(m => m.minimize && m.architecture, {cacheId: "core-modals-nativeModal"});
 
 export default class Modals {
 

--- a/src/betterdiscord/ui/modals/addonerrormodal.jsx
+++ b/src/betterdiscord/ui/modals/addonerrormodal.jsx
@@ -12,9 +12,9 @@ import Content from "./content";
 import ModalRoot from "./root";
 import Footer from "./footer";
 import {ChevronRightIcon, PlugIcon, InfoIcon, PaletteIcon} from "lucide-react";
-import {getByKeys} from "@webpack";
+import DiscordModules from "@modules/discordmodules";
 
-const Parser = Object(getByKeys(["defaultRules", "parse"])).defaultRules;
+const Parser = Object(DiscordModules.SimpleMarkdownWrapper).defaultRules;
 const {useState, useCallback, useMemo} = React;
 
 const joinClassNames = (...classNames) => classNames.filter(e => e).join(" ");

--- a/src/betterdiscord/ui/modals/backdrop.jsx
+++ b/src/betterdiscord/ui/modals/backdrop.jsx
@@ -1,12 +1,10 @@
 import clsx from "clsx";
 import React from "@modules/react";
-import {getByKeys} from "@webpack";
-
-const Spring = getByKeys(["useSpring", "animated"]);
+import DiscordModules from "@modules/discordmodules";
 
 
 export default function Backdrop({isVisible, className, onClick}) {
-    const transition = Spring.useTransition(isVisible, {
+    const transition = DiscordModules.Spring.useTransition(isVisible, {
         keys: e => e ? "backdrop" : "empty",
         config: {duration: 300},
         from: {
@@ -26,7 +24,7 @@ export default function Backdrop({isVisible, className, onClick}) {
     return transition((styles, visible) => {
         if (!visible) return null;
 
-        return <Spring.animated.div
+        return <DiscordModules.Spring.animated.div
                 className={clsx("bd-modal-backdrop", className)}
                 style={styles}
                 onClick={onClick}

--- a/src/betterdiscord/ui/modals/changelog.jsx
+++ b/src/betterdiscord/ui/modals/changelog.jsx
@@ -19,7 +19,7 @@ import {getByKeys} from "@webpack";
 const {useMemo} = React;
 
 
-const AnchorClasses = getByKeys(["anchorUnderlineOnHover"]) || {anchor: "anchor-3Z-8Bb", anchorUnderlineOnHover: "anchorUnderlineOnHover-2ESHQB"};
+const AnchorClasses = getByKeys(["anchorUnderlineOnHover"], {cacheId: "core-changelog-AnchorClasses"}) || {anchor: "anchor-3Z-8Bb", anchorUnderlineOnHover: "anchorUnderlineOnHover-2ESHQB"};
 const joinSupportServer = (click) => {
     click.preventDefault();
     click.stopPropagation();

--- a/src/betterdiscord/ui/modals/root.jsx
+++ b/src/betterdiscord/ui/modals/root.jsx
@@ -1,9 +1,9 @@
 import clsx from "clsx";
 import React from "@modules/react";
 import {getByKeys, getModule} from "@webpack";
+import DiscordModules from "@modules/discordmodules";
 
-const Spring = getByKeys(["useSpring", "animated"]);
-const Anims = getByKeys(["Easing"]);
+const Anims = getByKeys(["Easing"], {cacheId: "core-modalroot-Anims"});
 
 
 export const Sizes = Object.freeze({
@@ -19,8 +19,8 @@ export const Styles = Object.freeze({
 });
 
 
-const AccessibilityContext = getModule(m => m?._currentValue?.reducedMotion, {searchExports: true});
-const FocusLock = getModule(m => m?.render?.toString().includes("impressionProperties") && m?.render?.toString().includes(".Provider"), {searchExports: true}) ?? React.Fragment;
+const AccessibilityContext = getModule(m => m?._currentValue?.reducedMotion, {searchExports: true, cacheId: "core-modalsroot-AccessibilityContext"});
+const FocusLock = getModule(m => m?.render?.toString().includes("impressionProperties") && m?.render?.toString().includes(".Provider"), {searchExports: true, cacheId: "core-modalsroot-FocusLock"}) ?? React.Fragment;
 
 export default function ModalRoot({className, transitionState, children, size = Sizes.DYNAMIC, style = Styles.CUSTOM}) {
     const visible = transitionState == 0 || transitionState == 1; // 300 ms
@@ -28,7 +28,7 @@ export default function ModalRoot({className, transitionState, children, size = 
     const preferences = React.useContext(AccessibilityContext ?? {});
     const reducedMotion = preferences?.reducedMotion?.enabled ?? document.documentElement?.classList.contains("reduce-motion");
     
-    const springStyles = Spring.useSpring({
+    const springStyles = DiscordModules.Spring.useSpring({
         opacity: visible ? 1 : 0,
         transform: visible || reducedMotion ? "scale(1)" : "scale(0.7)",
         config: {
@@ -39,12 +39,12 @@ export default function ModalRoot({className, transitionState, children, size = 
     });
 
     return <FocusLock disableTrack={true}>
-        <Spring.animated.div
+        <DiscordModules.Spring.animated.div
                 className={clsx("bd-modal-root", size, className, style)}
                 style={springStyles}
             >
         {children}
-    </Spring.animated.div>
+    </DiscordModules.Spring.animated.div>
     </FocusLock>;
     // const [visible, setVisible] = React.useState(true);
 

--- a/src/betterdiscord/ui/notices.js
+++ b/src/betterdiscord/ui/notices.js
@@ -3,8 +3,8 @@ import {getByKeys} from "@webpack";
 
 
 export default class Notices {
-    static get baseClass() {return this.__baseClass ??= getByKeys(["container", "base", "sidebar"])?.base;}
-    static get errorPageClass() {return this.__errorPageClass ??= getByKeys(["errorPage"])?.errorPage;}
+    static get baseClass() {return this.__baseClass ??= getByKeys(["container", "base", "sidebar"], {cacheId: "core-notices-baseClasses"})?.base;}
+    static get errorPageClass() {return this.__errorPageClass ??= getByKeys(["errorPage"], {cacheId: "core-notices-errorClasses"})?.errorPage;}
 
     /** Shorthand for `type = "info"` for {@link module:Notices.show} */
     static info(content, options = {}) {return this.show(content, Object.assign({}, options, {type: "info"}));}

--- a/src/betterdiscord/ui/settings.js
+++ b/src/betterdiscord/ui/settings.js
@@ -239,7 +239,7 @@ export default new class SettingsRenderer {
     }
 
     forceUpdate() {
-        const viewClass = getByKeys(["standardSidebarView"])?.standardSidebarView.split(" ")[0];
+        const viewClass = getByKeys(["standardSidebarView"], {cacheId: "core-settings-contentClasses"})?.standardSidebarView.split(" ")[0];
         const node = document.querySelector(`.${viewClass}`);
         if (!node) return;
         const stateNode = Utilities.findInTree(ReactUtils.getInternalInstance(node), m => m && m.getPredicateSections, {walkable: ["return", "stateNode"]});

--- a/src/betterdiscord/ui/settings/addoncard.jsx
+++ b/src/betterdiscord/ui/settings/addoncard.jsx
@@ -48,10 +48,10 @@ const LayerManager = {
     }
 };
 
-const UserStore = getByKeys(["getCurrentUser"]);
-const ChannelStore = getByKeys(["getDMFromUserId"]);
-const PrivateChannelActions = getByKeys(["openPrivateChannel"]);
-const ChannelActions = getByKeys(["selectPrivateChannel"]);
+const UserStore = getByKeys(["getCurrentUser"], {cacheId: "core-addoncard-UserStore"});
+const ChannelStore = getByKeys(["getDMFromUserId"], {cacheId: "core-addoncard-ChannelStore"});
+const PrivateChannelActions = getByKeys(["openPrivateChannel"], {cacheId: "core-addoncard-PrivateChannelActions"});
+const ChannelActions = getByKeys(["selectPrivateChannel"], {cacheId: "core-addoncard-ChannelActions"});
 const getString = value => typeof value == "string" ? value : value.toString();
 
 function makeButton(title, children, action, {isControl = false, danger = false, disabled = false} = {}) {

--- a/src/betterdiscord/ui/spinner.jsx
+++ b/src/betterdiscord/ui/spinner.jsx
@@ -2,7 +2,7 @@ import clsx from "clsx";
 import React from "@modules/react";
 import {getModule} from "@webpack";
 
-const AccessibilityContext = getModule(m => m?._currentValue?.reducedMotion, {searchExports: true}) || React.createContext({
+const AccessibilityContext = getModule(m => m?._currentValue?.reducedMotion, {searchExports: true, cacheId: "core-spinner-AccessibilityContext"}) || React.createContext({
     reducedMotion: {enabled: false}
 });
 

--- a/src/betterdiscord/ui/toasts.js
+++ b/src/betterdiscord/ui/toasts.js
@@ -7,8 +7,8 @@ import {getByKeys} from "@webpack";
 
 export default class Toasts {
 
-    static get ChannelsClass() {return getByKeys(["sidebar", "hasNotice"]).sidebar.split(" ")[0];}
-    static get MembersWrapClass() {return getByKeys(["membersWrap"]).membersWrap.split(" ")[0];}
+    static get ChannelsClass() {return getByKeys(["sidebar", "hasNotice"], {cacheId: "core-toasts-sidebarClasses"}).sidebar.split(" ")[0];}
+    static get MembersWrapClass() {return getByKeys(["membersWrap"], {cacheId: "core-toasts-membersClasses"}).membersWrap.split(" ")[0];}
 
     static get shouldShowToasts() {return Settings.get("settings", "general", "showToasts");}
 

--- a/src/betterdiscord/webpack/searching.ts
+++ b/src/betterdiscord/webpack/searching.ts
@@ -1,42 +1,95 @@
+import DataStore from "@modules/datastore";
 import {webpackRequire} from "./require";
 import {getDefaultKey, shouldSkipModule, wrapFilter} from "./shared";
 
-export function getModule<T>(filter: Webpack.Filter, options: Webpack.Options = {}): T | undefined {
+// eslint-disable-next-line no-useless-escape
+const stackPluginRegex = /\/([^\/]+)\.plugin\.js:(\d+):(\d+)/g;
+
+function getIdFromStack() {
+    const stack = new Error().stack!;
+
+    const matches = stack.matchAll(stackPluginRegex);
+    let prev = null;
+    let plugin = null;
+    let discriminator = 0;
+
+    // find the earliest plugin to be in the call stack 
+    for (const match of matches) {
+        if (match[1] != prev) {
+            prev = match[1];
+            plugin = match[1];
+        }
+
+        // adapted from https://gist.github.com/jlevy/c246006675becc446360a798e2b2d781
+        discriminator = (discriminator << 5) - discriminator + parseInt(match[2]);
+        discriminator = (discriminator << 5) - discriminator + parseInt(match[3]);
+    }
+
+    if (!plugin) return;
+    return `${plugin}:${discriminator >>> 0}`;
+}
+
+const cache = DataStore.getWebpackCache();
+
+function getMatched<T>(module: Webpack.Module<any>, filter: Webpack.Filter, options: Webpack.SingleOptions): T | undefined {
     const {defaultExport = true, searchExports = false, searchDefault = true, raw = false} = options;
-    
+
+    if (shouldSkipModule(module.exports)) return;
+
+    if (filter(module.exports, module, module.id)) {
+        return raw ? module as T : module.exports;
+    }
+
+    if (!searchExports && !searchDefault) return;
+
+    let defaultKey: string | undefined;
+    const searchKeys: string[] = [];
+    if (searchExports) searchKeys.push(...Object.keys(module.exports));
+    else if (searchDefault && (defaultKey = getDefaultKey(module))) searchKeys.push(defaultKey);
+
+    for (let i = 0; i < searchKeys.length; i++) {
+        const key = searchKeys[i];
+        const exported = module.exports[key];
+
+        if (shouldSkipModule(exported)) return;
+
+        if (filter(exported, module, module.id)) {
+            if (!defaultExport && defaultKey === key) {
+                return module.exports;
+            }
+
+            if (raw) return module as T;
+            return exported;
+        }
+    }
+}
+
+export function getModule<T>(filter: Webpack.Filter, options: Webpack.SingleOptions = {}): T | undefined {
+    let cacheId = options.cacheId;
+    if(!cacheId) cacheId = getIdFromStack();
+
     filter = wrapFilter(filter);
+
+    // check whether the cached id works
+    if(cacheId && cache[cacheId]) {
+        const id = cache[cacheId];
+        const module = webpackRequire.c[id];
+        
+        const matched = getMatched<T>(module, filter, options);
+        if(matched) return matched;
+    }
 
     const keys = Object.keys(webpackRequire.c);    
     for (let i = 0; i < keys.length; i++) {
         const module = webpackRequire.c[keys[i]];
         
-        if (shouldSkipModule(module.exports)) continue;
-
-        if (filter(module.exports, module, module.id)) {
-            return raw ? module as T : module.exports;
-        }
-
-        if (!searchExports && !searchDefault) continue;
-
-        let defaultKey: string | undefined;
-        const searchKeys: string[] = [];
-        if (searchExports) searchKeys.push(...Object.keys(module.exports));
-        else if (searchDefault && (defaultKey = getDefaultKey(module))) searchKeys.push(defaultKey);
-
-        for (let i = 0; i < searchKeys.length; i++) {
-            const key = searchKeys[i];
-            const exported = module.exports[key];
-
-            if (shouldSkipModule(exported)) continue;
-
-            if (filter(exported, module, module.id)) {
-                if (!defaultExport && defaultKey === key) {
-                    return module.exports;
-                }
-
-                if (raw) return module as T;
-                return exported;
-            }
+        const matched = getMatched<T>(module, filter, options);
+        if(matched) {
+            if(cacheId) {
+                cache[cacheId] = keys[i];
+                DataStore.setWebpackCache(cache);
+            }   
+            return matched;
         }
     }
 

--- a/src/betterdiscord/webpack/stores.ts
+++ b/src/betterdiscord/webpack/stores.ts
@@ -1,3 +1,4 @@
+import DiscordModules from "@modules/discordmodules";
 import { Filters, getModule } from ".";
 
 interface FluxStore {
@@ -42,7 +43,7 @@ type StoreNameType = CommonlyUsedStores | string & { _name_?: "" };
 
 let Flux: { Store: FluxStoreConstructor } | undefined;
 export function getStore(name: StoreNameType): FluxStore | undefined {
-    if (!Flux) Flux = getModule(m => m.Store?.getAll);
+    if (!Flux) Flux = DiscordModules.Flux;
     if (!Flux) return getModule<FluxStore>(Filters.byStoreName(name))!;
 
     return Flux.Store.getAll().find((store: any) => store.getName() === name);

--- a/src/betterdiscord/webpack/types.d.ts
+++ b/src/betterdiscord/webpack/types.d.ts
@@ -25,6 +25,9 @@ declare namespace Webpack {
         raw?: boolean
     };
 
+    type SingleOptions = Options & {
+        cacheId?: string
+    }
     type BulkQueries = Options & {
         filter: Filter,
         all?: boolean
@@ -33,7 +36,7 @@ declare namespace Webpack {
         target?: any
     };
 
-    type LazyOptions = Options & { signal?: AbortSignal };
+    type LazyOptions = SingleOptions & { signal?: AbortSignal };
 
     type ModuleWithEffect = [
         any[],

--- a/src/betterdiscord/webpack/webpack.ts
+++ b/src/betterdiscord/webpack/webpack.ts
@@ -2,7 +2,7 @@ import * as Filters from "./filter";
 import {getAllModules, getModule} from "./searching";
 import { getLazy } from "./lazy";
 
-export function getByKeys<T>(keys: string[], options: Webpack.Options = {}) {
+export function getByKeys<T>(keys: string[], options: Webpack.SingleOptions = {}) {
     return getModule<T>(Filters.byKeys(keys), options);
 }
 export function getAllByKeys<T extends unknown[]>(keys: string[], options: Webpack.Options = {}) {
@@ -12,7 +12,7 @@ export function getLazyByKeys<T>(keys: string[], options: Webpack.Options = {}) 
     return getLazy<T>(Filters.byKeys(keys), options);
 }
 
-export function getByPrototypes<T>(prototypes: string[], options: Webpack.Options = {}) {
+export function getByPrototypes<T>(prototypes: string[], options: Webpack.SingleOptions = {}) {
     return getModule<T>(Filters.byPrototypeKeys(prototypes), options);
 }
 export function getAllByPrototypes<T extends unknown[]>(prototypes: string[], options: Webpack.Options = {}) {
@@ -22,7 +22,7 @@ export function getLazyByPrototypes<T>(prototypes: string[], options: Webpack.Op
     return getLazy<T>(Filters.byPrototypeKeys(prototypes), options);
 }
 
-export function getByStrings<T>(strings: string[], options: Webpack.Options = {}) {
+export function getByStrings<T>(strings: string[], options: Webpack.SingleOptions = {}) {
     return getModule<T>(Filters.byStrings(...strings), options);
 }
 export function getAllByStrings<T extends unknown[]>(strings: string[], options: Webpack.Options = {}) {
@@ -32,7 +32,7 @@ export function getLazyByStrings<T>(strings: string[], options: Webpack.Options 
     return getLazy<T>(Filters.byStrings(...strings), options);
 }
 
-export function getByRegex<T>(regex: RegExp, options: Webpack.Options = {}) {
+export function getByRegex<T>(regex: RegExp, options: Webpack.SingleOptions = {}) {
     return getModule<T>(Filters.byRegex(regex), options);
 }
 export function getAllByRegex<T extends unknown[]>(regex: RegExp, options: Webpack.Options = {}) {
@@ -42,7 +42,7 @@ export function getLazyByRegex<T>(regex: RegExp, options: Webpack.Options = {}) 
     return getLazy<T>(Filters.byRegex(regex), options);
 }
 
-export function getBySource<T>(sources: Array<string | RegExp>, options: Webpack.Options = {}) {
+export function getBySource<T>(sources: Array<string | RegExp>, options: Webpack.SingleOptions = {}) {
     return getModule<T>(Filters.bySource(...sources), options);
 }
 export function getAllBySource<T extends unknown[]>(sources: Array<string | RegExp>, options: Webpack.Options = {}) {
@@ -52,7 +52,7 @@ export function getLazyBySource<T>(sources: Array<string | RegExp>, options: Web
     return getLazy<T>(Filters.bySource(...sources), options);
 }
 
-export function getByDisplayName<T>(name: string, options: Webpack.Options = {}) {
+export function getByDisplayName<T>(name: string, options: Webpack.SingleOptions = {}) {
     return getModule<T>(Filters.byDisplayName(name), options);
 }
 export function getAllByDisplayName<T extends unknown[]>(name: string, options: Webpack.Options = {}) {


### PR DESCRIPTION
This PR adds a cache for webpack module queries, so they run much faster after the first time. Queries by plugins automatically have ids generated based on the stack trace, or they can manually specify them to keep the cache working after updating. Only queries limited to a single module are cached.

From some testing with around 20 plugins this improves plugin load times by around 75% after the first load. Testing it with around 20 plugins dropped plugin launch times from an average of 761ms to 185ms, and from some other testing it appears there is about the same percentage speedup regardless of computer speed.

Additionally, this also exposes the DiscordModules object via BdApi.Webpack.common, and it adds several modules that are widely used.