### PR TITLE
refresh cache when checking for addon updates

### DIFF
--- a/src/betterdiscord/modules/updater.ts
+++ b/src/betterdiscord/modules/updater.ts
@@ -280,7 +280,8 @@ export class AddonUpdater {
         this.pending.splice(0, this.pending.length);
     }
 
-    checkAll(showNotice = true) {
+    async checkAll(showNotice = true) {
+        await this.updateCache();
         for (const addon of this.manager.addonList) this.checkForUpdate(addon.filename, addon.version);
         if (showNotice) this.showUpdateNotice();
     }


### PR DESCRIPTION
Refreshes the updater cache when checking for updates, so that were not constantly comparing against the same data after init 😠 