### PR TITLE
Bump package.json version to 1.12.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "betterdiscord",
-    "version": "1.12.1",
+    "version": "1.12.4",
     "description": "Enhances Discord by adding functionality and themes.",
     "type": "module",
     "scripts": {


### PR DESCRIPTION
Whilst the hotfixes have been released, the package version has not been incremented. All that was changed was a bump from 1.12.1 > 1.12.4 (correct as of 7th Wednesday May 2025. 09:20 UTC). 