### PR TITLE
Fix and update existing styles

### DIFF
--- a/src/betterdiscord/styles/ui/addonlist.css
+++ b/src/betterdiscord/styles/ui/addonlist.css
@@ -192,7 +192,7 @@
     padding: 4px 6px;
 }
 
-.bd-links .bd-addon-button + .bd-addon-button {
+.bd-links .bd-addon-button:not(:first-child) {
     margin-left: 10px;
 }
 

--- a/src/betterdiscord/styles/ui/bdsettings.css
+++ b/src/betterdiscord/styles/ui/bdsettings.css
@@ -36,16 +36,22 @@
 .bd-select {
     position: relative;
     cursor: pointer;
-    color: var(--text-default);
-    font-size: 14px;
+    color: var(--interactive-normal);
+    /* font-size: 14px; */
     display: flex;
     align-items: center;
     justify-content: space-between;
-    background-color: var(--deprecated-text-input-bg);
-    border: 1px solid var(--deprecated-text-input-border);
-    border-radius: 3px;
-    padding: 5px 5px 5px 0;
+    background-color: var(--input-background);
+    border: 1px solid var(--input-border);
+    border-radius: var(--radius-sm);
+    padding: 8px 12px;
     transition: 150ms ease border-color;
+    font-family: var(--font-primary);
+    font-size: 16px;
+    font-weight: 500;
+    line-height: 1.25;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .bd-select.bd-select-disabled {
@@ -55,7 +61,7 @@
 
 .bd-select:hover,
 .bd-select.menu-open {
-    border-color: var(--background-base-lowest);
+    border-color: var(--input-border);
 }
 
 .bd-select.bd-select-transparent {
@@ -65,7 +71,7 @@
     padding: 0;
 }
 
-.bd-select-value {
+.bd-select-transparent .bd-select-value {
     padding-left: 8px;
 }
 
@@ -76,25 +82,30 @@
 
 .bd-select .bd-select-options {
     position: absolute;
-    background: var(--background-base-lower);
-    border-radius: 0 0 3px 3px;
+    background: var(--background-surface-higher);
+    color: var(--text-secondary);
+    border-radius: var(--radius-sm);
     max-height: 300px;
     min-width: calc(100% + 2px);
     overflow-y: auto;
     box-shadow: rgba(0, 0, 0, 0.3) 0 1px 5px 0;
-    border: 1px solid rgba(0, 0, 0, 0.3);
+    border: 1px solid var(--input-border);
     border-top: 0;
-    margin-top: -1px;
-    margin-left: -1px;
+    margin-top: 8px;
+    margin-left: -12px;
     z-index: 2;
     top: 100%;
 }
 
 .bd-select-transparent .bd-select-options {
-    border: 1px solid rgba(0, 0, 0, 0.3);
+    margin-left: -6px;
+}
+
+/* .bd-select-transparent .bd-select-options {
+    border: 1px solid var(--input-border);
     margin-top: 3px;
     border-radius: 3px;
-}
+} */
 
 .bd-select .bd-select-option {
     padding: 8px 12px;
@@ -103,11 +114,13 @@
 }
 
 .bd-select .bd-select-option:hover {
-    background: rgba(0, 0, 0, 0.1);
+    background: var(--background-modifier-hover);
+    color: var(--interactive-hover);
 }
 
 .bd-select .bd-select-option.selected {
-    background: rgba(0, 0, 0, 0.2);
+    background: var(--background-modifier-selected);
+    color: var(--interactive-active);
 }
 
 .bd-setting-item .bd-select {

--- a/src/betterdiscord/styles/ui/changelog.css
+++ b/src/betterdiscord/styles/ui/changelog.css
@@ -236,6 +236,6 @@
     opacity: 1;
 }
 
-.bd-social + .bd-social {
+.bd-changelog-modal .bd-social:not(:first-child) {
     margin-left: 10px;
 }

--- a/src/betterdiscord/styles/ui/keybind.css
+++ b/src/betterdiscord/styles/ui/keybind.css
@@ -5,9 +5,9 @@
     position: relative;
     min-width: 250px;
     box-sizing: border-box;
-    border-radius: 3px;
-    background-color: hsla(0, calc(var(--saturation-factor, 1)*0%), 0%, .1);
-    border: 1px solid hsla(0, calc(var(--saturation-factor, 1)*0%), 0%, .3);
+    border-radius: var(--radius-sm);
+    background-color: var(--input-background);
+    border: 1px solid var(--input-border);
     padding: 0 4px;
     height: 40px;
     cursor: pointer;
@@ -54,6 +54,10 @@
     padding: 3px 8px;
 }
 
+.bd-keybind-wrap .bd-keybind-record.bd-button-color-red svg {
+    color: var(--interactive-active);
+}
+
 .bd-keybind-clear {
     margin-left: 5px;
     /* background: none!important; */
@@ -70,3 +74,4 @@
     width: 18px !important;
     height: 18px !important;
 }
+

--- a/src/betterdiscord/styles/ui/notices.css
+++ b/src/betterdiscord/styles/ui/notices.css
@@ -25,6 +25,10 @@
     }
 }
 
+#bd-notices {
+    grid-area: notice;
+}
+
 .bd-notice {
     animation: bd-open-notice 400ms ease;
     overflow: hidden;

--- a/src/betterdiscord/ui/modals/changelog.tsx
+++ b/src/betterdiscord/ui/modals/changelog.tsx
@@ -84,7 +84,7 @@ export default function ChangelogModal({transitionState, footer, title, subtitle
     const ChangelogHeader = useMemo(() => <Header justify={Flex.Justify.BETWEEN}>
         <Flex direction={Flex.Direction.VERTICAL}>
             <Text tag="h1" size={Text.Sizes.SIZE_20} strong={true}>{title}</Text>
-            <Text size={Text.Sizes.SIZE_12} color={Text.Colors.HEADER_SECONDARY}>{subtitle}</Text>
+            <Text size={Text.Sizes.SIZE_12} color={Text.Colors.MUTED}>{subtitle}</Text>
         </Flex>
         <CloseButton onClick={onClose} />
     </Header>, [title, subtitle, onClose]);


### PR DESCRIPTION
Updates styles for textboxes, dropdowns, and keybinds to match Discord's newest redesign. Also fixes styling for the changelog and addon cards. Also fixes the location of notices for now.

## Dropdowns

<img width="237" height="185" alt="image" src="https://github.com/user-attachments/assets/80b8bd39-26f5-4917-9cd8-13ab6da64fb4" />

<img width="306" height="277" alt="image" src="https://github.com/user-attachments/assets/f99120e5-ffa1-49a2-9c65-4af19434edc3" />

## Keybinds

<img width="271" height="79" alt="image" src="https://github.com/user-attachments/assets/80e0e5ce-aba6-49d8-aa38-efac77a76547" />

## Textboxes

<img width="270" height="72" alt="image" src="https://github.com/user-attachments/assets/1567cc84-914b-4b9b-84ca-5591df1f6179" />

## Addon Card + Changelog Links

<img width="342" height="69" alt="image" src="https://github.com/user-attachments/assets/ce17ba6c-d19b-47d7-a1c7-772f2a6d16f7" />

<img width="606" height="62" alt="image" src="https://github.com/user-attachments/assets/dd93838f-a979-4b4e-b6bc-51b3299101f4" />

## Notices

<img width="1701" height="144" alt="image" src="https://github.com/user-attachments/assets/c566926d-82f7-4ac5-b819-ca0790ae8e83" />
