### PR TITLE
Fix themeattributes.js

### DIFF
--- a/src/betterdiscord/builtins/general/themeattributes.js
+++ b/src/betterdiscord/builtins/general/themeattributes.js
@@ -13,7 +13,7 @@ export default new class ThemeAttributes extends Builtin {
 
     enabled() {
         this.before(MessageComponent, "Z", (thisObject, [args]) => {
-            if (args["aria-roledescription"] !== "Message") return;
+            if (args?.["aria-roledescription"] !== "Message") return;
             const author = findInTree(args, (arg) => arg?.username, {walkable: ["props", "childrenMessageContent", "message", "author"]});
             const authorId = author?.id;
             if (!authorId) return;


### PR DESCRIPTION
Was throwing additional errors on the recovery page due to some message components without the `aria-roledescription` property set 