### PR TITLE
add `data-speaking` attribute to VoiceUser

### DIFF
--- a/src/betterdiscord/builtins/general/themeattributes.ts
+++ b/src/betterdiscord/builtins/general/themeattributes.ts
@@ -12,6 +12,7 @@ export default new class ThemeAttributes extends Builtin {
 
     async enabled() {
         const MessageComponent = await getLazyBySource([".messageListItem"]);
+        const VoiceUserComponent = await getLazyBySource(["avatarContainerClass", ".iconPriortySpeaker"]);
         this.after(MessageComponent?.ZP, "type", (thisObject, [args], returnValue) => {
             const li = findInTree(returnValue, (node) => node?.className?.includes("messageListItem"));
             if (!li) return;
@@ -28,6 +29,11 @@ export default new class ThemeAttributes extends Builtin {
         this.after(UserProfileComponent, "render", (thisObject, [{user}], returnValue) => {
             returnValue.props["data-member-id"] = user.id;
             returnValue.props["data-is-self"] = !!user.email;
+        });
+        this.after(VoiceUserComponent, "ZP", (thisObject, [{speaking}], returnValue) => {
+            const VoiceUser = findInTree(returnValue, (node) => node?.attributes, {walkable: ["ref", "current"]});
+            if (!VoiceUser) return;
+            VoiceUser.dataset.speaking = speaking;
         });
     }
 


### PR DESCRIPTION
I think they removed the utility class for this. Just adding an attribute to replace it. findInTree probably unnecessary, but I like 

<img width="803" height="261" alt="image" src="https://github.com/user-attachments/assets/1fd20ac4-e01c-49a8-9a51-bf57e103f653" />
