### PR TITLE
Fix `clearable: true` option

### DIFF
--- a/src/betterdiscord/ui/settings/components/keybind.jsx
+++ b/src/betterdiscord/ui/settings/components/keybind.jsx
@@ -58,6 +58,7 @@ export default function Keybind({value: initialValue, onChange, max = 4, clearab
         event.preventDefault();
         if (disabled) return;
         if (onChange) onChange([]);
+        setValue([]);
         setState({...state, isRecording: false, accum: []});
     }, [onChange, state, disabled]);
 


### PR DESCRIPTION
This fixes the close button not doing anything on `clearable: true` keybinds 