### PR TITLE
Extend Data Api + Hooks

### DIFF
--- a/src/betterdiscord/api/data.ts
+++ b/src/betterdiscord/api/data.ts
@@ -10,6 +10,14 @@ type SaveArgs<Bounded extends boolean, T> = [
     data: T
 ];
 
+type OnChangeArgs<Bounded extends boolean, T> = [
+    ...(Bounded extends false ? [pluginName: string] : []),
+    key: string,
+    onChange: (value?: T) => void
+] | [
+    ...(Bounded extends false ? [pluginName: string] : []),
+    onChange: (key: string, value?: T) => void
+];
 
 /**
  * `Data` is a simple utility class for the management of plugin data. An instance is available on {@link BdApi}.
@@ -18,12 +26,11 @@ type SaveArgs<Bounded extends boolean, T> = [
  * @name Data
  */
 class Data<Bounded extends boolean> {
+    #pluginName = "";
 
-    #callerName = "";
-
-    constructor(callerName?: string) {
-        if (!callerName) return;
-        this.#callerName = callerName;
+    constructor(pluginName?: string) {
+        if (!pluginName) return;
+        this.#pluginName = pluginName;
     }
 
     /**
@@ -33,9 +40,9 @@ class Data<Bounded extends boolean> {
      * @param {string} key Which piece of data to store
      * @param {any} data The data to be saved
      */
-    save<T>(...args: SaveArgs<Bounded, T>) {
-        if (this.#callerName) {
-            return JsonStore.setData(this.#callerName, ...(args as unknown as SaveArgs<true, T>));
+    public save<T>(...args: SaveArgs<Bounded, T>) {
+        if (this.#pluginName) {
+            return JsonStore.setData(this.#pluginName, ...(args as unknown as SaveArgs<true, T>));
         }
 
         return JsonStore.setData(...(args as unknown as SaveArgs<false, T>));
@@ -48,9 +55,9 @@ class Data<Bounded extends boolean> {
      * @param {string} key Which piece of data to load
      * @returns {any} The stored data
      */
-    load<T>(...args: BaseArgs<Bounded>): T {
-        if (this.#callerName) {
-            return JsonStore.getData(this.#callerName, args[0]);
+    public load<T>(...args: BaseArgs<Bounded>): T {
+        if (this.#pluginName) {
+            return JsonStore.getData(this.#pluginName, args[0]);
         }
 
         return JsonStore.getData(args[0], args[1]);
@@ -67,9 +74,9 @@ class Data<Bounded extends boolean> {
      * Recache loads can block the filesystem and significantly degrade performance.
      * Use this method only for **debugging or testing purposes**. Avoid frequent recaching in production environments.
      */
-    async recache(...args: Bounded extends true ? [] : [callerName: string]) {
-        const callerName = this.#callerName || args[0];
-        return JsonStore.recache(callerName!);
+    public async recache(...args: Bounded extends true ? [] : [pluginName: string]) {
+        const pluginName = this.#pluginName || args[0];
+        return JsonStore.recache(pluginName!);
     }
 
     /**
@@ -78,16 +85,48 @@ class Data<Bounded extends boolean> {
      * @param {string} pluginName Name of the plugin deleting data
      * @param {string} key Which piece of data to delete.
      */
-    delete(...args: BaseArgs<Bounded>) {
-        if (this.#callerName) {
-            return JsonStore.deleteData(this.#callerName, args[0]);
+    public delete(...args: BaseArgs<Bounded>) {
+        if (this.#pluginName) {
+            return JsonStore.deleteData(this.#pluginName, args[0]);
         }
 
         return JsonStore.deleteData(args[0], args[1]);
     }
 
+    public on<T>(...args: OnChangeArgs<Bounded, T>) {
+        if (this.#pluginName) {
+            if (typeof args[0] === "function") {
+                return JsonStore.addPluginChangeListener(this.#pluginName, args[0]);
+            }
+
+            return JsonStore.addPluginChangeListener(this.#pluginName, args[1], args[0]);
+        }
+
+        if (typeof args[1] === "function") {
+            return JsonStore.addPluginChangeListener(args[0] as string, args[1]);
+        }
+
+        return JsonStore.addPluginChangeListener(args[0] as string, args[2], args[1]);
+    }
+
+    public off(...args: OnChangeArgs<Bounded, unknown>) {
+        if (this.#pluginName) {
+            if (typeof args[0] === "function") {
+                return JsonStore.removePluginChangeListener(this.#pluginName, args[0]);
+            }
+
+            return JsonStore.removePluginChangeListener(this.#pluginName, args[1], args[0]);
+        }
+
+        if (typeof args[1] === "function") {
+            return JsonStore.removePluginChangeListener(args[0] as string, args[1]);
+        }
+
+        return JsonStore.removePluginChangeListener(args[0] as string, args[2], args[1]);
+    }
 }
 
 Object.freeze(Data);
 Object.freeze(Data.prototype);
+
 export default Data;

--- a/src/betterdiscord/api/hooks.ts
+++ b/src/betterdiscord/api/hooks.ts
@@ -1,0 +1,34 @@
+import JsonStore from "@stores/json";
+import {useForceUpdate, useStateFromStores} from "@ui/hooks";
+
+type Falsey = false | 0 | "" | null | undefined | void;
+type IsTruthy<T> = T extends Falsey ? false : true;
+
+type UseDataArgs<Bounded extends boolean> = [
+    ...(Bounded extends false ? [pluginName: string] : []),
+    key: string
+];
+
+class Hooks<CN extends string | undefined = undefined, Bounded extends IsTruthy<CN> = IsTruthy<CN>> {
+    readonly #callerName: CN;
+
+    constructor(callerName?: CN);
+    constructor(callerName: CN) {
+        this.#callerName = callerName;
+    }
+
+    public useStateFromStores = useStateFromStores;
+    public useForceUpdate = useForceUpdate;
+
+    public useData<T>(...args: UseDataArgs<Bounded>) {
+        const callerName = this.#callerName || args.shift();
+
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        return JsonStore.useData<T>(callerName!, args[0]);
+    }
+}
+
+Object.freeze(Hooks);
+Object.freeze(Hooks.prototype);
+
+export default Hooks;

--- a/src/betterdiscord/api/index.ts
+++ b/src/betterdiscord/api/index.ts
@@ -17,6 +17,7 @@ import ContextMenu from "./contextmenu";
 import fetch from "./fetch";
 import Logger from "./logger";
 import CommandAPI from "./commands";
+import Hooks from "./hooks";
 
 import ColorInput from "@ui/settings/components/color";
 import DropdownInput from "@ui/settings/components/dropdown";
@@ -50,6 +51,7 @@ const DataAPI = new Data<false>();
 const DOMAPI = new DOM<false>();
 const ContextMenuAPI = new ContextMenu();
 const CommandsAPI = new CommandAPI<false>();
+const HooksAPI = new Hooks();
 const DefaultLogger = new Logger<false>();
 
 /**
@@ -117,6 +119,7 @@ export default class BdApi {
     static DOM: DOM<false>;
     static Logger: Logger<false>;
     static Commands: CommandAPI<false>;
+    static Hooks: Hooks;
     static React = React;
     static ReactDOM = ReactDOM;
     static version = version;
@@ -145,6 +148,7 @@ export default class BdApi {
         this.DOM = new DOM(pluginName);
         this.Logger = new Logger(pluginName);
         this.Commands = new CommandAPI(pluginName);
+        this.Hooks = new Hooks(pluginName);
 
         bounded.set(pluginName, this);
     }
@@ -244,6 +248,12 @@ BdApi.Net = {fetch};
  * @type Logger
  */
 BdApi.Logger = DefaultLogger;
+
+/**
+ * An instance of {@link Hooks} for react hooks.
+ * @type Hooks
+ */
+BdApi.Hooks = HooksAPI;
 
 Object.freeze(BdApi);
 Object.freeze(BdApi.Net);

--- a/src/betterdiscord/api/utils.ts
+++ b/src/betterdiscord/api/utils.ts
@@ -2,6 +2,7 @@ import clsx from "clsx";
 import {comparator} from "@structs/semver";
 import {debounce, extend, findInTree, getNestedProp} from "@common/utils";
 import {forceLoad} from "@webpack";
+import Store from "@stores/base";
 
 
 /**
@@ -96,6 +97,8 @@ const Utils = {
      * @returns {number} 0 indicates equal, -1 indicates left hand greater, 1 indicates right hand greater
      */
     semverCompare: comparator,
+
+    Store
 } as const;
 
 // https://stackoverflow.com/questions/58434389/typescript-deep-keyof-of-a-nested-object/58436959#58436959

--- a/src/betterdiscord/modules/addonmanager.ts
+++ b/src/betterdiscord/modules/addonmanager.ts
@@ -71,7 +71,7 @@ export default abstract class AddonManager extends Store {
 
     trigger(event: string, ...args: any[]) {
         // Emit the events as a store for react
-        super.emit();
+        super.emitChange();
 
         // Emit the events as a normal emitter while other parts
         // of the codebase are still converting to stores

--- a/src/betterdiscord/modules/commandmanager.tsx
+++ b/src/betterdiscord/modules/commandmanager.tsx
@@ -3,8 +3,8 @@ import React from "@modules/react";
 import pluginmanager from "./pluginmanager";
 import Logger from "@common/logger";
 import {Filters, getByStrings, getModule, getStore, getWithKey, modules} from "@webpack";
-import type {FluxStore} from "../types/discord/modules";
-import type {Channel, Guild} from "../types/discord/structs";
+import type {FluxStore} from "discord/modules";
+import type {Channel, Guild} from "discord/structs";
 
 // TODO: create better types for this file, too many "any"
 

--- a/src/betterdiscord/stores/base.ts
+++ b/src/betterdiscord/stores/base.ts
@@ -1,38 +1,22 @@
 export default abstract class Store {
-    static stores = new Set<Store>();
-    static getStore<T extends Store = Store>(name: string) {
-        for (const store of Store.stores) {
-          if (Store.prototype.getName.call(store) === name) return store as T;
-        }
-    }
-    
-    
-    constructor() {
-        Store.stores.add(this);
-    }
-    
-    initialize(): void {}
+    public initialize(): void {}
 
-    displayName?: string;
-    getName() {
-        if (this.displayName) return this.displayName;
-        return this.constructor.name;
-    }
-    
-      
     #listeners = new Set<() => void>();
-    addChangeListener(callback: () => void) {
+    public addChangeListener(callback: () => void) {
         this.#listeners.add(callback);
         return () => this.removeChangeListener(callback);
     }
 
-    removeChangeListener(callback: () => void) {
+    public removeChangeListener(callback: () => void) {
         this.#listeners.delete(callback);
     }
-    
-    emit() {
+
+    public emitChange() {
         for (const listener of this.#listeners) {
             listener();
         }
     }
 }
+
+Object.freeze(Store);
+Object.freeze(Store.prototype);

--- a/src/betterdiscord/stores/config.ts
+++ b/src/betterdiscord/stores/config.ts
@@ -25,7 +25,7 @@ export default new class ConfigStore extends Store {
 
     set(id: keyof typeof this.data, value: string) {
         this.data[id] = value;
-        this.emit();
+        this.emitChange();
     }
 
     get isDevelopment() {return this.data.build !== "production";}

--- a/src/betterdiscord/stores/editor.ts
+++ b/src/betterdiscord/stores/editor.ts
@@ -51,7 +51,7 @@ export default new class EditorStore extends Store {
             discordTheme: Stores.ThemeStore?.theme || "dark"
         });
 
-        this.emit();
+        this.emitChange();
     }
 
     getEditorOptions() {

--- a/src/betterdiscord/stores/json.ts
+++ b/src/betterdiscord/stores/json.ts
@@ -3,12 +3,13 @@ import path from "path";
 import Store from "./base";
 import Config from "./config";
 import Logger from "@common/logger";
+import {useInsertionEffect, useState} from "react";
 
 
 export type Files = "settings" | "plugins" | "themes" | "misc" | "addon-store";
 
 export default new class JsonStore extends Store {
-    cache: Record<Files, Record<string, unknown> | undefined> = {
+    private cache: Record<Files, Record<string, unknown> | undefined> = {
         "settings": undefined,
         "plugins": undefined,
         "themes": undefined,
@@ -16,20 +17,24 @@ export default new class JsonStore extends Store {
         "addon-store": undefined
     };
 
-    pluginCache: Record<string, Record<string, unknown>> = {};
+    private pluginCache: Record<string, Record<string, unknown>> = {};
+    private pluginListeners = new Map<string, {
+        keys: Map<string, Set<(newData?: unknown) => void>>,
+        all: Set<(key: string, newData?: unknown) => void>;
+    }>();
 
     // Normal BD data
-    get(file: Files): Record<string, unknown>;
-    get(file: Files, key: string): unknown;
-    get(file: Files, key?: string) {
+    public get(file: Files): Record<string, unknown>;
+    public get(file: Files, key: string): unknown;
+    public get(file: Files, key?: string) {
         this.cache[file] = this.#ensureData(file);
         if (typeof key === "undefined") return this.cache[file] ?? {};
         return this.cache[file][key] ?? "";
     }
 
-    set(file: Files, key: Record<string, unknown>): void;
-    set(file: Files, key: string, value: unknown): void;
-    set(file: Files, key: Record<string, unknown> | string, value?: unknown) {
+    public set(file: Files, key: Record<string, unknown>): void;
+    public set(file: Files, key: string, value: unknown): void;
+    public set(file: Files, key: Record<string, unknown> | string, value?: unknown) {
         this.cache[file] = this.#ensureData(file);
         if (typeof value === "undefined") {
             if (typeof key === "string") throw new Error("Cannot save string as JSON");
@@ -43,7 +48,7 @@ export default new class JsonStore extends Store {
         this.#save(file);
     }
 
-    delete(file: Files, key: string) {
+    public delete(file: Files, key: string) {
         this.cache[file] = this.#ensureData(file);
         delete this.cache[file][key];
         this.#save(file);
@@ -63,7 +68,7 @@ export default new class JsonStore extends Store {
 
     #save(file: Files) {
         fs.writeFileSync(path.resolve(Config.get("channelPath"), `${file}.json`), JSON.stringify(this.cache[file], null, 4));
-        this.emit();
+        this.emitChange();
     }
 
     // Plugin data
@@ -87,40 +92,163 @@ export default new class JsonStore extends Store {
         }
     }
 
-    recache(pluginName: string) {
+    public recache(pluginName: string) {
         this.#ensurePluginData(pluginName);
+        const before = this.pluginCache[pluginName];
+
         try {
             this.pluginCache[pluginName] = JSON.parse(fs.readFileSync(this.#getPluginFile(pluginName)).toString());
-            this.emit();
+            this.emitChange();
             return true;
         }
         catch (err) {
             Logger.err("JsonStore", "recache: ", err);
             return false;
         }
+        finally {
+            const after = this.pluginCache[pluginName];
+
+            const beforeKeys = Object.keys(before);
+            const afterKeys = Object.keys(after);
+
+            const beforeSet = new Set(beforeKeys);
+            const afterSet = new Set(afterKeys);
+
+            const result: {
+                deleted: string[];
+                changed: string[];
+            } = {
+                deleted: [],
+                changed: []
+            };
+
+            for (const k of beforeSet) {
+                if (afterSet.has(k)) result.changed.push(k);
+                else result.deleted.push(k);
+            }
+
+            for (const k of afterSet) {
+                if (!beforeSet.has(k)) {
+                    result.changed.push(k);
+                }
+            }
+
+            for (const key of result.changed) {
+                this.emitPluginChangeListeners(pluginName, key, after[key]);
+            }
+
+            for (const key of result.deleted) {
+                this.emitPluginChangeListeners(pluginName, key);
+            }
+        }
     }
 
     #savePluginData(pluginName: string) {
         fs.writeFileSync(this.#getPluginFile(pluginName), JSON.stringify(this.pluginCache[pluginName], null, 4));
-        this.emit();
+        this.emitChange();
     }
 
-    getData<T>(pluginName: string, key: string): T {
+    public getData<T>(pluginName: string, key: string): T {
         this.#ensurePluginData(pluginName); //       Ensure plugin data, if any, is cached
         return this.pluginCache[pluginName][key] as T; // Return blindly to allow falsey values
     }
 
-    setData(pluginName: string, key: string, value: unknown) {
+    public useData<T>(pluginName: string, key: string): T {
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        const [state, setState] = useState(() => this.getData<T>(pluginName, key));
+
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        useInsertionEffect(() => {
+            const listener = () => setState(() => this.getData<T>(pluginName, key));
+
+            listener();
+
+            return this.addPluginChangeListener(pluginName, listener, key);
+        }, []);
+
+        return state;
+    }
+
+    public setData(pluginName: string, key: string, value: unknown) {
         if (value === undefined) return; // Can't set undefined, use deletePluginData
         this.#ensurePluginData(pluginName); // Ensure plugin data, if any, is cached
 
         this.pluginCache[pluginName][key] = value;
         this.#savePluginData(pluginName);
+        this.emitPluginChangeListeners(pluginName, key, value);
     }
 
-    deleteData(pluginName: string, key: string) {
+    public deleteData(pluginName: string, key: string) {
         this.#ensurePluginData(pluginName); // Ensure plugin data, if any, is cached
         delete this.pluginCache[pluginName][key];
         this.#savePluginData(pluginName);
+        this.emitPluginChangeListeners(pluginName, key);
+    }
+
+    private emitPluginChangeListeners(pluginName: string, key: string, newData?: unknown) {
+        if (!this.pluginListeners.has(pluginName)) return;
+
+        const pluginListeners = this.pluginListeners.get(pluginName)!;
+
+        for (const element of pluginListeners.all) {
+            // So plugins can do arguments.length === 1 to see if it was a delete
+            if (arguments.length === 3) {
+                element(key, newData);
+            }
+            else {
+                element(key);
+            }
+        }
+
+        if (!pluginListeners.keys.has(key)) return;
+
+        const listeners = pluginListeners.keys.get(key)!;
+
+        for (const element of listeners) {
+            // So plugins can do arguments.length === 0 to see if it was a delete
+            if (arguments.length === 3) {
+                element(newData);
+            }
+            else {
+                element();
+            }
+        }
+    }
+
+    public addPluginChangeListener(pluginName: string, callback: any, key?: string | undefined) {
+        if (!this.pluginListeners.has(pluginName)) {
+            this.pluginListeners.set(pluginName, {
+                keys: new Map(),
+                all: new Set()
+            });
+        }
+
+        const listeners = this.pluginListeners.get(pluginName)!;
+
+        if (typeof key === "string") {
+            if (!listeners.keys.has(key)) listeners.keys.set(key, new Set());
+
+            const keyListeners = listeners.keys.get(key)!;
+            keyListeners.add(callback);
+
+            return () => void keyListeners.delete(callback);
+        }
+
+        listeners.all.add(callback);
+        return () => void listeners.all.delete(callback);
+    }
+    public removePluginChangeListener(pluginName: string, callback: any, key?: string | undefined) {
+        if (!this.pluginListeners.has(pluginName)) return;
+
+        const listeners = this.pluginListeners.get(pluginName)!;
+
+        if (typeof key === "string") {
+            if (!listeners.keys.has(key)) return;
+
+            listeners.keys.get(key)!.delete(callback);
+            return;
+        }
+
+        listeners.all.delete(callback);
     }
 };

--- a/src/betterdiscord/stores/notifications.ts
+++ b/src/betterdiscord/stores/notifications.ts
@@ -6,17 +6,17 @@ export default new class Notifications extends Store {
 
     setNotifications(notifications: Notification[]) {
         this.notificationsArray = notifications;
-        this.emit();
+        this.emitChange();
     }
 
     removeNotification(id: string) {
         this.notificationsArray = this.notificationsArray.filter((n: Notification) => n.id !== id);
-        this.emit();
+        this.emitChange();
     }
 
     addNotification(notification: Notification) {
         this.notificationsArray.push(notification);
-        this.emit();
+        this.emitChange();
     }
 
     get notifications(): Notification[] {

--- a/src/betterdiscord/stores/settings.ts
+++ b/src/betterdiscord/stores/settings.ts
@@ -231,7 +231,7 @@ export default new class SettingsManager extends Store {
     onSettingChange(collection: string, category: string, id: string, value: unknown) {
         this.state[collection][category][id] = value;
         Events.dispatch("setting-updated", collection, category, id, value);
-        this.emit();
+        this.emitChange();
         this.saveCollection(collection);
     }
 

--- a/src/betterdiscord/stores/toasts.ts
+++ b/src/betterdiscord/stores/toasts.ts
@@ -20,7 +20,7 @@ export default new class Toasts extends Store {
 
     private addToast(toast: ToastProps) {
         this._toasts = [...this._toasts, toast];
-        this.emit();
+        this.emitChange();
 
         setTimeout(() => {
             this.removeToast(toast.key);
@@ -29,7 +29,7 @@ export default new class Toasts extends Store {
 
     private removeToast(key: number) {
         this._toasts = this._toasts.filter(toast => toast.key !== key);
-        this.emit();
+        this.emitChange();
     }
 
     get toasts(): ToastProps[] {

--- a/src/betterdiscord/ui/customcss/editor.tsx
+++ b/src/betterdiscord/ui/customcss/editor.tsx
@@ -8,7 +8,7 @@ import Button from "../base/button";
 import Flex from "../base/flex";
 import Switch from "../settings/components/switch";
 import Text from "@ui/base/text";
-import {useInternalStore} from "@ui/hooks";
+import {useStateFromStores} from "@ui/hooks";
 import {useLayoutEffect, useRef} from "react";
 
 import type {editor as MonacoEditor} from "monaco-editor";
@@ -66,7 +66,7 @@ export default forwardRef(function CodeEditor({value, language: requestedLang = 
 
     const [selection, setSelection] = useState<[line: number, col: number, selected: number]>([0, 0, 0]);
     const [markerInfo, setInfo] = useState<[errors: number, warnings: number, markers: any[]]>([0, 0, []]);
-    const {insertSpaces, tabSize} = useInternalStore(Settings, () => ({
+    const {insertSpaces, tabSize} = useStateFromStores(Settings, () => ({
         insertSpaces: Settings.get<boolean>("settings", "editor", "insertSpaces"),
         tabSize: Settings.get<number>("settings", "editor", "tabSize")
     }));

--- a/src/betterdiscord/ui/misc/versioninfo.tsx
+++ b/src/betterdiscord/ui/misc/versioninfo.tsx
@@ -5,9 +5,8 @@ import {t} from "@common/i18n";
 import thememanager from "@modules/thememanager";
 import settings from "@stores/settings";
 import Text from "@ui/base/text";
-import {useInternalStore} from "@ui/hooks";
+import {useStateFromStores} from "@ui/hooks";
 import getDebugInfo, {getAddonCounts, getCoreInfo, getDiscordInfo} from "@utils/debug";
-import {shallowEqual} from "fast-equals";
 
 const {useMemo, useState, useCallback} = React;
 
@@ -19,7 +18,7 @@ export default function VersionInfo() {
     const [clicks, setClicked] = useState(0);
 
     const currentUser = useMemo(() => DiscordModules.UserStore?.getCurrentUser()?.id, []);
-    const isCanary = useInternalStore(settings, () => settings.get("developer", "canary"));
+    const isCanary = useStateFromStores(settings, () => settings.get("developer", "canary"));
 
     const discordInfo = useMemo(() => {
         const info = getDiscordInfo(false) as string[];
@@ -40,8 +39,8 @@ export default function VersionInfo() {
         setTimeout(() => setClicked(0), 250);
     }, []);
 
-    const pluginCount = useInternalStore(pluginmanager, () => getAddonCounts(pluginmanager), [], shallowEqual);
-    const themeCount = useInternalStore(thememanager, () => getAddonCounts(thememanager), [], shallowEqual);
+    const pluginCount = useStateFromStores(pluginmanager, () => getAddonCounts(pluginmanager), [], true);
+    const themeCount = useStateFromStores(thememanager, () => getAddonCounts(thememanager), [], true);
 
     const tooltip = useMemo(() => {
         if (clicks === 0) return "Click to copy";

--- a/src/betterdiscord/ui/notifications.tsx
+++ b/src/betterdiscord/ui/notifications.tsx
@@ -7,8 +7,7 @@ import {CircleAlertIcon, CircleCheckIcon, InfoIcon, TriangleAlertIcon} from "luc
 import DOMManager from "@modules/dommanager";
 import DiscordModules from "@modules/discordmodules";
 import type {MouseEvent, ReactNode} from "react";
-import {useInternalStore} from "@ui/hooks.ts";
-import {shallowEqual} from "fast-equals";
+import {useStateFromStores} from "@ui/hooks.ts";
 import Markdown from "@ui/base/markdown.tsx";
 import ErrorBoundary from "@ui/errorboundary.tsx";
 
@@ -120,8 +119,8 @@ class NotificationUI {
 }
 
 const PersistentNotificationContainer = () => {
-    const notifications = useInternalStore<Notification[]>(Notifications, () => Notifications.notifications.concat(), [], shallowEqual);
-    const position: string = useInternalStore(Settings, () => Settings.get("settings", "general", "notificationPosition"));
+    const notifications = useStateFromStores<Notification[]>(Notifications, () => Notifications.notifications.concat(), [], true);
+    const position: string = useStateFromStores(Settings, () => Settings.get("settings", "general", "notificationPosition"));
 
     return (
         <div

--- a/src/betterdiscord/ui/settings/addonlist.tsx
+++ b/src/betterdiscord/ui/settings/addonlist.tsx
@@ -18,8 +18,7 @@ import {buildDirectionOptions, makeBasicButton, getState, saveState, AddonHeader
 import Settings from "@stores/settings";
 import Text from "@ui/base/text";
 import {CheckIcon, ChevronRightIcon, FolderIcon, LayoutGridIcon, StoreIcon, StretchHorizontalIcon, XIcon} from "lucide-react";
-import {useInternalStore} from "@ui/hooks";
-import {shallowEqual} from "fast-equals";
+import {useStateFromStores} from "@ui/hooks";
 import {type Addon} from "@modules/addonmanager";
 import type AddonManager from "@modules/addonmanager"; // eslint-disable-line no-duplicate-imports
 import type {Plugin} from "@modules/pluginmanager";
@@ -134,8 +133,8 @@ export default function AddonList({title, store}: {title: string; store: AddonMa
     const [view, setView] = useState<ViewTypes>(getState.bind(null, store.prefix, "view", "list"));
 
 
-    const addonList = useInternalStore(store, () => store.addonList.concat(), [store], shallowEqual);
-    const addonState = useInternalStore(store, () => Object.assign({}, store.state), [store], shallowEqual);
+    const addonList = useStateFromStores(store, () => store.addonList.concat(), [store], true);
+    const addonState = useStateFromStores(store, () => Object.assign({}, store.state), [store], true);
 
     const onChange = useCallback((id: string) => {
         store.toggleAddon(id);

--- a/src/betterdiscord/ui/settings/group.tsx
+++ b/src/betterdiscord/ui/settings/group.tsx
@@ -14,7 +14,7 @@ import Filepicker from "./components/file";
 import Button, {type ButtonProps} from "../base/button";
 import Position from "@ui/settings/components/position";
 import {SettingsContext} from "@ui/contexts";
-import {useInternalStore} from "@ui/hooks";
+import {useStateFromStores} from "@ui/hooks";
 import SettingsStore from "@stores/settings";
 import type {Setting, SettingItem} from "@data/settings";
 import type {PropsWithChildren, ReactNode} from "react";
@@ -31,7 +31,7 @@ function SettingsProvider({collection, category, id, children}: PropsWithChildre
         };
     }, [collection, category, id]);
 
-    const settingState = useInternalStore(SettingsStore, getSettingState);
+    const settingState = useStateFromStores(SettingsStore, getSettingState);
 
     // Only recreate context value when data actually changes
     const context = React.useMemo(() => settingState, [settingState]);

--- a/src/betterdiscord/ui/toasts.tsx
+++ b/src/betterdiscord/ui/toasts.tsx
@@ -4,7 +4,7 @@ import DOMManager from "@modules/dommanager";
 import ReactDOM from "@modules/reactdom";
 import ToastStore from "@stores/toasts";
 import ToastIcon from "@ui/toasts/ToastIcon";
-import {useInternalStore} from "@ui/hooks";
+import {useStateFromStores} from "@ui/hooks";
 
 import clsx from "clsx";
 import type {Root} from "react-dom/client";
@@ -39,7 +39,7 @@ export function Toast({content, type, icon, style}: ToastItemProps) {
 }
 
 export function ToastContainer() {
-    const toasts = useInternalStore(ToastStore, () => ToastStore.toasts);
+    const toasts = useStateFromStores(ToastStore, () => ToastStore.toasts);
 
     const transition = ReactSpring.useTransition(toasts, {
         keys: (toast: ToastProps) => toast.key,


### PR DESCRIPTION
Adds `Data.on` / `Data.off` for subscribing to data changes

Adds `Utils.Store` so plugins can easily create stores to use with `Hooks.useStateFromStores`

Adds a new Hooks namespace. It includes
- `useStateFromStores` A pretty close 1 to 1 version of discords own Flux useStateFromStores. It allows you to subscribe to discord flux stores and bd util stores
- `useData` for using data within a react component
- `useForceUpdate` a small util to allow you to force update functional components