### PR TITLE
Small fix for the new notification system to fix some overflow issues

### DIFF
--- a/src/betterdiscord/styles/ui/notifications.css
+++ b/src/betterdiscord/styles/ui/notifications.css
@@ -4,7 +4,6 @@
     padding: 16px;
     z-index: 9999;
     pointer-events: none;
-    display: flex;
 }
 
 #bd-notifications-root>* {
@@ -30,6 +29,8 @@
     margin-bottom: 20px;
     position: relative;
     width: 350px;
+    max-height: 500px;
+    overflow: hidden;
 }
 
 .bd-notification [class*="markdown_"] [class*="paragraph_"]:last-child {
@@ -63,8 +64,8 @@
 .bd-notification-content {
     border-radius: 8px 8px 0 0;
     display: flex;
-    flex-direction: column;
     padding: 16px 40px 0px 16px;
+    padding-right: 5px;
 }
 
 .bd-notification-icon {
@@ -110,10 +111,30 @@
     font-family: var(--font-display);
     font-size: 14px;
     font-weight: 400;
-    line-height: 1.2857142857142858;
-    word-wrap: break-word;
-    word-break: break-word;
+    line-height: 1.29;
+    max-height: 380px;
+    overflow-y: auto;
+    overflow-x: hidden;
+    max-width: 100%;
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    padding-right: 5px;
     overflow-wrap: break-word;
+}
+
+.bd-notification-content-text::-webkit-scrollbar {
+    width: 8px;
+    background: transparent;
+}
+
+.bd-notification-content-text::-webkit-scrollbar-thumb {
+    background: var(--scrollbar-thin-thumb, #202225);
+    border-radius: 8px;
+}
+
+.bd-notification-content-text::-webkit-scrollbar-track {
+    background: transparent;
 }
 
 .bd-notification-close {


### PR DESCRIPTION
This PR consists of a few CSS edits to prevent notification contents from being too tall to read. It also makes them scrollable so that all content can still be read if they are in fact too tall.
(These edits were requested in the development guild by @zrodevkaan)

This is a new PR because I'm actually using a clean branch now, seperate from the previous translation fixes.
I do apologize for my incompetence in using github.