### PR TITLE
further style tweaks

### DIFF
--- a/src/betterdiscord/styles/ui/addonlist.css
+++ b/src/betterdiscord/styles/ui/addonlist.css
@@ -39,7 +39,7 @@
     margin-bottom: 20px;
     border-radius: 5px;
     overflow: hidden;
-    background: var(--background-base-lower);
+    background: var(--bg-surface-raised);
 }
 
 .bd-addon-list.bd-grid-view .bd-addon-card {
@@ -48,7 +48,7 @@
 
 .bd-addon-list .bd-addon-header {
     color: var(--header-primary);
-    background: var(--background-base-lowest);
+    background: var(--background-mod-subtle);
     padding: 16px;
     font-size: 14px;
     line-height: 20px;

--- a/src/betterdiscord/styles/ui/addonstore.css
+++ b/src/betterdiscord/styles/ui/addonstore.css
@@ -5,18 +5,18 @@
     overflow: hidden;
     border-radius: 8px;
     position: relative;
-    background-color: var(--background-base-lowest);
+    background: var(--bg-surface-raised);
     max-width: 320px;
     min-height: 320px;
 }
 
 .theme-dark .bd-addon-store-card {
-    background-color: var(--background-base-lowest);
+    background: var(--bg-surface-raised);
 }
 
 .theme-dark .bd-addon-store-card:hover,
 .theme-dark .bd-addon-store-card:hover .bd-addon-store-card-author-mask {
-    background-color: var(--app-background-frame);
+    background-color: var(--bg-surface-overlay-tmp);
 }
 
 .full-motion .bd-addon-store-card {
@@ -36,11 +36,11 @@
 
 .bd-addon-store-card-author-mask {
     padding: 4px;
-    background-color: var(--background-base-lower);
+    background-color: var(--bg-surface-raised);
 }
 
 .theme-dark .bd-addon-store-card-author-mask {
-    background-color: var(--background-base-lower);
+    background-color: var(--bg-surface-raised);
 }
 
 .full-motion .bd-addon-store-card-author-mask {
@@ -172,8 +172,8 @@
 
 .bd-addon-store-card-tag {
     color: var(--interactive-normal);
-    background: var(--background-base-lowest);
-    border: 1px solid var(--background-base-lower);
+    background: var(--background-mod-subtle);
+    border: 1px solid var(--bg-surface-raised);
     padding: 2px 5px;
     border-radius: 8px;
     transition: border-color 200ms linear, color 200ms linear;
@@ -259,7 +259,7 @@ button.bd-addon-store-card-button {
 .bd-addon-store-card-loading {
     padding: 4px;
     border-radius: 50%;
-    background-color: var(--background-base-lower);
+    background-color: var(--bg-surface-raised);
 }
 
 img:where(.bd-addon-store-card-preview-img, .bd-install-modal-preview-img)[src="https://betterdiscord.app/resources/ui/content_thumbnail.svg"] {

--- a/src/betterdiscord/styles/ui/number.css
+++ b/src/betterdiscord/styles/ui/number.css
@@ -8,7 +8,7 @@
 }
 
 .bd-number-input {
-    width: 35px;
+    box-sizing: border-box;
     padding: 8px 12px;
     background-color: var(--input-background);
     border: 1px solid var(--input-border);
@@ -19,6 +19,10 @@
 
 .bd-number-input:focus-within {
     border-color: var(--bd-brand);
+}
+
+.bd-number-input:not([min][max]) {
+    width: 65px;
 }
 
 .bd-button.bd-number-input-decrement {


### PR DESCRIPTION
Updates the style of the addon cards for the settings and the store, just to fix the background colours being inconsistent with the update. Also fixes the width on the number input. Didn't notice the box-sizing was off before. As it is now, it should have a consistent width if no min or max are set, and dynamic width to fit the content if they are. 

## Store Cards
![Discord_7OwsaR44qD](https://github.com/user-attachments/assets/7877e0d8-91e9-43f9-84ae-6b979bceb85e)
![Discord_Ch2hDr7Fom](https://github.com/user-attachments/assets/bfb05b16-3d2c-4131-81b8-520e9b79a5d6)

## Settings Cards
<img width="756" height="560" alt="Discord_VhdzPLXPXx" src="https://github.com/user-attachments/assets/93052bae-1faf-4348-b65c-9d7d45ca833d" />

