### PR TITLE
Stylize addon toasts and fix notifs + data api

### DIFF
--- a/src/betterdiscord/api/data.ts
+++ b/src/betterdiscord/api/data.ts
@@ -5,15 +5,11 @@ type BaseArgs<Bounded extends boolean> = [
     key: string
 ];
 
-type LoadArgs<Bounded extends boolean> =
-    | BaseArgs<Bounded>
-    | [...BaseArgs<Bounded>, recache: boolean];
-
-
 type SaveArgs<Bounded extends boolean, T> = [
     ...BaseArgs<Bounded>,
     data: T
 ];
+
 
 /**
  * `Data` is a simple utility class for the management of plugin data. An instance is available on {@link BdApi}.
@@ -50,17 +46,14 @@ class Data<Bounded extends boolean> {
      *
      * @param {string} pluginName Name of the plugin loading data
      * @param {string} key Which piece of data to load
-     * @param {boolean} recache forces reload of data from disk if true
      * @returns {any} The stored data
      */
-    load<T>(...args: LoadArgs<Bounded>): T {
+    load<T>(...args: BaseArgs<Bounded>): T {
         if (this.#callerName) {
-            // @ts-expect-error Typescript wants an explaination about my bad code?
-            return JsonStore.getData(this.#callerName, args[0], args[1]);
+            return JsonStore.getData(this.#callerName, args[0]);
         }
 
-        // @ts-expect-error Typescript wants an explaination about my bad code?
-        return JsonStore.getData(args[0], args[1], args[2]);
+        return JsonStore.getData(args[0], args[1]);
     }
 
     /**
@@ -78,7 +71,6 @@ class Data<Bounded extends boolean> {
         const callerName = this.#callerName || args[0];
         return JsonStore.recache(callerName!);
     }
-
 
     /**
      * Deletes a piece of stored data. This is different than saving `null` or `undefined`.

--- a/src/betterdiscord/modules/addonmanager.ts
+++ b/src/betterdiscord/modules/addonmanager.ts
@@ -89,10 +89,7 @@ export default abstract class AddonManager extends Store {
 
         const errors = this.loadAllAddons();
         const numEnabled = Object.values(this.state).filter(b => b).length;
-        if (numEnabled > 0) {
-            Toasts.show(t("Addons.manyEnabled", {count: numEnabled, type: this.prefix}));
-        }
-
+        if (numEnabled > 0) Toasts.show(t("Addons.manyEnabled", {count: numEnabled, type: this.prefix}));
         this.hasInitialized = true;
         return errors;
     }

--- a/src/betterdiscord/modules/pluginmanager.ts
+++ b/src/betterdiscord/modules/pluginmanager.ts
@@ -152,15 +152,13 @@ export default new class PluginManager extends AddonManager {
         catch (err) {
             this.state[addon.id] = false;
             this.trigger("disabled", addon);
-            Toasts.error(t("Addons.couldNotStart", {name: addon.name, version: addon.version}));
+            Toasts.warning(t("Addons.couldNotStart", {name: addon.name, version: addon.version}));
             Logger.stacktrace(this.name, `${addon.name} v${addon.version} could not be started.`, err as Error);
             return new AddonError(addon.name, addon.filename, t("Addons.enabled", {method: "start()"}), {message: (err as Error).message, stack: (err as Error).stack}, this.prefix);
         }
         this.trigger("started", addon.id);
 
-        if (this.hasInitialized) {
-            Toasts.show(t("Addons.enabled", {name: addon.name, version: addon.version}));
-        }
+        if (this.hasInitialized) Toasts.success(t("Addons.enabled", {name: addon.name, version: addon.version}));
     }
 
     stopPlugin(idOrAddon: string | Plugin) {
@@ -172,12 +170,12 @@ export default new class PluginManager extends AddonManager {
         }
         catch (err) {
             this.state[addon.id] = false;
-            Toasts.error(t("Addons.couldNotStop", {name: addon.name, version: addon.version}));
+            Toasts.warning(t("Addons.couldNotStop", {name: addon.name, version: addon.version}));
             Logger.stacktrace(this.name, `${addon.name} v${addon.version} could not be started.`, err as Error);
             return new AddonError(addon.name, addon.filename, t("Addons.enabled", {method: "stop()"}), {message: (err as Error).message, stack: (err as Error).stack}, this.prefix);
         }
         this.trigger("stopped", addon.id);
-        Toasts.show(t("Addons.disabled", {name: addon.name, version: addon.version}));
+        Toasts.error(t("Addons.disabled", {name: addon.name, version: addon.version}));
     }
 
     getPlugin(idOrFile: string) {

--- a/src/betterdiscord/modules/thememanager.ts
+++ b/src/betterdiscord/modules/thememanager.ts
@@ -83,16 +83,14 @@ export default new class ThemeManager extends AddonManager {
         if (!addon) return;
         DOMManager.injectTheme(addon.slug + "-theme-container", addon.css);
 
-        if (this.hasInitialized) {
-            Toasts.show(t("Addons.enabled", {name: addon.name, version: addon.version}));
-        }
+        if (this.hasInitialized) Toasts.success(t("Addons.enabled", {name: addon.name, version: addon.version}));
     }
 
     removeTheme(idOrAddon: string | Theme) {
         const addon = typeof (idOrAddon) == "string" ? this.addonList.find(p => p.id == idOrAddon) : idOrAddon;
         if (!addon) return;
         DOMManager.removeTheme(addon.slug + "-theme-container");
-        Toasts.show(t("Addons.disabled", {name: addon.name, version: addon.version}));
+        Toasts.error(t("Addons.disabled", {name: addon.name, version: addon.version}));
     }
 
     extractCustomProperties(css: string) {

--- a/src/betterdiscord/polyfill/fs.ts
+++ b/src/betterdiscord/polyfill/fs.ts
@@ -35,7 +35,7 @@ export const writeFile = function (path: string, data: string | Uint8Array, opti
     }
 };
 
-export const writeFileSync = function (path: string, data: string | Uint8Array, options: WriteFileOptions & {originalFs: boolean;}) {
+export const writeFileSync = function (path: string, data: string | Uint8Array, options?: WriteFileOptions & {originalFs: boolean;}) {
     Remote.filesystem.writeFile(path, data, options);
 };
 

--- a/src/betterdiscord/stores/json.ts
+++ b/src/betterdiscord/stores/json.ts
@@ -105,15 +105,8 @@ export default new class JsonStore extends Store {
         this.emit();
     }
 
-    getData<T>(pluginName: string, key: string, recache: boolean = false): T {
+    getData<T>(pluginName: string, key: string): T {
         this.#ensurePluginData(pluginName); //       Ensure plugin data, if any, is cached
-        if (recache) {
-            const success = this.recache(pluginName);
-            if (!success) {
-                Logger.err("JsonStore", `Failed to recache data for plugin: ${pluginName}`);
-                throw new Error(`Recache operation failed for plugin: ${pluginName}`);
-            }
-        }
         return this.pluginCache[pluginName][key] as T; // Return blindly to allow falsey values
     }
 

--- a/src/betterdiscord/ui/notifications.tsx
+++ b/src/betterdiscord/ui/notifications.tsx
@@ -176,19 +176,9 @@ const NotificationItem = ({notification}: {notification: Notification;}) => {
             className={`bd-notification bd-notification-${type}`}
         >
             <div className={"bd-notification-content"}>
-                <div className="bd-notification-icon">
-                    {notification.icon ? (
-                        <notification.icon />
-                    ) : (
-                        <Icon type={type} />
-                    )}
-                </div>
-                <div>
-                    <div className="bd-notification-title">
-                        {title}
-                        <span
-                            className={"bd-notification-content-text"}>{React.Children.map(content, m => typeof m === "string"
-                                ? <Markdown>{m}</Markdown> : <ErrorBoundary>{m}</ErrorBoundary>)}</span>
+                <div className="bd-notification-header">
+                    <div className="bd-notification-icon">
+                        {notification.icon ? <ErrorBoundary><notification.icon /></ErrorBoundary> : <Icon type={type} />}
                     </div>
                     {title && <div className="bd-notification-title">{title}</div>}
                 </div>

--- a/src/electron/preload/api/filesystem.ts
+++ b/src/electron/preload/api/filesystem.ts
@@ -9,7 +9,7 @@ export function readFile(path: string, options: object | BufferEncoding = "utf8"
     return fs.readFileSync(path, options);
 }
 
-export function writeFile(path: string, content: string | Uint8Array, options: fs.WriteFileOptions & {originalFs: boolean;}) {
+export function writeFile(path: string, content: string | Uint8Array, options?: fs.WriteFileOptions & {originalFs: boolean;}) {
     if (content instanceof Uint8Array) {
         content = Buffer.from(content);
     }


### PR DESCRIPTION
- Stylizes the addon enable/disable toasts to be green/red to represent the action.
- Switches "could not start/stop" messages to warning toasts
- Fixes notification information being doubled
- Aligns the `load` Data api to sync expectations