### PR TITLE
Fix fs stat mtime handling and accent color query

### DIFF
--- a/src/betterdiscord/builtins/customcss.js
+++ b/src/betterdiscord/builtins/customcss.js
@@ -80,10 +80,10 @@ export default new class CustomCSS extends Builtin {
                 this.saveCSS("");
             }
             const stats = fs.statSync(this.file);
-            if (!stats || !stats.mtime || !stats.mtime.getTime()) return;
-            if (typeof (stats.mtime.getTime()) !== "number") return;
-            if (timeCache[filename] == stats.mtime.getTime()) return;
-            timeCache[filename] = stats.mtime.getTime();
+            if (!stats || !stats.mtimeMs) return;
+            if (typeof (stats.mtimeMs) !== "number") return;
+            if (timeCache[filename] == stats.mtimeMs) return;
+            timeCache[filename] = stats.mtimeMs;
             if (eventType == "change") {
                 const newCSS = this.loadCSS();
                 if (newCSS == this.savedCss) return;

--- a/src/betterdiscord/modules/addonmanager.ts
+++ b/src/betterdiscord/modules/addonmanager.ts
@@ -141,10 +141,10 @@ export default abstract class AddonManager extends Store {
                 const stats = fs.statSync(absolutePath);
                 // console.log("watcher", stats);
                 if (!stats.isFile()) return;
-                if (!stats || !stats.mtime || !stats.mtime.getTime()) return;
-                if (typeof (stats.mtime.getTime()) !== "number") return;
-                if (this.timeCache[filename] == stats.mtime.getTime()) return;
-                this.timeCache[filename] = stats.mtime.getTime();
+                if (!stats || !stats.mtimeMs) return;
+                if (typeof (stats.mtimeMs) !== "number") return;
+                if (this.timeCache[filename] == stats.mtimeMs) return;
+                this.timeCache[filename] = stats.mtimeMs;
                 if (eventType == "rename") this.loadAddon(filename, true);
                 if (eventType == "change") this.reloadAddon(filename, true);
             }
@@ -385,7 +385,7 @@ export default abstract class AddonManager extends Store {
             const absolutePath = path.resolve(this.addonFolder, filename);
             const stats = fs.statSync(absolutePath);
             if (!stats || !stats.isFile()) continue;
-            this.timeCache[filename] = stats.mtime.getTime();
+            this.timeCache[filename] = stats.mtimeMs;
 
             if (!filename.endsWith(this.extension)) {
                 // Lets check to see if this filename has the duplicated file pattern `something(1).ext`

--- a/src/electron/main/modules/ipc.js
+++ b/src/electron/main/modules/ipc.js
@@ -92,7 +92,8 @@ const setWindowSize = (event, width, height) => {
 
 const getAccentColor = () => {
     // intentionally left blank so that fallback colors will be used
-    return systemPreferences.getAccentColor() || "";
+    return ((process.platform == "win32" || process.platform == "darwin")
+        && systemPreferences.getAccentColor()) || "";
 };
 
 const stopDevtoolsWarning = event => event.sender.removeAllListeners("devtools-opened");


### PR DESCRIPTION
This pull request adds support for newer versions of Electron and NodeJS.
Previously, I couldn't launch BetterDiscord using Electron 34 with Node v22.14.0.
I'm using https://aur.archlinux.org/packages/discord-electron-openasar 

* Use stats.mtimeMs instead of parsed Date -> epoch milliseconds conversion.
stats.mtime gave me errors, I think because it's now lazy computed in the new Node versions.

* Check OS before calling systemPreferences.getAccentColor(), as it isn't supported on Linux.