### PR TITLE
Fix addon editor & themes editor losing focus to Discord UI

### DIFF
--- a/src/betterdiscord/ui/floatingwindows.tsx
+++ b/src/betterdiscord/ui/floatingwindows.tsx
@@ -10,6 +10,9 @@ import {getByDisplayName} from "@webpack";
 const AppLayerProvider = getByDisplayName("AppLayerProvider");
 
 let hasInitialized = false;
+let originalFocus = null;
+let activeWindows = 0;
+
 export default class FloatingWindows {
     static initialize() {
         const container = <FloatingWindowContainer />;
@@ -25,6 +28,32 @@ export default class FloatingWindows {
 
     static open(window) {
         if (!hasInitialized) this.initialize();
+        
+        // Override focus to prevent Discord from stealing it from floating windows
+        if (activeWindows === 0 && !originalFocus) {
+            originalFocus = HTMLElement.prototype.focus;
+            HTMLElement.prototype.focus = function() {
+                if (this.closest?.('#floating-windows-layer')) {
+                    return originalFocus.call(this);
+                }
+                return;
+            };
+        }
+        
+        activeWindows++;
+        
+        const originalOnClose = window.onClose;
+        window.onClose = () => {
+            activeWindows--;
+            
+            if (activeWindows === 0 && originalFocus) {
+                HTMLElement.prototype.focus = originalFocus;
+                originalFocus = null;
+            }
+            
+            originalOnClose?.();
+        };
+        
         return Events.emit("open-window", window);
     }
 }

--- a/src/betterdiscord/ui/floatingwindows.tsx
+++ b/src/betterdiscord/ui/floatingwindows.tsx
@@ -33,7 +33,7 @@ export default class FloatingWindows {
         if (activeWindows === 0 && !originalFocus) {
             originalFocus = HTMLElement.prototype.focus;
             HTMLElement.prototype.focus = function() {
-                if (this.closest?.('#floating-windows-layer')) {
+                if (this.closest?.("#floating-windows-layer")) {
                     return originalFocus.call(this);
                 }
                 return;


### PR DESCRIPTION
When opening the addon editor or theme editor in a floating window, Discord's UI elements continuously steal focus from the editor, making it impossible to edit.

This PR fixes the issue by temporarily limiting focus changes to elements within the floating window while the editor is open. Normal focus behavior is restored when the editor closes.

Tested with multiple addons and themes and confirmed the editor now maintains focus properly.