### PR TITLE
Fix addon editor losing focus to Discord UI

### DIFF
--- a/src/betterdiscord/modules/addonmanager.ts
+++ b/src/betterdiscord/modules/addonmanager.ts
@@ -454,9 +454,19 @@ export default abstract class AddonManager extends Store {
             language: this.language
         });
 
+        // Prevent Discord from stealing focus
+        const originalFocus = HTMLElement.prototype.focus;
+        const focusOverride = function() {
+            if (this.closest('.floating-addon-window') || this.closest('#bd-editor')) {
+                return originalFocus.call(this);
+            }
+            return;
+        };
+
         FloatingWindows.open({
             onClose: () => {
                 this.windows.delete(fullPath);
+                HTMLElement.prototype.focus = originalFocus; // Restore normal focus
             },
             onResize: () => {
                 if (!editorRef || !editorRef.current || !editorRef.current.resize!) return;

--- a/src/betterdiscord/modules/addonmanager.ts
+++ b/src/betterdiscord/modules/addonmanager.ts
@@ -463,6 +463,9 @@ export default abstract class AddonManager extends Store {
             return;
         };
 
+        HTMLElement.prototype.focus = focusOverride;
+
+        try {
         FloatingWindows.open({
             onClose: () => {
                 this.windows.delete(fullPath);
@@ -486,5 +489,9 @@ export default abstract class AddonManager extends Store {
             },
             confirmationText: t("Addons.confirmationText", {name: addon.name})
         });
+        } catch (error) {
+            HTMLElement.prototype.focus = originalFocus;
+            throw error;
+        }
     }
 }


### PR DESCRIPTION
When opening the addon editor in a floating window, Discord's UI elements continuously steal focus from the editor, making it impossible to edit addon code.

This PR fixes the issue by temporarily limiting focus changes to elements within the floating window while the editor is open. Normal focus behavior is restored when the editor closes.

Tested with multiple addons and confirmed the editor now maintains focus properly.