### PR TITLE
Fix user config for flatpak

### DIFF
--- a/injector/src/modules/betterdiscord.js
+++ b/injector/src/modules/betterdiscord.js
@@ -10,11 +10,20 @@ import * as IPCEvents from "common/constants/ipcevents";
 const appPath = electron.app.getAppPath();
 const buildInfoFile = path.resolve(appPath, "..", "build_info.json");
 
-// Locate data path to find transparency settings
-let dataPath = "";
-if (process.platform === "win32" || process.platform === "darwin") dataPath = path.join(electron.app.getPath("userData"), "..");
-else dataPath = process.env.XDG_CONFIG_HOME ? process.env.XDG_CONFIG_HOME : path.join(process.env.HOME, ".config"); // This will help with snap packages eventually
-dataPath = path.join(dataPath, "BetterDiscord") + "/";
+// Windows and macOS both use the fixed global BetterDiscord folder but
+// Electron gives the postfixed version of userData, so go up a directory
+let userConfig = path.join(electron.app.getPath("userData"), "..");
+
+// If we're on Linux there are a couple cases to deal with
+if (process.platform !== "win32" && process.platform !== "darwin") {
+    // Use || instead of ?? because a falsey value of "" is invalid per XDG spec
+    userConfig = process.env.XDG_CONFIG_HOME || path.join(process.env.HOME, ".config");
+
+    // HOST_XDG_CONFIG_HOME is set by flatpak, so use without validation if set
+    if (process.env.HOST_XDG_CONFIG_HOME) userConfig = process.env.HOST_XDG_CONFIG_HOME;
+}
+
+const dataPath = path.join(userConfig, "BetterDiscord") + "/";
 
 let hasCrashed = false;
 export default class BetterDiscord {

--- a/preload/src/discordnativepatch.js
+++ b/preload/src/discordnativepatch.js
@@ -3,10 +3,20 @@ import path from "path";
 
 import * as IPCEvents from "common/constants/ipcevents";
 
-let dataPath = "";
-if (process.platform === "win32" || process.platform === "darwin") dataPath = path.join(electron.ipcRenderer.sendSync(IPCEvents.GET_PATH, "userData"), "..");
-else dataPath = process.env.XDG_CONFIG_HOME ? process.env.XDG_CONFIG_HOME : path.join(process.env.HOME, ".config"); // This will help with snap packages eventually
-dataPath = path.join(dataPath, "BetterDiscord") + "/";
+// Windows and macOS both use the fixed global BetterDiscord folder but
+// Electron gives the postfixed version of userData, so go up a directory
+let userConfig = path.join(electron.ipcRenderer.sendSync(IPCEvents.GET_PATH, "userData"), "..");
+
+// If we're on Linux there are a couple cases to deal with
+if (process.platform !== "win32" && process.platform !== "darwin") {
+    // Use || instead of ?? because a falsey value of "" is invalid per XDG spec
+    userConfig = process.env.XDG_CONFIG_HOME || path.join(process.env.HOME, ".config");
+
+    // HOST_XDG_CONFIG_HOME is set by flatpak, so use without validation if set
+    if (process.env.HOST_XDG_CONFIG_HOME) userConfig = process.env.HOST_XDG_CONFIG_HOME;
+}
+
+const dataPath = path.join(userConfig, "BetterDiscord") + "/";
 
 let _settings;
 function getSetting(category, key) {
@@ -42,7 +52,7 @@ const contextBridge = {
             api.window.USE_OSX_NATIVE_TRAFFIC_LIGHTS = process.platform === "darwin" && process.env.BETTERDISCORD_IN_APP_TRAFFIC_LIGHTS === "false";
 
             api.window.setDevtoolsCallbacks(
-                () => {                    
+                () => {
                     isOpen = true;
                     if (!patchDevtoolsCallbacks) onOpened?.();
                 },
@@ -68,7 +78,7 @@ class DiscordNativePatch {
 
         // If devtools is open
         if (isOpen) {
-            // If you enable it, run the onClsoed function 
+            // If you enable it, run the onClsoed function
             if (value) onClosed?.();
             // If its disabled, run the onOpened function
             else onOpened?.();
@@ -76,11 +86,11 @@ class DiscordNativePatch {
     }
 
     // For native frame
-    // document.body does not exist when this is ran. 
+    // document.body does not exist when this is ran.
     // so we have to wait for it
     static injectCSS() {
         if (process.env.BETTERDISCORD_NATIVE_FRAME === "false") return;
-        
+
         // Have to use `global.` because the file is in node
         const mutationObserver = new global.MutationObserver(() => {
             if (global.document.body) {


### PR DESCRIPTION
Our new install process for Discord flatpak on linux is to use `flatpak override` to grant Discord access to the "global" BetterDiscord install. Flatpak sets the `HOST_XDG_CONFIG_HOME` environment variable that we can use here to distinguish between "global" and "local" installs. 

The only potential issue is this __may break existing flatpak installs__ that were injected with BD by `betterdiscordctl`. I'm not sure how that script handled flatpak.