### PR TITLE
Add restart script to restart discord `bun run restart` with channels support

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "build:betterdiscord": "bun run build --module=betterdiscord",
         "build:production": "NODE_ENV=production bun run build --minify",
         "inject": "bun scripts/inject.js",
+        "restart": "bun scripts/restart.js",
         "lint": "bun run --bun eslint",
         "lint-css": "stylelint src/betterdiscord/styles/*.css && stylelint src/betterdiscord/styles/**/*.css",
         "test": "bun test tests/",

--- a/scripts/restart.js
+++ b/scripts/restart.js
@@ -1,0 +1,64 @@
+const args = process.argv;
+const fs = require("fs");
+const path = require("path");
+const {execSync, spawn} = require("child_process");
+
+const useBdRelease = args[2] && args[2].toLowerCase() === "release";
+const releaseInput = useBdRelease ? args[3] && args[3].toLowerCase() : args[2] && args[2].toLowerCase();
+const release = releaseInput === "canary" ? "Discord Canary" : releaseInput === "ptb" ? "Discord PTB" : "Discord";
+const discordExeName = releaseInput === "canary" ? "DiscordCanary.exe" : releaseInput === "ptb" ? "DiscordPTB.exe" : "Discord.exe";
+
+const discordPath = (function () {
+    let latestExe = "";
+    if (process.platform === "win32") {
+        const basedir = path.join(process.env.LOCALAPPDATA, release.replace(/ /g, ""));
+        if (!fs.existsSync(basedir)) throw new Error(`Cannot find directory for ${release}`);
+        const version = fs.readdirSync(basedir).filter(f => fs.lstatSync(path.join(basedir, f)).isDirectory() && f.split(".").length > 1).sort().reverse()[0];
+        latestExe = path.join(basedir, version, discordExeName);
+    }
+    else {
+        let userData = process.env.XDG_CONFIG_HOME ? process.env.XDG_CONFIG_HOME : path.join(process.env.HOME, ".config");
+        if (process.platform === "darwin") userData = path.join(process.env.HOME, "Library", "Application Support");
+        const basedir = path.join(userData, release.toLowerCase().replace(" ", ""));
+        if (!fs.existsSync(basedir)) return "";
+        const version = fs.readdirSync(basedir).filter(f => fs.lstatSync(path.join(basedir, f)).isDirectory() && f.split(".").length > 1).sort().reverse()[0];
+        if (!version) return "";
+        latestExe = path.join(basedir, version, discordExeName);
+    }
+
+    if (fs.existsSync(latestExe)) return latestExe;
+    return "";
+})();
+console.log("");
+
+console.log(`Stopping ${release}`);
+const killCommand = process.platform === "win32" ? "taskkill /F /IM " + discordExeName : "pkill -f " + discordExeName;
+try {
+    execSync(killCommand, {shell: false, stdio: "ignore"});
+    console.log(`    ✅ Stopped ${release}`);
+}
+catch (error) {
+    if (error.status !== 128) console.log(`    ❌ Failed to stop ${release}`);
+    console.log(`    ❌ Failed to stop ${release}, but it may not be running`);
+}
+console.log("");
+
+console.log(`Searching ${release}`);
+if (!fs.existsSync(discordPath)) throw new Error(`    ❌ Failed to find ${release} executable path`);
+console.log(`    ✅ Found ${release} in ${discordPath}`);
+console.log("");
+
+console.log(`Starting ${release}`);
+const startCommand = process.platform === "win32" ? "cmd.exe" : "open";
+const startArgs = process.platform === "win32" ? ["/c", "start", "", discordPath] : [discordPath];
+try {
+    spawn(startCommand, startArgs, {detached: true, stdio: "ignore"});
+    console.log(`    ✅ Started ${release}`);
+}
+catch (error) {
+    console.log(`    ❌ Failed to start ${release}`);
+    throw error;
+}
+
+console.log("");
+console.log("Restart successful");


### PR DESCRIPTION
As the title says, this pr adds a `restart` script to restart discord.

It supports also an `optional` parameter to specify the which discord channel to restart between `ptb` and `canary`.

Tested only on windows.

I took some of the code for the discord path finding from the `inject` script.