### PR TITLE
Fix floating windows losing focus to Discord UI

### DIFF
--- a/src/betterdiscord/ui/floatingwindows.tsx
+++ b/src/betterdiscord/ui/floatingwindows.tsx
@@ -10,6 +10,9 @@ import {getByDisplayName} from "@webpack";
 const AppLayerProvider = getByDisplayName("AppLayerProvider");
 
 let hasInitialized = false;
+let originalFocus = null;
+let activeWindows = 0;
+
 export default class FloatingWindows {
     static initialize() {
         const container = <FloatingWindowContainer />;
@@ -25,6 +28,32 @@ export default class FloatingWindows {
 
     static open(window) {
         if (!hasInitialized) this.initialize();
+        
+        // Override focus to prevent Discord from stealing it from floating windows
+        if (activeWindows === 0 && !originalFocus) {
+            originalFocus = HTMLElement.prototype.focus;
+            HTMLElement.prototype.focus = function() {
+                if (this.closest?.('#floating-windows-layer')) {
+                    return originalFocus.call(this);
+                }
+                return;
+            };
+        }
+        
+        activeWindows++;
+        
+        const originalOnClose = window.onClose;
+        window.onClose = () => {
+            activeWindows--;
+            
+            if (activeWindows === 0 && originalFocus) {
+                HTMLElement.prototype.focus = originalFocus;
+                originalFocus = null;
+            }
+            
+            originalOnClose?.();
+        };
+        
         return Events.emit("open-window", window);
     }
 }


### PR DESCRIPTION
Discord's UI elements continuously steal focus from floating windows (addon editor, detached CSS editor, etc.), making them unusable.

This PR fixes the issue by temporarily overriding focus behavior while floating windows are open, ensuring focus stays within the floating window. Normal focus behavior is restored when all floating windows are closed.

The fix is applied centrally in FloatingWindows rather than individually in each component, making it work for all current and future floating windows.

Tested with all `floatingwindows` editors.