### PR TITLE
Combine plugin/theme toasts into only one toast on startup

### DIFF
--- a/assets/locales/en-us.json
+++ b/assets/locales/en-us.json
@@ -294,7 +294,11 @@
         },
         "tags": "Tags",
         "preview": "Preview",
-        "official": "Official"
+        "official": "Official",
+        "manyEnabled": {
+            "one": "{{count}} {{type}} has been enabled.",
+            "other": "{{count}} {{type}}s have been enabled."
+        }
     },
     "CustomCSS": {
         "confirmationText": "You have unsaved changes to your Custom CSS. Closing this window will lose all those changes.",

--- a/src/betterdiscord/modules/addonmanager.ts
+++ b/src/betterdiscord/modules/addonmanager.ts
@@ -91,7 +91,7 @@ export default abstract class AddonManager extends Store {
     // Subclasses should overload this and modify the addon object as needed to fully load it
     abstract initializeAddon(addon: Addon): AddonError | undefined | void;
 
-    abstract startAddon(idOrAddon: string | Addon): AddonError | undefined | void;
+    abstract startAddon(idOrAddon: string | Addon, shouldToast?: boolean): AddonError | undefined | void;
     abstract stopAddon(idOrAddon: string | Addon): AddonError | undefined | void;
 
     loadState() {
@@ -244,7 +244,7 @@ export default abstract class AddonManager extends Store {
     }
 
     // Subclasses should use the return (if not AddonError) and push to this.addonList
-    loadAddon(filename: string, shouldToast = false): AddonError | false | undefined | void {
+    loadAddon(filename: string, shouldToast = false, startup = false): AddonError | false | undefined | void {
         if (typeof (filename) === "undefined") return;
         let addon;
         try {
@@ -273,7 +273,7 @@ export default abstract class AddonManager extends Store {
         this.trigger("loaded", addon);
 
         if (!this.state[addon.id]) return this.state[addon.id] = false;
-        return this.startAddon(addon);
+        return this.startAddon(addon, !startup);
     }
 
     unloadAddon(idOrFileOrAddon: string | Addon, shouldToast = true, isReload = false) {
@@ -381,6 +381,7 @@ export default abstract class AddonManager extends Store {
         this.loadState();
         const errors = [];
         const files = fs.readdirSync(this.addonFolder);
+        let loaded = 0;
 
         for (const filename of files) {
             const absolutePath = path.resolve(this.addonFolder, filename);
@@ -405,13 +406,14 @@ export default abstract class AddonManager extends Store {
                 // Rename the file and let it go on
                 fs.renameSync(absolutePath, path.resolve(this.addonFolder, newFilename));
             }
-            const addon = this.loadAddon(filename, false);
+            const addon = this.loadAddon(filename, false, true);
             if (addon instanceof AddonError) errors.push(addon);
+            else if (addon !== false) loaded++;
         }
 
         this.saveState();
         this.watchAddons();
-        return errors;
+        return {errors, loaded};
     }
 
     deleteAddon(idOrFileOrAddon: string | Addon) {

--- a/src/betterdiscord/modules/core.ts
+++ b/src/betterdiscord/modules/core.ts
@@ -79,11 +79,11 @@ export default new class Core {
 
         Logger.log("Startup", "Loading Plugins");
         // const pluginErrors = [];
-        const pluginErrors = PluginManager.initialize();
+        const pluginInit = PluginManager.initialize();
 
         Logger.log("Startup", "Loading Themes");
         // const themeErrors = [];
-        const themeErrors = ThemeManager.initialize();
+        const themeInit = ThemeManager.initialize();
 
         Logger.log("Startup", "Initializing Updater");
         Updater.initialize();
@@ -93,7 +93,7 @@ export default new class Core {
 
         // Show loading errors
         Logger.log("Startup", "Collecting Startup Errors");
-        Modals.showAddonErrors({plugins: pluginErrors, themes: themeErrors});
+        Modals.showAddonErrors({plugins: pluginInit.errors, themes: themeInit.errors});
 
         const previousVersion = JsonStore.get("misc", "version");
         if (Config.get("version") !== previousVersion) {

--- a/src/betterdiscord/modules/pluginmanager.ts
+++ b/src/betterdiscord/modules/pluginmanager.ts
@@ -58,9 +58,12 @@ export default new class PluginManager extends AddonManager {
     }
 
     initialize() {
-        const errors = super.initialize();
+        const init = super.initialize();
+        if (init.loaded > 0) {
+            Toasts.show(t("Addons.manyEnabled", {count: init.loaded, type: "plugin"}));
+        }
         this.setupFunctions();
-        return errors;
+        return init;
     }
 
     /* Aliases */
@@ -74,8 +77,8 @@ export default new class PluginManager extends AddonManager {
     unloadPlugin(idOrFileOrAddon: string | Plugin) {return this.unloadAddon(idOrFileOrAddon);}
     loadPlugin(filename: string) {return this.loadAddon(filename);}
 
-    loadAddon(filename: string, shouldCTE = true) {
-        const error = super.loadAddon(filename, shouldCTE);
+    loadAddon(filename: string, shouldCTE = true, startup = false) {
+        const error = super.loadAddon(filename, shouldCTE, startup);
         if (error && shouldCTE) Modals.showAddonErrors({plugins: [error]});
         return error;
     }
@@ -138,11 +141,11 @@ export default new class PluginManager extends AddonManager {
         }
     }
 
-    startAddon(idOrAddon: string | Plugin) {return this.startPlugin(idOrAddon);}
+    startAddon(idOrAddon: string | Plugin, shouldToast = true) {return this.startPlugin(idOrAddon, shouldToast);}
     stopAddon(idOrAddon: string | Plugin) {return this.stopPlugin(idOrAddon);}
     getAddon(id: string) {return this.getPlugin(id);}
 
-    startPlugin(idOrAddon: string | Plugin) {
+    startPlugin(idOrAddon: string | Plugin, shouldToast = true) {
         const addon = typeof (idOrAddon) == "string" ? this.addonList.find(p => p.id == idOrAddon) : idOrAddon;
         if (!addon) return;
         const plugin = addon.instance;
@@ -157,7 +160,7 @@ export default new class PluginManager extends AddonManager {
             return new AddonError(addon.name, addon.filename, t("Addons.enabled", {method: "start()"}), {message: (err as Error).message, stack: (err as Error).stack}, this.prefix);
         }
         this.trigger("started", addon.id);
-        Toasts.show(t("Addons.enabled", {name: addon.name, version: addon.version}));
+        if (shouldToast) Toasts.show(t("Addons.enabled", {name: addon.name, version: addon.version}));
     }
 
     stopPlugin(idOrAddon: string | Plugin) {

--- a/src/betterdiscord/modules/thememanager.ts
+++ b/src/betterdiscord/modules/thememanager.ts
@@ -43,6 +43,14 @@ export default new class ThemeManager extends AddonManager {
 
     addonList: Theme[] = [];
 
+    initialize() {
+        const init = super.initialize();
+        if (init.loaded > 0) {
+            Toasts.show(t("Addons.manyEnabled", {count: init.loaded, type: "theme"}));
+        }
+        return init;
+    }
+
     /* Aliases */
     updateThemeList() {return this.updateList();}
     loadAllThemes() {return this.loadAllAddons();}
@@ -55,8 +63,8 @@ export default new class ThemeManager extends AddonManager {
     loadTheme(filename: string) {return this.loadAddon(filename);}
     reloadTheme(idOrFileOrAddon: string | Theme) {return this.reloadAddon(idOrFileOrAddon);}
 
-    loadAddon(filename: string, shouldCTE = true) {
-        const error = super.loadAddon(filename, shouldCTE);
+    loadAddon(filename: string, shouldCTE = true, startup = false) {
+        const error = super.loadAddon(filename, shouldCTE, startup);
         if (error && shouldCTE) Modals.showAddonErrors({themes: [error]});
         return error;
     }
@@ -75,14 +83,14 @@ export default new class ThemeManager extends AddonManager {
         return addon;
     }
 
-    startAddon(idOrAddon: string | Theme) {return this.addTheme(idOrAddon);}
+    startAddon(idOrAddon: string | Theme, shouldToast = true) {return this.addTheme(idOrAddon, shouldToast);}
     stopAddon(idOrAddon: string | Theme) {return this.removeTheme(idOrAddon);}
 
-    addTheme(idOrAddon: string | Theme) {
+    addTheme(idOrAddon: string | Theme, shouldToast = true) {
         const addon = typeof (idOrAddon) == "string" ? this.addonList.find(p => p.id == idOrAddon) : idOrAddon;
         if (!addon) return;
         DOMManager.injectTheme(addon.slug + "-theme-container", addon.css);
-        Toasts.show(t("Addons.enabled", {name: addon.name, version: addon.version}));
+        if (shouldToast) Toasts.show(t("Addons.enabled", {name: addon.name, version: addon.version}));
     }
 
     removeTheme(idOrAddon: string | Theme) {


### PR DESCRIPTION
Currently when launching BD every plugin and theme individually creates a toast to show that it is enabled, which leads to the user being flooded with potentially dozens of toasts on launch. This PR makes it so that the initial launch only creates up to two toasts which show how many plugins/themes were enabled.

<img width="250" alt="An image showing two toasts" src="https://github.com/user-attachments/assets/5d5106ec-5c1c-4763-b86c-bc4441ac40da" />
