### PR TITLE
Add a border to the textbox component

### DIFF
--- a/src/betterdiscord/styles/ui/textbox.css
+++ b/src/betterdiscord/styles/ui/textbox.css
@@ -5,7 +5,7 @@
     border-radius: 3px;
     color: var(--text-normal);
     background-color: var(--input-background);
-    border: none;
+    border: 1px solid var(--input-border);
     padding: 10px;
     height: 40px;
 }


### PR DESCRIPTION
BD's textbox has bad contrast since the big Discord update because Discord added a border to their textboxes.

Old:
![Screenshot_20250614_172749](https://github.com/user-attachments/assets/d341e1b6-f112-491e-8585-027c51d51bcf)

New:
![Screenshot_20250614_172859](https://github.com/user-attachments/assets/df76d707-01a5-48e0-86ab-a8457c163087)
