### PR TITLE
Canary node mtimeMs fix

### DIFF
--- a/src/betterdiscord/modules/addonmanager.ts
+++ b/src/betterdiscord/modules/addonmanager.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import fs from "fs";
+import fs, {stat} from "fs";
 
 import Logger from "@common/logger";
 
@@ -385,7 +385,7 @@ export default abstract class AddonManager extends Store {
             const absolutePath = path.resolve(this.addonFolder, filename);
             const stats = fs.statSync(absolutePath);
             if (!stats || !stats.isFile()) continue;
-            this.timeCache[filename] = stats.mtime.getTime();
+            this.timeCache[filename] = stats.mtimeMs;
 
             if (!filename.endsWith(this.extension)) {
                 // Lets check to see if this filename has the duplicated file pattern `something(1).ext`

--- a/src/betterdiscord/modules/addonmanager.ts
+++ b/src/betterdiscord/modules/addonmanager.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import fs, {stat} from "fs";
+import fs from "fs";
 
 import Logger from "@common/logger";
 


### PR DESCRIPTION
As of recent something was changed in Discord or Electron which removed `mtime`--As of now we do not have any direction on what changed so this will fix Canary