### PR TITLE
Improve the addon system

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "betterdiscord",
@@ -37,13 +36,13 @@
     },
   },
   "packages": {
-    "@babel/code-frame": ["@babel/code-frame@7.26.2", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.25.9", "js-tokens": "^4.0.0", "picocolors": "^1.0.0" } }, "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ=="],
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
-    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.25.9", "", {}, "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ=="],
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
     "@csstools/selector-specificity": ["@csstools/selector-specificity@2.2.0", "", { "peerDependencies": { "postcss-selector-parser": "^6.0.10" } }, "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw=="],
 
-    "@electron/asar": ["@electron/asar@3.2.18", "", { "dependencies": { "commander": "^5.0.0", "glob": "^7.1.6", "minimatch": "^3.0.4" }, "bin": { "asar": "bin/asar.js" } }, "sha512-2XyvMe3N3Nrs8cV39IKELRHTYUWFKrmqqSY1U+GMlc0jvqjIVnoxhNd2H4JolWQncbJi1DCvb5TNxZuI2fEjWg=="],
+    "@electron/asar": ["@electron/asar@3.4.1", "", { "dependencies": { "commander": "^5.0.0", "glob": "^7.1.6", "minimatch": "^3.0.4" }, "bin": { "asar": "bin/asar.js" } }, "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA=="],
 
     "@electron/get": ["@electron/get@2.0.3", "", { "dependencies": { "debug": "^4.1.1", "env-paths": "^2.2.0", "fs-extra": "^8.1.0", "got": "^11.8.5", "progress": "^2.0.3", "semver": "^6.2.0", "sumchecker": "^3.0.1" }, "optionalDependencies": { "global-agent": "^3.0.0" } }, "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ=="],
 
@@ -97,31 +96,35 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.24.2", "", { "os": "win32", "cpu": "x64" }, "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg=="],
 
-    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.4.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA=="],
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
 
-    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.1", "", {}, "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ=="],
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
 
-    "@eslint/config-array": ["@eslint/config-array@0.19.2", "", { "dependencies": { "@eslint/object-schema": "^2.1.6", "debug": "^4.3.1", "minimatch": "^3.1.2" } }, "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w=="],
+    "@eslint/config-array": ["@eslint/config-array@0.21.2", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.5" } }, "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw=="],
 
-    "@eslint/core": ["@eslint/core@0.11.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-DWUB2pksgNEb6Bz2fggIy1wh6fGgZP4Xyy/Mt0QZPiloKKXerbqq9D3SBQTlCRYOrcRPu4vuz+CGjwdfqxnoWA=="],
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.4.2", "", { "dependencies": { "@eslint/core": "^0.17.0" } }, "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="],
 
-    "@eslint/eslintrc": ["@eslint/eslintrc@3.2.0", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.0", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w=="],
+    "@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
 
-    "@eslint/js": ["@eslint/js@9.20.0", "", {}, "sha512-iZA07H9io9Wn836aVTytRaNqh00Sad+EamwOVJT12GTLw1VGMFV/4JaME+JjLtr9fiGaoWgYnS54wrfWsSs4oQ=="],
+    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.5", "", { "dependencies": { "ajv": "^6.14.0", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.5", "strip-json-comments": "^3.1.1" } }, "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg=="],
 
-    "@eslint/object-schema": ["@eslint/object-schema@2.1.6", "", {}, "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA=="],
+    "@eslint/js": ["@eslint/js@9.39.4", "", {}, "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw=="],
 
-    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.2.5", "", { "dependencies": { "@eslint/core": "^0.10.0", "levn": "^0.4.1" } }, "sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A=="],
+    "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
 
     "@happy-dom/global-registrator": ["@happy-dom/global-registrator@18.0.1", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^18.0.1" } }, "sha512-xCy/cpEP8xyJ6u0eokYgaQxeUmcKqHx/+aC3R0DLa7/S38efhZAVDQqLJ5zzTguLFS0gvAzZHP40NGaLwRyapQ=="],
 
-    "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
+    "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 
-    "@humanfs/node": ["@humanfs/node@0.16.6", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.3.0" } }, "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw=="],
+    "@humanfs/node": ["@humanfs/node@0.16.8", "", { "dependencies": { "@humanfs/core": "^0.19.2", "@humanfs/types": "^0.15.0", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ=="],
+
+    "@humanfs/types": ["@humanfs/types@0.15.0", "", {}, "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q=="],
 
     "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
 
-    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.1", "", {}, "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA=="],
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
@@ -131,61 +134,61 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@parcel/watcher": ["@parcel/watcher@2.5.1", "", { "dependencies": { "detect-libc": "^1.0.3", "is-glob": "^4.0.3", "micromatch": "^4.0.5", "node-addon-api": "^7.0.0" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.5.1", "@parcel/watcher-darwin-arm64": "2.5.1", "@parcel/watcher-darwin-x64": "2.5.1", "@parcel/watcher-freebsd-x64": "2.5.1", "@parcel/watcher-linux-arm-glibc": "2.5.1", "@parcel/watcher-linux-arm-musl": "2.5.1", "@parcel/watcher-linux-arm64-glibc": "2.5.1", "@parcel/watcher-linux-arm64-musl": "2.5.1", "@parcel/watcher-linux-x64-glibc": "2.5.1", "@parcel/watcher-linux-x64-musl": "2.5.1", "@parcel/watcher-win32-arm64": "2.5.1", "@parcel/watcher-win32-ia32": "2.5.1", "@parcel/watcher-win32-x64": "2.5.1" } }, "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg=="],
+    "@parcel/watcher": ["@parcel/watcher@2.5.6", "", { "dependencies": { "detect-libc": "^2.0.3", "is-glob": "^4.0.3", "node-addon-api": "^7.0.0", "picomatch": "^4.0.3" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.5.6", "@parcel/watcher-darwin-arm64": "2.5.6", "@parcel/watcher-darwin-x64": "2.5.6", "@parcel/watcher-freebsd-x64": "2.5.6", "@parcel/watcher-linux-arm-glibc": "2.5.6", "@parcel/watcher-linux-arm-musl": "2.5.6", "@parcel/watcher-linux-arm64-glibc": "2.5.6", "@parcel/watcher-linux-arm64-musl": "2.5.6", "@parcel/watcher-linux-x64-glibc": "2.5.6", "@parcel/watcher-linux-x64-musl": "2.5.6", "@parcel/watcher-win32-arm64": "2.5.6", "@parcel/watcher-win32-ia32": "2.5.6", "@parcel/watcher-win32-x64": "2.5.6" } }, "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ=="],
 
-    "@parcel/watcher-android-arm64": ["@parcel/watcher-android-arm64@2.5.1", "", { "os": "android", "cpu": "arm64" }, "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA=="],
+    "@parcel/watcher-android-arm64": ["@parcel/watcher-android-arm64@2.5.6", "", { "os": "android", "cpu": "arm64" }, "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A=="],
 
-    "@parcel/watcher-darwin-arm64": ["@parcel/watcher-darwin-arm64@2.5.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw=="],
+    "@parcel/watcher-darwin-arm64": ["@parcel/watcher-darwin-arm64@2.5.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA=="],
 
-    "@parcel/watcher-darwin-x64": ["@parcel/watcher-darwin-x64@2.5.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg=="],
+    "@parcel/watcher-darwin-x64": ["@parcel/watcher-darwin-x64@2.5.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg=="],
 
-    "@parcel/watcher-freebsd-x64": ["@parcel/watcher-freebsd-x64@2.5.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ=="],
+    "@parcel/watcher-freebsd-x64": ["@parcel/watcher-freebsd-x64@2.5.6", "", { "os": "freebsd", "cpu": "x64" }, "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng=="],
 
-    "@parcel/watcher-linux-arm-glibc": ["@parcel/watcher-linux-arm-glibc@2.5.1", "", { "os": "linux", "cpu": "arm" }, "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA=="],
+    "@parcel/watcher-linux-arm-glibc": ["@parcel/watcher-linux-arm-glibc@2.5.6", "", { "os": "linux", "cpu": "arm" }, "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ=="],
 
-    "@parcel/watcher-linux-arm-musl": ["@parcel/watcher-linux-arm-musl@2.5.1", "", { "os": "linux", "cpu": "arm" }, "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q=="],
+    "@parcel/watcher-linux-arm-musl": ["@parcel/watcher-linux-arm-musl@2.5.6", "", { "os": "linux", "cpu": "arm" }, "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg=="],
 
-    "@parcel/watcher-linux-arm64-glibc": ["@parcel/watcher-linux-arm64-glibc@2.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w=="],
+    "@parcel/watcher-linux-arm64-glibc": ["@parcel/watcher-linux-arm64-glibc@2.5.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA=="],
 
-    "@parcel/watcher-linux-arm64-musl": ["@parcel/watcher-linux-arm64-musl@2.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg=="],
+    "@parcel/watcher-linux-arm64-musl": ["@parcel/watcher-linux-arm64-musl@2.5.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA=="],
 
-    "@parcel/watcher-linux-x64-glibc": ["@parcel/watcher-linux-x64-glibc@2.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A=="],
+    "@parcel/watcher-linux-x64-glibc": ["@parcel/watcher-linux-x64-glibc@2.5.6", "", { "os": "linux", "cpu": "x64" }, "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ=="],
 
-    "@parcel/watcher-linux-x64-musl": ["@parcel/watcher-linux-x64-musl@2.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg=="],
+    "@parcel/watcher-linux-x64-musl": ["@parcel/watcher-linux-x64-musl@2.5.6", "", { "os": "linux", "cpu": "x64" }, "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg=="],
 
-    "@parcel/watcher-win32-arm64": ["@parcel/watcher-win32-arm64@2.5.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw=="],
+    "@parcel/watcher-win32-arm64": ["@parcel/watcher-win32-arm64@2.5.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q=="],
 
-    "@parcel/watcher-win32-ia32": ["@parcel/watcher-win32-ia32@2.5.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ=="],
+    "@parcel/watcher-win32-ia32": ["@parcel/watcher-win32-ia32@2.5.6", "", { "os": "win32", "cpu": "ia32" }, "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g=="],
 
-    "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.1", "", { "os": "win32", "cpu": "x64" }, "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA=="],
+    "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
-    "@react-spring/animated": ["@react-spring/animated@10.0.1", "", { "dependencies": { "@react-spring/shared": "~10.0.1", "@react-spring/types": "~10.0.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-BGL3hA66Y8Qm3KmRZUlfG/mFbDPYajgil2/jOP0VXf2+o2WPVmcDps/eEgdDqgf5Pv9eBbyj7LschLMuSjlW3Q=="],
+    "@react-spring/animated": ["@react-spring/animated@10.0.3", "", { "dependencies": { "@react-spring/shared": "~10.0.3", "@react-spring/types": "~10.0.3" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-7MrxADV3vaUADn2V9iYhaIL6iOWRx9nCJjYrsk2AHD2kwPr6fg7Pt0v+deX5RnCDmCKNnD6W5fasiyM8D+wzJQ=="],
 
-    "@react-spring/core": ["@react-spring/core@10.0.1", "", { "dependencies": { "@react-spring/animated": "~10.0.1", "@react-spring/shared": "~10.0.1", "@react-spring/types": "~10.0.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-KaMMsN1qHuVTsFpg/5ajAVye7OEqhYbCq0g4aKM9bnSZlDBBYpO7Uf+9eixyXN8YEbF+YXaYj9eoWDs+npZ+sA=="],
+    "@react-spring/core": ["@react-spring/core@10.0.3", "", { "dependencies": { "@react-spring/animated": "~10.0.3", "@react-spring/shared": "~10.0.3", "@react-spring/types": "~10.0.3" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-D4DwNO68oohDf/0HG2G0Uragzb9IA1oXblxrd6MZAcBcUQG2EHUWXewjdECMPLNmQvlYVyyBRH6gPxXM5DX7DQ=="],
 
-    "@react-spring/rafz": ["@react-spring/rafz@10.0.1", "", {}, "sha512-UrzG/d6Is+9i0aCAjsjWRqIlFFiC4lFqFHrH63zK935z2YDU95TOFio4VKGISJ5SG0xq4ULy7c1V3KU+XvL+Yg=="],
+    "@react-spring/rafz": ["@react-spring/rafz@10.0.3", "", {}, "sha512-Ri2/xqt8OnQ2iFKkxKMSF4Nqv0LSWnxXT4jXFzBDsHgeeH/cHxTLupAWUwmV9hAGgmEhBmh5aONtj3J6R/18wg=="],
 
-    "@react-spring/shared": ["@react-spring/shared@10.0.1", "", { "dependencies": { "@react-spring/rafz": "~10.0.1", "@react-spring/types": "~10.0.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-KR2tmjDShPruI/GGPfAZOOLvDgkhFseabjvxzZFFggJMPkyICLjO0J6mCIoGtdJSuHywZyc4Mmlgi+C88lS00g=="],
+    "@react-spring/shared": ["@react-spring/shared@10.0.3", "", { "dependencies": { "@react-spring/rafz": "~10.0.3", "@react-spring/types": "~10.0.3" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-geCal66nrkaQzUVhPkGomylo+Jpd5VPK8tPMEDevQEfNSWAQP15swHm+MCRG4wVQrQlTi9lOzKzpRoTL3CA84Q=="],
 
-    "@react-spring/types": ["@react-spring/types@10.0.1", "", {}, "sha512-Fk1wYVAKL+ZTYK+4YFDpHf3Slsy59pfFFvnnTfRjQQFGlyIo4VejPtDs3CbDiuBjM135YztRyZjIH2VbycB+ZQ=="],
+    "@react-spring/types": ["@react-spring/types@10.0.3", "", {}, "sha512-H5Ixkd2OuSIgHtxuHLTt7aJYfhMXKXT/rK32HPD/kSrOB6q6ooeiWAXkBy7L8F3ZxdkBb9ini9zP9UwnEFzWgQ=="],
 
-    "@react-spring/web": ["@react-spring/web@10.0.1", "", { "dependencies": { "@react-spring/animated": "~10.0.1", "@react-spring/core": "~10.0.1", "@react-spring/shared": "~10.0.1", "@react-spring/types": "~10.0.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-FgQk02OqFrYyJBTTnBTWAU0WPzkHkKXauc6aeexcvATvLapUxwnfGuLlsLYF8BYjEVfkivPT04ziAue6zyRBtQ=="],
+    "@react-spring/web": ["@react-spring/web@10.0.3", "", { "dependencies": { "@react-spring/animated": "~10.0.3", "@react-spring/core": "~10.0.3", "@react-spring/shared": "~10.0.3", "@react-spring/types": "~10.0.3" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-ndU+kWY81rHsT7gTFtCJ6mrVhaJ6grFmgTnENipzmKqot4HGf5smPNK+cZZJqoGeDsj9ZsiWPW4geT/NyD484A=="],
 
     "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
 
     "@szmarczak/http-timer": ["@szmarczak/http-timer@4.0.6", "", { "dependencies": { "defer-to-connect": "^2.0.0" } }, "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w=="],
 
-    "@types/bun": ["@types/bun@1.2.2", "", { "dependencies": { "bun-types": "1.2.2" } }, "sha512-tr74gdku+AEDN5ergNiBnplr7hpDp3V1h7fqI2GcR/rsUaM39jpSeKH0TFibRvU0KwniRx5POgaYnaXbk0hU+w=="],
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/cacheable-request": ["@types/cacheable-request@6.0.3", "", { "dependencies": { "@types/http-cache-semantics": "*", "@types/keyv": "^3.1.4", "@types/node": "*", "@types/responselike": "^1.0.0" } }, "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw=="],
 
     "@types/eslint": ["@types/eslint@9.6.1", "", { "dependencies": { "@types/estree": "*", "@types/json-schema": "*" } }, "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag=="],
 
-    "@types/estree": ["@types/estree@1.0.6", "", {}, "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="],
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
-    "@types/http-cache-semantics": ["@types/http-cache-semantics@4.0.4", "", {}, "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="],
+    "@types/http-cache-semantics": ["@types/http-cache-semantics@4.2.0", "", {}, "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
@@ -193,47 +196,49 @@
 
     "@types/minimist": ["@types/minimist@1.2.5", "", {}, "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag=="],
 
-    "@types/node": ["@types/node@20.19.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-hfrc+1tud1xcdVTABC2JiomZJEklMcXYNTVtZLAeqTVWD+qL5jkHKT+1lOtqDdGxt+mB53DTtiz673vfjU8D1Q=="],
+    "@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
 
     "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
 
     "@types/parse-json": ["@types/parse-json@4.0.2", "", {}, "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="],
 
-    "@types/react": ["@types/react@19.1.2", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw=="],
+    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
-    "@types/react-dom": ["@types/react-dom@19.1.2", "", { "peerDependencies": { "@types/react": "^19.0.0" } }, "sha512-XGJkWF41Qq305SKWEILa1O8vzhb3aOo3ogBlSmiqNko/WmRb6QIaweuZCXjKygVDXpzXb5wyxKTSOsmkuqj+Qw=="],
+    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
-    "@types/react-reconciler": ["@types/react-reconciler@0.32.0", "", { "peerDependencies": { "@types/react": "*" } }, "sha512-+WHarFkJevhH1s655qeeSEf/yxFST0dVRsmSqUgxG8mMOKqycgYBv2wVpyubBY7MX8KiX5FQ03rNIwrxfm7Bmw=="],
+    "@types/react-reconciler": ["@types/react-reconciler@0.32.3", "", { "peerDependencies": { "@types/react": "*" } }, "sha512-cMi5ZrLG7UtbL7LTK6hq9w/EZIRk4Mf1Z5qHoI+qBh7/WkYkFXQ7gOto2yfUvPzF5ERMAhaXS5eTQ2SAnHjLzA=="],
 
     "@types/responselike": ["@types/responselike@1.0.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw=="],
 
     "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
 
-    "@types/ws": ["@types/ws@8.5.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw=="],
-
     "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
-    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.23.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.23.0", "@typescript-eslint/type-utils": "8.23.0", "@typescript-eslint/utils": "8.23.0", "@typescript-eslint/visitor-keys": "8.23.0", "graphemer": "^1.4.0", "ignore": "^5.3.1", "natural-compare": "^1.4.0", "ts-api-utils": "^2.0.1" }, "peerDependencies": { "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.8.0" } }, "sha512-vBz65tJgRrA1Q5gWlRfvoH+w943dq9K1p1yDBY2pc+a1nbBLZp7fB9+Hk8DaALUbzjqlMfgaqlVPT1REJdkt/w=="],
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.59.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.59.1", "@typescript-eslint/type-utils": "8.59.1", "@typescript-eslint/utils": "8.59.1", "@typescript-eslint/visitor-keys": "8.59.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.59.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag=="],
 
-    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.23.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.23.0", "@typescript-eslint/types": "8.23.0", "@typescript-eslint/typescript-estree": "8.23.0", "@typescript-eslint/visitor-keys": "8.23.0", "debug": "^4.3.4" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.8.0" } }, "sha512-h2lUByouOXFAlMec2mILeELUbME5SZRN/7R9Cw2RD2lRQQY08MWMM+PmVVKKJNK1aIwqTo9t/0CvOxwPbRIE2Q=="],
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.59.1", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.59.1", "@typescript-eslint/types": "8.59.1", "@typescript-eslint/typescript-estree": "8.59.1", "@typescript-eslint/visitor-keys": "8.59.1", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA=="],
 
-    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.23.0", "", { "dependencies": { "@typescript-eslint/types": "8.23.0", "@typescript-eslint/visitor-keys": "8.23.0" } }, "sha512-OGqo7+dXHqI7Hfm+WqkZjKjsiRtFUQHPdGMXzk5mYXhJUedO7e/Y7i8AK3MyLMgZR93TX4bIzYrfyVjLC+0VSw=="],
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.59.1", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.59.1", "@typescript-eslint/types": "^8.59.1", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg=="],
 
-    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.23.0", "", { "dependencies": { "@typescript-eslint/typescript-estree": "8.23.0", "@typescript-eslint/utils": "8.23.0", "debug": "^4.3.4", "ts-api-utils": "^2.0.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.8.0" } }, "sha512-iIuLdYpQWZKbiH+RkCGc6iu+VwscP5rCtQ1lyQ7TYuKLrcZoeJVpcLiG8DliXVkUxirW/PWlmS+d6yD51L9jvA=="],
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.59.1", "", { "dependencies": { "@typescript-eslint/types": "8.59.1", "@typescript-eslint/visitor-keys": "8.59.1" } }, "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg=="],
 
-    "@typescript-eslint/types": ["@typescript-eslint/types@8.23.0", "", {}, "sha512-1sK4ILJbCmZOTt9k4vkoulT6/y5CHJ1qUYxqpF1K/DBAd8+ZUL4LlSCxOssuH5m4rUaaN0uS0HlVPvd45zjduQ=="],
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.59.1", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA=="],
 
-    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.23.0", "", { "dependencies": { "@typescript-eslint/types": "8.23.0", "@typescript-eslint/visitor-keys": "8.23.0", "debug": "^4.3.4", "fast-glob": "^3.3.2", "is-glob": "^4.0.3", "minimatch": "^9.0.4", "semver": "^7.6.0", "ts-api-utils": "^2.0.1" }, "peerDependencies": { "typescript": ">=4.8.4 <5.8.0" } }, "sha512-LcqzfipsB8RTvH8FX24W4UUFk1bl+0yTOf9ZA08XngFwMg4Kj8A+9hwz8Cr/ZS4KwHrmo9PJiLZkOt49vPnuvQ=="],
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.59.1", "", { "dependencies": { "@typescript-eslint/types": "8.59.1", "@typescript-eslint/typescript-estree": "8.59.1", "@typescript-eslint/utils": "8.59.1", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w=="],
 
-    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.23.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.4.0", "@typescript-eslint/scope-manager": "8.23.0", "@typescript-eslint/types": "8.23.0", "@typescript-eslint/typescript-estree": "8.23.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.8.0" } }, "sha512-uB/+PSo6Exu02b5ZEiVtmY6RVYO7YU5xqgzTIVZwTHvvK3HsL8tZZHFaTLFtRG3CsV4A5mhOv+NZx5BlhXPyIA=="],
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.59.1", "", {}, "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A=="],
 
-    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.23.0", "", { "dependencies": { "@typescript-eslint/types": "8.23.0", "eslint-visitor-keys": "^4.2.0" } }, "sha512-oWWhcWDLwDfu++BGTZcmXWqpwtkwb5o7fxUIGksMQQDSdPW9prsSnfIOZMlsj4vBOSrcnjIUZMiIjODgGosFhQ=="],
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.59.1", "", { "dependencies": { "@typescript-eslint/project-service": "8.59.1", "@typescript-eslint/tsconfig-utils": "8.59.1", "@typescript-eslint/types": "8.59.1", "@typescript-eslint/visitor-keys": "8.59.1", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.59.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.59.1", "@typescript-eslint/types": "8.59.1", "@typescript-eslint/typescript-estree": "8.59.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.59.1", "", { "dependencies": { "@typescript-eslint/types": "8.59.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
-    "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+    "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -243,7 +248,7 @@
 
     "array-buffer-byte-length": ["array-buffer-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "is-array-buffer": "^3.0.5" } }, "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw=="],
 
-    "array-includes": ["array-includes@3.1.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.2", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.4", "is-string": "^1.0.7" } }, "sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ=="],
+    "array-includes": ["array-includes@3.1.9", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "define-properties": "^1.2.1", "es-abstract": "^1.24.0", "es-object-atoms": "^1.1.1", "get-intrinsic": "^1.3.0", "is-string": "^1.1.1", "math-intrinsics": "^1.1.0" } }, "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ=="],
 
     "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
 
@@ -273,7 +278,7 @@
 
     "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
 
-    "brace-expansion": ["brace-expansion@1.1.11", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="],
+    "brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -283,17 +288,17 @@
 
     "bun-style-loader": ["bun-style-loader@0.4.0", "", { "dependencies": { "lightningcss-wasm": "^1.22.1" }, "peerDependencies": { "sass": ">= 1.0.0", "typescript": ">= 5.0.0" } }, "sha512-FqUxMfARrdc8/dUpmrw7cBIzhu9DTGJtrD+heOm+BzUd97NzxgsLZvyyxDRFLrXXJE9C4rTYUrQjxQPJxaIfJQ=="],
 
-    "bun-types": ["bun-types@1.2.2", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-RCbMH5elr9gjgDGDhkTTugA21XtJAy/9jkKe/G3WR2q17VPGhcquf9Sir6uay9iW+7P/BV0CAHA1XlHXMAVKHg=="],
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "cacheable-lookup": ["cacheable-lookup@5.0.4", "", {}, "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA=="],
 
     "cacheable-request": ["cacheable-request@7.0.4", "", { "dependencies": { "clone-response": "^1.0.2", "get-stream": "^5.1.0", "http-cache-semantics": "^4.0.0", "keyv": "^4.0.0", "lowercase-keys": "^2.0.0", "normalize-url": "^6.0.1", "responselike": "^2.0.0" } }, "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg=="],
 
-    "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
+    "call-bind": ["call-bind@1.0.9", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "get-intrinsic": "^1.3.0", "set-function-length": "^1.2.2" } }, "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ=="],
 
-    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g=="],
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
-    "call-bound": ["call-bound@1.0.3", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "get-intrinsic": "^1.2.6" } }, "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA=="],
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -331,11 +336,11 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
-    "css-functions-list": ["css-functions-list@3.2.3", "", {}, "sha512-IQOkD3hbR5KrN93MtcYuad6YPuTSUhntLHDuLEbFWE+ff2/XSZNdZG+LcbbIW5AXKg/WFIfYItIzVoHngHXZzA=="],
+    "css-functions-list": ["css-functions-list@3.3.3", "", {}, "sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg=="],
 
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
-    "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "data-view-buffer": ["data-view-buffer@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ=="],
 
@@ -343,7 +348,7 @@
 
     "data-view-byte-offset": ["data-view-byte-offset@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-data-view": "^1.0.1" } }, "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ=="],
 
-    "debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
 
@@ -361,7 +366,7 @@
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
-    "detect-libc": ["detect-libc@1.0.3", "", { "bin": { "detect-libc": "./bin/detect-libc.js" } }, "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="],
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
 
@@ -369,37 +374,37 @@
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 
-    "dotenv": ["dotenv@16.4.7", "", {}, "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ=="],
+    "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
-    "dpdm": ["dpdm@3.14.0", "", { "dependencies": { "chalk": "^4.1.2", "fs-extra": "^11.1.1", "glob": "^10.3.4", "ora": "^5.4.1", "tslib": "^2.6.2", "typescript": "^5.2.2", "yargs": "^17.7.2" }, "bin": { "dpdm": "lib/bin/dpdm.js" } }, "sha512-YJzsFSyEtj88q5eTELg3UWU7TVZkG1dpbF4JDQ3t1b07xuzXmdoGeSz9TKOke1mUuOpWlk4q+pBh+aHzD6GBTg=="],
+    "dpdm": ["dpdm@3.15.1", "", { "dependencies": { "chalk": "^4.1.2", "fs-extra": "^11.2.0", "glob": "^10.3.10", "ora": "^5.4.1", "tslib": "^2.7.0", "typescript": "^5.6.3", "yargs": "^17.7.2" }, "bin": { "dpdm": "lib/bin/dpdm.js" } }, "sha512-qa+BsZAGU3BhhQ6/Fdpd9YYYa3gdF0zMY/vW5rAj/QLJQgPbTX25h7cOe12dfRZvU0/JJP/g5LRgB6lTaVwILw=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
-    "electron": ["electron@36.2.1", "", { "dependencies": { "@electron/get": "^2.0.0", "@types/node": "^22.7.7", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js" } }, "sha512-mm1Y+Ms46xcOTA69h8hpqfX392HfV4lga9aEkYkd/Syx1JBStvcACOIouCgGrnZpxNZPVS1jM8NTcMkNjuK6BQ=="],
+    "electron": ["electron@36.9.5", "", { "dependencies": { "@electron/get": "^2.0.0", "@types/node": "^22.7.7", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js" } }, "sha512-1UCss2IqxqujSzg/2jkRjuiT3G+EEXgd6UKB5kUekwQW1LJ6d4QCr8YItfC3Rr9VIGRDJ29eOERmnRNO1Eh+NA=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
-    "end-of-stream": ["end-of-stream@1.4.4", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q=="],
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
-    "error-ex": ["error-ex@1.3.2", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g=="],
+    "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
-    "es-abstract": ["es-abstract@1.23.9", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.3", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.0", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-regex": "^1.2.1", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.0", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.3", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.3", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.18" } }, "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA=="],
+    "es-abstract": ["es-abstract@1.24.2", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.3.0", "get-proto": "^1.0.1", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-negative-zero": "^2.0.3", "is-regex": "^1.2.1", "is-set": "^2.0.3", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.1", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.4", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.4", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "stop-iteration-iterator": "^1.1.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.19" } }, "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
-    "es-iterator-helpers": ["es-iterator-helpers@1.2.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-abstract": "^1.23.6", "es-errors": "^1.3.0", "es-set-tostringtag": "^2.0.3", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.6", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "internal-slot": "^1.1.0", "iterator.prototype": "^1.1.4", "safe-array-concat": "^1.1.3" } }, "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w=="],
+    "es-iterator-helpers": ["es-iterator-helpers@1.3.2", "", { "dependencies": { "call-bind": "^1.0.9", "call-bound": "^1.0.4", "define-properties": "^1.2.1", "es-abstract": "^1.24.2", "es-errors": "^1.3.0", "es-set-tostringtag": "^2.1.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.3.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "internal-slot": "^1.1.0", "iterator.prototype": "^1.1.5", "math-intrinsics": "^1.1.0" } }, "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
-    "es-shim-unscopables": ["es-shim-unscopables@1.0.2", "", { "dependencies": { "hasown": "^2.0.0" } }, "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw=="],
+    "es-shim-unscopables": ["es-shim-unscopables@1.1.0", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw=="],
 
     "es-to-primitive": ["es-to-primitive@1.3.0", "", { "dependencies": { "is-callable": "^1.2.7", "is-date-object": "^1.0.5", "is-symbol": "^1.0.4" } }, "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g=="],
 
@@ -411,19 +416,19 @@
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
-    "eslint": ["eslint@9.20.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.2.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.19.0", "@eslint/core": "^0.11.0", "@eslint/eslintrc": "^3.2.0", "@eslint/js": "9.20.0", "@eslint/plugin-kit": "^0.2.5", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.1", "@types/estree": "^1.0.6", "@types/json-schema": "^7.0.15", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.2.0", "eslint-visitor-keys": "^4.2.0", "espree": "^10.3.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-aL4F8167Hg4IvsW89ejnpTwx+B/UQRzJPGgbIOl+4XqffWsahVVsLEWoZvnrVuwpWmnRd7XeXmQI1zlKcFDteA=="],
+    "eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
 
-    "eslint-plugin-react": ["eslint-plugin-react@7.37.4", "", { "dependencies": { "array-includes": "^3.1.8", "array.prototype.findlast": "^1.2.5", "array.prototype.flatmap": "^1.3.3", "array.prototype.tosorted": "^1.1.4", "doctrine": "^2.1.0", "es-iterator-helpers": "^1.2.1", "estraverse": "^5.3.0", "hasown": "^2.0.2", "jsx-ast-utils": "^2.4.1 || ^3.0.0", "minimatch": "^3.1.2", "object.entries": "^1.1.8", "object.fromentries": "^2.0.8", "object.values": "^1.2.1", "prop-types": "^15.8.1", "resolve": "^2.0.0-next.5", "semver": "^6.3.1", "string.prototype.matchall": "^4.0.12", "string.prototype.repeat": "^1.0.0" }, "peerDependencies": { "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7" } }, "sha512-BGP0jRmfYyvOyvMoRX/uoUeW+GqNj9y16bPQzqAHf3AYII/tDs+jMN0dBVkl88/OZwNGwrVFxE7riHsXVfy/LQ=="],
+    "eslint-plugin-react": ["eslint-plugin-react@7.37.5", "", { "dependencies": { "array-includes": "^3.1.8", "array.prototype.findlast": "^1.2.5", "array.prototype.flatmap": "^1.3.3", "array.prototype.tosorted": "^1.1.4", "doctrine": "^2.1.0", "es-iterator-helpers": "^1.2.1", "estraverse": "^5.3.0", "hasown": "^2.0.2", "jsx-ast-utils": "^2.4.1 || ^3.0.0", "minimatch": "^3.1.2", "object.entries": "^1.1.9", "object.fromentries": "^2.0.8", "object.values": "^1.2.1", "prop-types": "^15.8.1", "resolve": "^2.0.0-next.5", "semver": "^6.3.1", "string.prototype.matchall": "^4.0.12", "string.prototype.repeat": "^1.0.0" }, "peerDependencies": { "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7" } }, "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA=="],
 
-    "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@5.2.0-canary-ff628334-20250205", "", { "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0" } }, "sha512-UcLi2b+P4ozlfL13l9ASIFKuIQ7y/PzPz1bSyK54Jh8UqQfMMda8nDdetB+zjroGR6qZj2vStnqhuemYMqKRjw=="],
+    "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@5.2.0", "", { "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0" } }, "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg=="],
 
-    "eslint-scope": ["eslint-scope@8.2.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A=="],
+    "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
 
-    "eslint-visitor-keys": ["eslint-visitor-keys@4.2.0", "", {}, "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw=="],
+    "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 
-    "espree": ["espree@10.3.0", "", { "dependencies": { "acorn": "^8.14.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.0" } }, "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg=="],
+    "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
 
-    "esquery": ["esquery@1.6.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg=="],
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
 
     "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
 
@@ -435,7 +440,7 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
-    "fast-equals": ["fast-equals@5.2.2", "", {}, "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw=="],
+    "fast-equals": ["fast-equals@5.4.0", "", {}, "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
@@ -443,13 +448,15 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
-    "fast-uri": ["fast-uri@3.0.6", "", {}, "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw=="],
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
     "fastest-levenshtein": ["fastest-levenshtein@1.0.16", "", {}, "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg=="],
 
-    "fastq": ["fastq@1.19.0", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA=="],
+    "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 
@@ -459,13 +466,13 @@
 
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
 
-    "flatted": ["flatted@3.3.2", "", {}, "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA=="],
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
-    "for-each": ["for-each@0.3.4", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-kKaIINnFpzW6ffJNDjjyjrk21BkDx38c0xa/klsT8VzLCaMEefv4ZTacrcVR4DmgTeBra++jMDAfS/tS799YDw=="],
+    "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
-    "foreground-child": ["foreground-child@3.3.0", "", { "dependencies": { "cross-spawn": "^7.0.0", "signal-exit": "^4.0.1" } }, "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg=="],
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
-    "fs-extra": ["fs-extra@11.3.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew=="],
+    "fs-extra": ["fs-extra@11.3.4", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA=="],
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
@@ -475,9 +482,11 @@
 
     "functions-have-names": ["functions-have-names@1.2.3", "", {}, "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="],
 
+    "generator-function": ["generator-function@2.0.1", "", {}, "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="],
+
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
-    "get-intrinsic": ["get-intrinsic@1.2.7", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "function-bind": "^1.1.2", "get-proto": "^1.0.0", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA=="],
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
@@ -495,7 +504,7 @@
 
     "global-prefix": ["global-prefix@3.0.0", "", { "dependencies": { "ini": "^1.3.5", "kind-of": "^6.0.2", "which": "^1.3.1" } }, "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg=="],
 
-    "globals": ["globals@15.14.0", "", {}, "sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig=="],
+    "globals": ["globals@15.15.0", "", {}, "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg=="],
 
     "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
 
@@ -508,8 +517,6 @@
     "got": ["got@11.8.6", "", { "dependencies": { "@sindresorhus/is": "^4.0.0", "@szmarczak/http-timer": "^4.0.5", "@types/cacheable-request": "^6.0.1", "@types/responselike": "^1.0.0", "cacheable-lookup": "^5.0.3", "cacheable-request": "^7.0.2", "decompress-response": "^6.0.0", "http2-wrapper": "^1.0.0-beta.5.2", "lowercase-keys": "^2.0.0", "p-cancelable": "^2.0.0", "responselike": "^2.0.0" } }, "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
-
-    "graphemer": ["graphemer@1.4.0", "", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
 
     "happy-dom": ["happy-dom@18.0.1", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-qn+rKOW7KWpVTtgIUi6RVmTBZJSe2k0Db0vh1f7CWrWclkkc7/Q+FrOfkZIb2eiErLyqu5AXEzE7XthO9JVxRA=="],
 
@@ -527,13 +534,13 @@
 
     "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
-    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
     "hosted-git-info": ["hosted-git-info@4.1.0", "", { "dependencies": { "lru-cache": "^6.0.0" } }, "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA=="],
 
     "html-tags": ["html-tags@3.3.1", "", {}, "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ=="],
 
-    "http-cache-semantics": ["http-cache-semantics@4.1.1", "", {}, "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="],
+    "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
 
     "http2-wrapper": ["http2-wrapper@1.0.3", "", { "dependencies": { "quick-lru": "^5.1.1", "resolve-alpn": "^1.0.0" } }, "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg=="],
 
@@ -541,7 +548,7 @@
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
-    "immutable": ["immutable@5.0.3", "", {}, "sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw=="],
+    "immutable": ["immutable@5.1.5", "", {}, "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
@@ -583,13 +590,15 @@
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
-    "is-generator-function": ["is-generator-function@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "get-proto": "^1.0.0", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ=="],
+    "is-generator-function": ["is-generator-function@1.1.2", "", { "dependencies": { "call-bound": "^1.0.4", "generator-function": "^2.0.0", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-interactive": ["is-interactive@1.0.0", "", {}, "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="],
 
     "is-map": ["is-map@2.0.3", "", {}, "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw=="],
+
+    "is-negative-zero": ["is-negative-zero@2.0.3", "", {}, "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
@@ -629,7 +638,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
@@ -641,7 +650,7 @@
 
     "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="],
 
-    "jsonfile": ["jsonfile@6.1.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ=="],
+    "jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
 
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
 
@@ -653,7 +662,7 @@
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
-    "lightningcss-wasm": ["lightningcss-wasm@1.29.1", "", { "dependencies": { "napi-wasm": "^1.0.1" } }, "sha512-yrcX5OfnB5NJY32h2kOCaUr/OUz/os51uy/dTqSi+Z5lkUgnI9XIzlFDjbru/DaMkJ7v08QKN14Yr75SvDnqjA=="],
+    "lightningcss-wasm": ["lightningcss-wasm@1.32.0", "", { "dependencies": { "napi-wasm": "^1.0.1" } }, "sha512-SteAkCtRuSCDYPGHKhLV/dDs5Bk+7I4QUxWxfk4xwsTI1rQk8MQyYtpGcd3NECsUGzK0q2/KqoVS+YHCqKHUTQ=="],
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
@@ -693,21 +702,23 @@
 
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
-    "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "minimist-options": ["minimist-options@4.1.0", "", { "dependencies": { "arrify": "^1.0.1", "is-plain-obj": "^1.1.0", "kind-of": "^6.0.3" } }, "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A=="],
 
-    "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "monaco-editor": ["monaco-editor@0.52.2", "", {}, "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.8", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w=="],
+    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
+
+    "node-exports-info": ["node-exports-info@1.6.0", "", { "dependencies": { "array.prototype.flatmap": "^1.3.3", "es-errors": "^1.3.0", "object.entries": "^1.1.9", "semver": "^6.3.1" } }, "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw=="],
 
     "normalize-package-data": ["normalize-package-data@3.0.3", "", { "dependencies": { "hosted-git-info": "^4.0.1", "is-core-module": "^2.5.0", "semver": "^7.3.4", "validate-npm-package-license": "^3.0.1" } }, "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA=="],
 
@@ -723,7 +734,7 @@
 
     "object.assign": ["object.assign@4.1.7", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0", "has-symbols": "^1.1.0", "object-keys": "^1.1.1" } }, "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw=="],
 
-    "object.entries": ["object.entries@1.1.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-cmopxi8VwRIAw/fkijJohSfpef5PdN0pMQJN6VC/ZKvn0LIknWD8KtgY6KlQdEc4tIjcQ3HxSMmnvtzIscdaYQ=="],
+    "object.entries": ["object.entries@1.1.9", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "define-properties": "^1.2.1", "es-object-atoms": "^1.1.1" } }, "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw=="],
 
     "object.fromentries": ["object.fromentries@2.0.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.2", "es-object-atoms": "^1.0.0" } }, "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ=="],
 
@@ -769,11 +780,11 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+    "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
-    "postcss": ["postcss@8.5.1", "", { "dependencies": { "nanoid": "^3.3.8", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ=="],
+    "postcss": ["postcss@8.5.13", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag=="],
 
     "postcss-media-query-parser": ["postcss-media-query-parser@0.2.3", "", {}, "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig=="],
 
@@ -791,7 +802,7 @@
 
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
-    "pump": ["pump@3.0.2", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw=="],
+    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
@@ -799,9 +810,9 @@
 
     "quick-lru": ["quick-lru@4.0.1", "", {}, "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="],
 
-    "react": ["react@19.0.0", "", {}, "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ=="],
+    "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
-    "react-dom": ["react-dom@19.1.0", "", { "dependencies": { "scheduler": "^0.26.0" }, "peerDependencies": { "react": "^19.1.0" } }, "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g=="],
+    "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
@@ -811,7 +822,7 @@
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
-    "readdirp": ["readdirp@4.1.1", "", {}, "sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw=="],
+    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
@@ -823,7 +834,7 @@
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
-    "resolve": ["resolve@2.0.0-next.5", "", { "dependencies": { "is-core-module": "^2.13.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA=="],
+    "resolve": ["resolve@2.0.0-next.6", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "node-exports-info": "^1.6.0", "object-keys": "^1.1.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA=="],
 
     "resolve-alpn": ["resolve-alpn@1.2.1", "", {}, "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="],
 
@@ -833,7 +844,7 @@
 
     "restore-cursor": ["restore-cursor@3.1.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA=="],
 
-    "reusify": ["reusify@1.0.4", "", {}, "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="],
+    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
     "rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
 
@@ -841,7 +852,7 @@
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
-    "safe-array-concat": ["safe-array-concat@1.1.3", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "get-intrinsic": "^1.2.6", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q=="],
+    "safe-array-concat": ["safe-array-concat@1.1.4", "", { "dependencies": { "call-bind": "^1.0.9", "call-bound": "^1.0.4", "get-intrinsic": "^1.3.0", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
@@ -849,9 +860,9 @@
 
     "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
 
-    "sass": ["sass@1.84.0", "", { "dependencies": { "chokidar": "^4.0.0", "immutable": "^5.0.2", "source-map-js": ">=0.6.2 <2.0.0" }, "optionalDependencies": { "@parcel/watcher": "^2.4.1" }, "bin": { "sass": "sass.js" } }, "sha512-XDAbhEPJRxi7H0SxrnOpiXFQoUJHwkR2u3Zc4el+fK/Tt5Hpzw5kkQ59qVDfvdaUq6gCrEZIbySFBM2T9DNKHg=="],
+    "sass": ["sass@1.99.0", "", { "dependencies": { "chokidar": "^4.0.0", "immutable": "^5.1.5", "source-map-js": ">=0.6.2 <2.0.0" }, "optionalDependencies": { "@parcel/watcher": "^2.4.1" }, "bin": { "sass": "sass.js" } }, "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q=="],
 
-    "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -871,7 +882,7 @@
 
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 
-    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
 
     "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
 
@@ -891,9 +902,11 @@
 
     "spdx-expression-parse": ["spdx-expression-parse@3.0.1", "", { "dependencies": { "spdx-exceptions": "^2.1.0", "spdx-license-ids": "^3.0.0" } }, "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q=="],
 
-    "spdx-license-ids": ["spdx-license-ids@3.0.21", "", {}, "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg=="],
+    "spdx-license-ids": ["spdx-license-ids@3.0.23", "", {}, "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw=="],
 
     "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
+
+    "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -939,11 +952,13 @@
 
     "table": ["table@6.9.0", "", { "dependencies": { "ajv": "^8.0.1", "lodash.truncate": "^4.4.2", "slice-ansi": "^4.0.0", "string-width": "^4.2.3", "strip-ansi": "^6.0.1" } }, "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A=="],
 
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "trim-newlines": ["trim-newlines@3.0.1", "", {}, "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="],
 
-    "ts-api-utils": ["ts-api-utils@2.0.1", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w=="],
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -959,9 +974,9 @@
 
     "typed-array-length": ["typed-array-length@1.0.7", "", { "dependencies": { "call-bind": "^1.0.7", "for-each": "^0.3.3", "gopd": "^1.0.1", "is-typed-array": "^1.1.13", "possible-typed-array-names": "^1.0.0", "reflect.getprototypeof": "^1.0.6" } }, "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg=="],
 
-    "typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "typescript-eslint": ["typescript-eslint@8.23.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.23.0", "@typescript-eslint/parser": "8.23.0", "@typescript-eslint/utils": "8.23.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.8.0" } }, "sha512-/LBRo3HrXr5LxmrdYSOCvoAMm7p2jNizNfbIpCgvG4HMsnoprRUOce/+8VJ9BDYWW68rqIENE/haVLWPeFZBVQ=="],
+    "typescript-eslint": ["typescript-eslint@8.59.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.59.1", "@typescript-eslint/parser": "8.59.1", "@typescript-eslint/typescript-estree": "8.59.1", "@typescript-eslint/utils": "8.59.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-xqDcFVBmlrltH64lklOVp1wYxgJr6LVdg3NamBgH2OOQDLFdTKfIZXF5PfghrnXQKXZGTQs8tr1vL7fJvq8CTQ=="],
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 
@@ -989,7 +1004,7 @@
 
     "which-collection": ["which-collection@1.0.2", "", { "dependencies": { "is-map": "^2.0.3", "is-set": "^2.0.3", "is-weakmap": "^2.0.2", "is-weakset": "^2.0.3" } }, "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw=="],
 
-    "which-typed-array": ["which-typed-array@1.1.18", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.3", "for-each": "^0.3.3", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA=="],
+    "which-typed-array": ["which-typed-array@1.1.20", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
@@ -1005,7 +1020,7 @@
 
     "yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
-    "yaml": ["yaml@1.10.2", "", {}, "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="],
+    "yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
 
     "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
@@ -1021,51 +1036,47 @@
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
-    "@eslint/plugin-kit/@eslint/core": ["@eslint/core@0.10.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw=="],
-
-    "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
-
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
-    "@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+    "@isaacs/cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
-    "@types/cacheable-request/@types/node": ["@types/node@22.13.1", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew=="],
+    "@parcel/watcher/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
-    "@types/keyv/@types/node": ["@types/node@22.13.1", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew=="],
+    "@types/cacheable-request/@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 
-    "@types/responselike/@types/node": ["@types/node@22.13.1", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew=="],
+    "@types/keyv/@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 
-    "@types/ws/@types/node": ["@types/node@22.13.1", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew=="],
+    "@types/responselike/@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 
-    "@types/yauzl/@types/node": ["@types/node@22.13.1", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew=="],
+    "@types/yauzl/@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 
-    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+    "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
-    "@typescript-eslint/typescript-estree/semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
     "bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
-    "bun-types/@types/node": ["@types/node@22.13.1", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew=="],
-
     "clone-response/mimic-response": ["mimic-response@1.0.1", "", {}, "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="],
 
     "decamelize-keys/map-obj": ["map-obj@1.0.1", "", {}, "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg=="],
 
-    "dpdm/glob": ["glob@10.4.5", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg=="],
+    "dpdm/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
-    "electron/@types/node": ["@types/node@22.13.1", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew=="],
-
-    "espree/acorn": ["acorn@8.14.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="],
+    "electron/@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
-    "global-agent/semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
+    "global-agent/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "global-prefix/which": ["which@1.3.1", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "which": "./bin/which" } }, "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ=="],
 
@@ -1079,7 +1090,7 @@
 
     "meow/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
-    "normalize-package-data/semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
+    "normalize-package-data/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "read-pkg/normalize-package-data": ["normalize-package-data@2.5.0", "", { "dependencies": { "hosted-git-info": "^2.1.4", "resolve": "^1.10.0", "semver": "2 || 3 || 4 || 5", "validate-npm-package-license": "^3.0.1" } }, "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA=="],
 
@@ -1093,7 +1104,9 @@
 
     "stylelint/file-entry-cache": ["file-entry-cache@6.0.1", "", { "dependencies": { "flat-cache": "^3.0.4" } }, "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg=="],
 
-    "table/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+    "table/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "@electron/get/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
@@ -1101,33 +1114,19 @@
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
-    "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
+    "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
-    "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+    "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
-    "@types/cacheable-request/@types/node/undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
-    "@types/keyv/@types/node/undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
-
-    "@types/responselike/@types/node/undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
-
-    "@types/ws/@types/node/undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
-
-    "@types/yauzl/@types/node/undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
-
-    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
-
-    "bun-types/@types/node/undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
-
-    "dpdm/glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
-
-    "electron/@types/node/undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
+    "dpdm/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "read-pkg-up/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "read-pkg/normalize-package-data/hosted-git-info": ["hosted-git-info@2.8.9", "", {}, "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="],
 
-    "read-pkg/normalize-package-data/resolve": ["resolve@1.22.10", "", { "dependencies": { "is-core-module": "^2.16.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w=="],
+    "read-pkg/normalize-package-data/resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
 
     "read-pkg/normalize-package-data/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
 
@@ -1135,9 +1134,9 @@
 
     "table/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
-    "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
-    "dpdm/glob/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
+    "dpdm/glob/minimatch/brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
 
     "read-pkg-up/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 

--- a/scripts/inject.ts
+++ b/scripts/inject.ts
@@ -1,68 +1,303 @@
-const args = process.argv;
 import fs from "fs";
 import path from "path";
 import bun from "bun";
+import asar from "@electron/asar";
+import {styleText as c} from "node:util";
 
 import doSanityChecks from "./helpers/validate";
 import buildPackage from "./helpers/package";
 import copyFiles from "./helpers/copy";
 
-const useBdRelease = args[2] && args[2].toLowerCase() === "release";
-const releaseInput = useBdRelease ? args[3] && args[3].toLowerCase() : args[2] && args[2].toLowerCase();
-const release = releaseInput === "canary" ? "Discord Canary" : releaseInput === "ptb" ? "Discord PTB" : "Discord";
+const args = process.argv.slice(2); // Slice to ignore 'bun' and 'inject.ts'
+if (args.includes("-h") || args.includes("--help")) {
+    showHelp();
+    process.exit(0);
+}
+
+function includesIgnoreCase(arr: string[], target: string): boolean {
+    target = target.toLowerCase();
+    return arr.some((el) => el.toLowerCase() === target);
+}
+
+const useBdRelease = includesIgnoreCase(args, "release");
+const isSimple = includesIgnoreCase(args, "simple");
+
+const release = includesIgnoreCase(args, "canary") ? "Discord Canary" : includesIgnoreCase(args, "ptb") ? "Discord PTB" : "Discord";
+const flatpak = includesIgnoreCase(args, "flatpak");
+const opt = includesIgnoreCase(args, "opt"); // pacman puts it into /opt, yay does it in the debian way
 const bdPath = useBdRelease ? path.resolve(__dirname, "..", "dist", "betterdiscord.asar") : path.resolve(__dirname, "..", "dist");
-const discordPath = await (async function () {
-    let resourcePath = "";
+
+function showHelp(): void {
+    const discordRelease = ["canary", "ptb"].map((v) => c(["yellow", "bold"], v)).join("|");
+    console.log(`
+${c("bold", `Usage: bun inject.ts [${c(["cyan"], "options")}]`)}
+
+${c("bold", "Options:")}
+  ${c(["blue", "bold"], "release")}              Build and inject the production asar (dist/betterdiscord.asar)
+                       If omitted, injects the development folder (dist/)
+  ${discordRelease}           Inject into Discord Canary or Discord PTB
+  ${c(["cyan", "bold"], "flatpak")}              Configure for Flatpak Discord installation
+  ${c(["cyan", "bold"], "opt")}                  Use /opt directory for Linux installations (Arch/pacman)
+  ${c(["cyan", "bold"], "simple")}               Skip app.asar patching (only write index.js)
+  ${c(["cyan", "bold"], "-h, --help")}           Show this help message
+
+${c("bold", "Examples:")}
+  ${c("bold", c("magenta", "bun inject.ts") + " canary")}
+  ${c("bold", c("magenta", "bun inject.ts") + " release canary")}
+  ${c("bold", c("magenta", "bun inject.ts") + " release ptb flatpak")}
+    `);
+}
+
+/**
+ * Represents the directory paths for a specific Discord version.
+ *
+ * Discord can have multiple installed versions (e.g., 0.0.130, 0.0.131),
+ * and this type contains the paths for a single version entry.
+ */
+type PathsEntry = {
+    /**
+     * Discord's root application installation directory.
+     *
+     * Examples:
+     * - **Debian/Ubuntu (`.deb`)**: `/usr/share/discord`
+     * - **Flatpak**: `/var/lib/flatpak/app/com.discordapp.Discord/current/active/files/discord`
+     * - **Windows**: `C:\Users\<user>\AppData\Local\Discord`
+     * - **macOS**: `/Applications/Discord.app/Contents`
+     */
+    discordBaseDir: string;
+
+    /**
+     * Discord's user configuration directory where caches and settings are stored.
+     *
+     * The `discord_desktop_core` module is located within this directory structure.
+     *
+     * Examples:
+     * - **Linux**: `~/.config/discord`
+     * - **Windows**: `%LOCALAPPDATA%\Discord`
+     * - **macOS**: `~/Library/Application Support/discord`
+     */
+    discordDir: string;
+
+    /**
+     * Full path to the `discord_desktop_core` module directory.
+     *
+     * This is where the core Discord application logic resides. May be `undefined`
+     * if Discord is in the process of updating or hasn't fully initialized this version yet.
+     *
+     * Empty when Discord hasn't prepared the directory for this version.
+     */
+    discord_desktop_core: string;
+
+    /**
+     * The semantic version string of this Discord installation (e.g., "0.0.130").
+     */
+    version: string;
+};
+
+/**
+ * Array of `PathsEntry` objects representing all installed Discord versions
+ * on the current system, typically sorted from oldest to newest.
+ */
+type Paths = PathsEntry[];
+
+async function getDiscordPaths(releaseName: string): Promise<Paths> {
+    const paths: PathsEntry = {
+        discordDir: "",
+        discordBaseDir: "",
+        discord_desktop_core: "",
+        version: "",
+    };
+    const versions: PathsEntry[] = [];
+
+    let syncBaseDirAndDir = false;
     if (process.platform === "win32") {
-        const basedir = path.join(process.env.LOCALAPPDATA!, release.replace(/ /g, ""));
-        if (!fs.existsSync(basedir)) throw new Error(`Cannot find directory for ${release}`);
-        const version = fs.readdirSync(basedir).filter(f => fs.lstatSync(path.join(basedir, f)).isDirectory() && f.split(".").length > 1).sort().reverse()[0];
-        // To account for discord_desktop_core-1 or any other number
-        const coreWrap = fs.readdirSync(path.join(basedir, version, "modules")).filter(e => e.indexOf("discord_desktop_core") === 0).sort().reverse()[0];
-        resourcePath = path.join(basedir, version, "modules", coreWrap, "discord_desktop_core");
+        paths.discordDir = path.join(process.env.LOCALAPPDATA!, releaseName.replace(/ /g, ""));
+        syncBaseDirAndDir = true;
     }
     else if (process.env.WSL_DISTRO_NAME) {
         const appdata = (await bun.$`wslpath "$(cmd.exe /c "echo %LOCALAPPDATA%" 2>/dev/null | tr -d '\r')"`.text()).trim();
-        const basedir = path.join(appdata, release.replace(/ /g, ""));
-        if (!fs.existsSync(basedir)) throw new Error(`Cannot find directory for ${release}`);
-        const version = fs.readdirSync(basedir).filter(f => fs.lstatSync(path.join(basedir, f)).isDirectory() && f.split(".").length > 1).sort().reverse()[0];
-        // To account for discord_desktop_core-1 or any other number
-        const coreWrap = fs.readdirSync(path.join(basedir, version, "modules")).filter(e => e.indexOf("discord_desktop_core") === 0).sort().reverse()[0];
-        resourcePath = path.join(basedir, version, "modules", coreWrap, "discord_desktop_core");
+        paths.discordDir = path.join(appdata, releaseName.replace(/ /g, ""));
+        syncBaseDirAndDir = true;
     }
     else {
-        let userData = process.env.XDG_CONFIG_HOME ? process.env.XDG_CONFIG_HOME : path.join(process.env.HOME!, ".config");
-        if (process.platform === "darwin") userData = path.join(process.env.HOME!, "Library", "Application Support");
-        const basedir = path.join(userData, release.toLowerCase().replace(" ", ""));
-        if (!fs.existsSync(basedir)) return "";
-        const version = fs.readdirSync(basedir).filter(f => fs.lstatSync(path.join(basedir, f)).isDirectory() && f.split(".").length > 1).sort().reverse()[0];
-        if (!version) return "";
-        resourcePath = path.join(basedir, version, "modules", "discord_desktop_core");
+        const releaseNameLower = releaseName.toLowerCase();
+        const releaseNameLowerNoSpaces = releaseNameLower.replace(" ", "");
+        const releaseNameLowerSnake = releaseNameLower.replace(" ", "-");
+        if (flatpak) {
+            paths.discordDir = path.posix.join(process.env.HOME!, ".var", "app", "com.discordapp.Discord", "config", releaseNameLowerNoSpaces);
+            paths.discordBaseDir = "/var/lib/flatpak/app/com.discordapp.Discord/current/active/files/" + releaseNameLowerSnake;
+        }
+        else if (process.platform === "darwin") {
+            const configDir = path.posix.join(process.env.HOME!, "Library", "Application Support");
+            paths.discordDir = path.posix.join(configDir, releaseNameLowerNoSpaces);
+            paths.discordBaseDir = "applications/" + release + ".app/contents";
+        }
+        else {
+            const configDir = process.env.XDG_CONFIG_HOME || path.posix.join(process.env.HOME!, ".config");
+            paths.discordDir = path.join(configDir, releaseNameLowerNoSpaces);
+            syncBaseDirAndDir = !opt;
+            if (opt) {
+                paths.discordBaseDir = path.join("/opt", releaseNameLowerNoSpaces);
+            }
+        }
     }
 
-    if (fs.existsSync(resourcePath)) return resourcePath;
-    return "";
-})();
+    // 2. Find the version and core module path
+    const appDirs = fs.readdirSync(paths.discordDir)
+        .filter(f => fs.lstatSync(path.join(paths.discordDir, f)).isDirectory() && f.includes("."))
+        .sort();
+
+    if (appDirs.length === 0) {
+        throw new Error(`No versions found: ${paths.discordDir}`);
+    }
+
+    for (const ver of appDirs) {
+        const pathsv: PathsEntry = {...paths, version: ver};
+        pathsv.discordDir = path.join(pathsv.discordDir, ver);
+        if (syncBaseDirAndDir) {
+            pathsv.discordBaseDir = pathsv.discordDir;
+        }
+        pathsv.discord_desktop_core = getDiscord_desktop_core(pathsv.discordDir);
+        versions.push(pathsv);
+    }
+
+    return versions;
+}
+
+function getDiscord_desktop_core(discordDir: string): string {
+    const corename = "discord_desktop_core";
+    const paths: string[] = [];
+    const modulesPath = path.join(discordDir, "modules");
+    paths.push(modulesPath);
+
+    // Handle variations in folder naming (especially on Windows/WSL)
+    try {
+        const coreWrap = fs.readdirSync(modulesPath).find(e => e.startsWith(corename + "-"));
+        if (coreWrap) paths.push(coreWrap);
+    }
+    catch {
+        return "";
+    }
+
+    paths.push(corename);
+
+    return path.join(...paths);
+}
 
 doSanityChecks(bdPath);
 buildPackage(bdPath);
-console.log("");
 
-console.log(`Injecting into ${release}`);
-if (!fs.existsSync(discordPath)) throw new Error(`Cannot find directory for ${release}`);
-console.log(`    ✅ Found ${release} in ${discordPath}`);
+const asarBase = "app.asar";
+async function patchAppAsar(resources: string): Promise<void> {
+    const appAsarPath = path.join(resources, asarBase);
 
-const indexJs = path.join(discordPath, "index.js");
-if (fs.existsSync(indexJs)) fs.unlinkSync(indexJs);
-if (process.env.WSL_DISTRO_NAME) {
-    copyFiles(bdPath, path.join(discordPath, "betterdiscord"));
-    fs.writeFileSync(indexJs, `require("./betterdiscord");\nmodule.exports = require("./core.asar");`);
+    const tempUnpackPath = path.join(resources, "app-unpacked-temp");
+    fs.rmSync(tempUnpackPath, {force: true, recursive: true});
+
+    const isAppAsarPatched = fs.readFileSync(appAsarPath, "utf8").includes("scheme: \"bd\"");
+
+    // Only patch if not already patched
+    if (!isAppAsarPatched) {
+        { // create backup
+            const appAsarBakPath = path.join(resources, `${asarBase}.bd.bak`);
+            try {await fs.promises.copyFile(appAsarPath, appAsarBakPath, fs.constants.COPYFILE_EXCL);}
+            catch {/* do not recopy */};
+        }
+        console.log(`    📦  Extracting ${asarBase}...`);
+        asar.extractAll(appAsarPath, tempUnpackPath);
+        let targetFile = path.join(tempUnpackPath, "app_bootstrap", "protocols.js");
+        if (!fs.existsSync(targetFile)) {
+            targetFile = path.join(tempUnpackPath, "bundle.js");
+            if (!fs.existsSync(targetFile)) {
+                throw new Error(`Cannot find resource file for ${release} at ${targetFile}`);
+            }
+        }
+        console.log(`    🔨  Patching ${asarBase} at ${targetFile}...`);
+        { // add new bd protocol
+            const appAsarContent = fs.readFileSync(targetFile, "utf8");
+            const patchedContent = appAsarContent.replace(
+                /(protocol\.registerSchemesAsPrivileged\(\s*\[)(\s*{\s*scheme:\s*DISCORD_CLIP_PROTOCOL)/,
+                `$1{scheme: "bd", privileges: {standard: true, secure: true, supportFetchAPI: true},},$2`
+            );
+
+            fs.writeFileSync(targetFile, patchedContent);
+        }
+
+        // repack app.asar
+        await asar.createPackage(tempUnpackPath, appAsarPath);
+        console.log(`    ✅ Patched ${targetFile} in ${asarBase}`);
+    }
+    else {
+        console.log(`    ℹ️  Can't patch ${asarBase}, it's already patched.`);
+    }
+    fs.rmSync(tempUnpackPath, {force: true, recursive: true});
 }
-else {
-    fs.writeFileSync(indexJs, `require("${bdPath.replace(/\\/g, "\\\\").replace(/"/g, "\\\"")}");\nmodule.exports = require("./core.asar");`);
+
+async function patchCore(discord_desktop_core: string): Promise<void> {
+    const indexJs = path.join(discord_desktop_core, "index.js");
+    if (fs.existsSync(indexJs)) fs.unlinkSync(indexJs);
+
+    const injectionCode = process.env.WSL_DISTRO_NAME
+        ? (copyFiles(bdPath, path.join(discord_desktop_core, "betterdiscord")), `require("./betterdiscord");\nmodule.exports = require("./core.asar");`)
+        : `require("${bdPath.replace(/\\/g, "\\\\").replace(/"/g, "\\\"")}");\nmodule.exports = require("./core.asar");`;
+
+    fs.writeFileSync(indexJs, injectionCode);
+    console.log("    ✅ Wrote index.js\n");
 }
 
-console.log("    ✅ Wrote index.js");
-console.log("");
+const prepared = await getDiscordPaths(release);
+const rev = prepared.toReversed();
+let potentialInjectionWipe = false;
+for (const [i, discordPaths] of rev.entries()) {
+    const isLatest = i === prepared.length - 1;
+    const {discordDir, discordBaseDir, discord_desktop_core, version} = discordPaths;
 
-console.log(`Injection successful, please restart ${release}.`);
+
+    console.log(`\nInjecting into ${release} (${version})`);
+    console.log(`    Base Dir: '${discordBaseDir}'`);
+    console.log(`    Dir: '${discordDir}'`);
+    console.log(`    discord_desktop_core: '${discord_desktop_core}'`);
+
+    const resources = path.join(discordBaseDir, "resources");
+    if (!fs.existsSync(resources)) {
+        throw new Error(`Cannot find directory for ${release} at ${resources}`);
+    }
+
+    const appAsarPath = path.join(resources, asarBase);
+    if (!fs.existsSync(appAsarPath)) {
+        throw new Error(`Cannot find ${asarBase} for ${release} at ${appAsarPath}`);
+    }
+    console.log(`    appAsarPath: '${appAsarPath}'`);
+
+    if (!discord_desktop_core) {
+        if (!isLatest) {
+            console.log(`    ⏭️ It's a pending update directory. Skipped.`);
+            potentialInjectionWipe = true;
+            continue;
+        }
+        throw new Error(`Cannot find discord_desktop_core for ${release} at ${discord_desktop_core}`);
+    }
+
+    // protocols.js (or bundle.js for canary)
+    if (!isSimple) {
+        await patchAppAsar(resources);
+    }
+    else {
+        console.log(`    ℹ️  Skipping ${asarBase} patching.`);
+    }
+
+    // index.js
+    await patchCore(discord_desktop_core);
+
+    // exec flatpak patch override here
+    if (flatpak) {
+        console.log("    🔒 Setting Flatpak filesystem overrides...");
+        await bun.$`flatpak override --filesystem=host com.discordapp.Discord`;
+    }
+    console.log(`Injection successful, please restart ${release} (${version}).`);
+    if (potentialInjectionWipe) {
+        console.log(`    ⚠️ Your injection may be wiped out by the pending update.`);
+        console.log(`    The update: ${prepared.map(({version: v}) => v).join(" -> ")}`);
+    }
+    break;
+}

--- a/src/betterdiscord/api/addonapi.ts
+++ b/src/betterdiscord/api/addonapi.ts
@@ -1,63 +1,73 @@
-import type AddonManager from "@modules/addonmanager";
+import type {AddonAny} from "@modules/addon";
+import type {default as AddonManager} from "@modules/addonmanager";
+import type {AddonStateLoad, AddonStateStart, AddonStateStarted, AddonStateStop} from "@modules/addonstate";
+import type {default as PluginManager} from "@modules/pluginmanager";
+import type {default as ThemeManager} from "@modules/thememanager";
 
 /**
  * `AddonAPI` is a utility class for working with plugins and themes. Instances are accessible through the {@link BdApi}.
  * @name AddonAPI
  */
-class AddonAPI {
-    #manager: AddonManager;
+class AddonAPI<A extends AddonAny> {
+    #manager: AddonManager<A>;
 
-    constructor(manager: AddonManager) {this.#manager = manager;}
+    constructor(manager: typeof PluginManager | typeof ThemeManager) {this.#manager = manager as unknown as AddonManager<A>;}
 
     /**
      * The path to the addon folder.
-     * @type string
+     * @type {string}
      */
-    get folder() {return this.#manager.addonFolder;}
+    get folder(): string {return this.#manager.addonFolder();}
 
     /**
      * Determines if a particular addon is enabled.
      * @param {string} idOrFile Addon ID or filename
      * @returns {boolean}
      */
-    isEnabled(idOrFile: string) {return this.#manager.isEnabled(idOrFile);}
+    isEnabled(idOrFile: string): boolean {return this.#manager.isEnabled(idOrFile);}
 
     /**
      * Enables the given addon.
-     * @param {string} idOrFile Addon ID or filename
+     * @param {A} addon Addon instance
+     * @returns {Promise<AddonStateStart<A>>}
      */
-    enable(idOrAddon: string) {return this.#manager.enableAddon(idOrAddon);}
+    enable(addon: A): Promise<AddonStateStart<A>> {return this.#manager.enableAddon(addon);}
 
     /**
      * Disables the given addon.
-     * @param {string} idOrFile Addon ID or filename
+     * @param {A} addon Addon instance
+     * @return {Promise<AddonStateStop>}
      */
-    disable(idOrAddon: string) {return this.#manager.disableAddon(idOrAddon);}
+    disable(addon: A): Promise<AddonStateStop> {return this.#manager.disableAddon(addon);}
 
     /**
      * Toggles if a particular addon is enabled.
-     * @param {string} idOrFile Addon ID or filename
+     * @param {A} addon Addon instance
+     * @returns {Promise<AddonStateStop | AddonStateStart<A>>}
      */
-    toggle(idOrAddon: string) {return this.#manager.toggleAddon(idOrAddon);}
+    toggle(addon: A): Promise<AddonStateStop | AddonStateStart<A>> {return this.#manager.toggleAddon(addon);}
 
     /**
      * Reloads if a particular addon is enabled.
-     * @param {string} idOrFile Addon ID or filename
+     * @param {A} addon Addon instance
+     * @returns {Promise<AddonStateLoad | AddonStateStarted<A>>}
      */
-    reload(idOrFileOrAddon: string) {return this.#manager.reloadAddon(idOrFileOrAddon);}
+    reload(addon: A): Promise<AddonStateLoad | AddonStateStarted<A>> {
+        return this.#manager.reloadAddon(addon);
+    }
 
     /**
      * Gets a particular addon.
      * @param {string} idOrFile Addon ID or filename
-     * @returns {object} Addon instance
+     * @returns {A} Addon instance
      */
     get(idOrFile: string) {return this.#manager.getAddon(idOrFile);}
 
     /**
      * Gets all addons of this type.
-     * @returns {Array<object>} Array of all addon instances
+     * @returns {A[]} Array of all addon instances
      */
-    getAll() {return this.#manager.addonList.map(a => this.#manager.getAddon(a.id));}
+    getAll(): A[] {return Object.values(this.#manager.cacheByName);}
 }
 
 Object.freeze(AddonAPI);

--- a/src/betterdiscord/api/index.ts
+++ b/src/betterdiscord/api/index.ts
@@ -1,7 +1,8 @@
 import BDLogger from "@common/logger";
 
-import PluginManager from "@modules/pluginmanager";
-import ThemeManager from "@modules/thememanager";
+import PluginManager, {type Plugin} from "@modules/pluginmanager";
+import ThemeManager, {type Theme} from "@modules/thememanager";
+
 import DiscordModules from "@modules/discordmodules";
 import Config from "@stores/config";
 
@@ -125,8 +126,8 @@ export default class BdApi {
     static ReactDOM = ReactDOM;
     static version = version;
 
-    static Plugins: AddonAPI;
-    static Themes: AddonAPI;
+    static Plugins: AddonAPI<Plugin>;
+    static Themes: AddonAPI<Theme>;
     static Webpack: typeof Webpack;
     static UI: typeof UI;
     static ReactUtils: typeof ReactUtils;

--- a/src/betterdiscord/builtins/commands/addons.ts
+++ b/src/betterdiscord/builtins/commands/addons.ts
@@ -1,12 +1,12 @@
 import {t} from "@common/i18n";
+import type {AddonSome, AddonType} from "@modules/addon";
+import {managerFromType} from "@modules/addonmanagerfrom";
 import {OptionTypes} from "@modules/commandmanager";
 import DiscordModules from "@modules/discordmodules";
-import Plugins from "@modules/pluginmanager";
-import Themes from "@modules/thememanager";
 
 
-export default (type: "plugin" | "theme") => {
-    const manager = type === "plugin" ? Plugins : Themes;
+export default (type: AddonType) => {
+    const manager = managerFromType(type);
 
     return {
         id: `${type}s`,
@@ -31,25 +31,22 @@ export default (type: "plugin" | "theme") => {
                 description: `Name of the ${type}`,
                 required: true,
                 get choices() {
-                    return manager.addonList.map(p => ({
-                        name: p.name,
-                        value: p.id
-                    }));
+                    return Object.entries(manager.cacheByName).map(([name, {id: value}]) => ({name, value}));
                 }
             }
         ],
-        execute: async (data, {channel}) => {
-            const action = data.find(o => o.name === "action").value;
-            const addonId = data.find(o => o.name === "name").value;
-            const addon = manager.getAddon(addonId)!;
+        execute: async (data: Array<{name: "name", value: string;} | {name: "action", value: "enable";}>, {channel}: {channel: {id: string;};}) => {
+            const action = data.find(o => o.name === "action")!.value;
+            const addonId = data.find(o => o.name === "name")!.value;
+            const addon = manager.getAddon(addonId)! as AddonSome;
             const isEnabled = manager.isEnabled(addon.id);
 
             if (action === "enable") {
                 if (isEnabled) return {content: `${addon.name} is already enabled!`};
 
-                const err = manager.enableAddon(addon.id);
+                const err = await manager.enableAddon(addon);
 
-                if (err) {
+                if (err.kind === "not-started") {
                     return {content: t("Addons.couldNotEnable", {name: addon.id})};
                 }
 
@@ -59,9 +56,9 @@ export default (type: "plugin" | "theme") => {
             if (action === "disable") {
                 if (!isEnabled) return {content: `${addon.name} is already disabled!`};
 
-                const err = manager.disableAddon(addon.id);
+                const err = await manager.disableAddon(addon);
 
-                if (err) {
+                if (err.kind === "not-stopped") {
                     return {content: t("Addons.couldNotDisable", {name: addon.id})};
                 }
 

--- a/src/betterdiscord/builtins/developer/recovery.tsx
+++ b/src/betterdiscord/builtins/developer/recovery.tsx
@@ -147,7 +147,7 @@ const ErrorDetails = ({componentStack, pluginInfo, stack, instance}) => {
                     <Button
                         className="bd-error-safe-mode"
                         onClick={async () => {
-                            pluginmanager.addonList.forEach((x) => pluginmanager.disableAddon(x.name));
+                            await pluginmanager.disableAllAddons();
                             await IPC.relaunch();
                         }}
                         color={Colors.RED}
@@ -181,9 +181,10 @@ export default new class Recovery extends Builtin {
         this.unpatchAll();
     }
 
-    getPluginInfo(pluginName) {
+    getPluginInfo(pluginName: string) {
         try {
             const plugin = pluginmanager.getPlugin(pluginName);
+            if (!plugin) return null;
             return {
                 name: plugin.name || pluginName,
                 githubUrl: plugin.source || plugin.github,
@@ -215,22 +216,25 @@ export default new class Recovery extends Builtin {
             if (foundIssue) {
                 const pluginName = `${foundIssue[2]}.plugin.js`;
                 pluginInfo = this.getPluginInfo(pluginName);
-                pluginmanager.disableAddon(foundIssue[2]);
-                NotificationUIInstance.show({
-                    id: "plugin-crash",
-                    title: t("Addons.disabled", {name: pluginName}),
-                    content: t("Modals.addonCrashed"),
-                    duration: Infinity,
-                    type: "info",
-                    icon: () => <Logo size={16} accent />,
-                    actions: [
-                        ...(config.isCanary ? [{
-                            label: "Re-enable",
-                            onClick: () => pluginmanager.enableAddon(foundIssue[2]),
-                            dontClose: true,
-                        }] : [])
-                    ]
-                });
+                const plugin = pluginmanager.getPlugin(foundIssue[2]);
+                if (plugin) {
+                    pluginmanager.disableAddon(plugin);
+                    NotificationUIInstance.show({
+                        id: "plugin-crash",
+                        title: t("Addons.disabled", {name: pluginName}),
+                        content: t("Modals.addonCrashed"),
+                        duration: Infinity,
+                        type: "info",
+                        icon: () => <Logo size={16} accent />,
+                        actions: [
+                            ...(config.isCanary ? [{
+                                label: "Re-enable",
+                                onClick: () => pluginmanager.enableAddon(plugin),
+                                dontClose: true,
+                            }] : [])
+                        ]
+                    });
+                }
             }
 
             buttons.className = clsx(buttons.className, "bd-recovery-buttons");

--- a/src/betterdiscord/data/web.ts
+++ b/src/betterdiscord/data/web.ts
@@ -1,3 +1,5 @@
+import type {AddonType} from "@modules/addonmanager";
+
 const HOSTNAME = "betterdiscord.app";
 /**
  * The current API version to use
@@ -55,15 +57,15 @@ export default class Web {
     /**
      * This will allow preloading of the addon channels
      * @param {string} channelId
-     * @returns {"plugin" | "theme" | undefined}
+     * @returns {AddonType | undefined}
      */
-    static getReleaseChannelType(channelId: string) {
+    static getReleaseChannelType(channelId: string): AddonType | undefined {
         if (releaseChannels.plugin.includes(channelId)) return "plugin";
         if (releaseChannels.theme.includes(channelId)) return "theme";
     }
 
     /** @param {string} rawGitURL  */
-    static convertToPreviewURL(rawGitURL: string) {
+    static convertToPreviewURL(rawGitURL: string): string {
         const match = rawGitURL.match(RAW_GIT_URL_REGEX);
 
         if (!match) {
@@ -83,7 +85,7 @@ export default class Web {
      * https://github.com/QWERTxD/BetterDiscordPlugins/blob/298752533fbbdab511c3a3f4ffe6afd41d0a93f1/CallTimeCounter/CallTimeCounter.plugin.js
      * @param {string} rawGitURL
      */
-    static convertRawToGitHubURL(rawGitURL: string) {
+    static convertRawToGitHubURL(rawGitURL: string): string {
         const match = rawGitURL.match(RAW_GIT_URL_REGEX);
 
         if (!match) {

--- a/src/betterdiscord/modules/addon.ts
+++ b/src/betterdiscord/modules/addon.ts
@@ -1,0 +1,7 @@
+import type {Plugin} from "./plugin";
+import type {Theme} from "./theme";
+
+export type AddonType = "plugin" | "theme";
+
+export type AddonAny = Plugin | Theme;
+export type AddonSome = Plugin & Theme;

--- a/src/betterdiscord/modules/addonbase.ts
+++ b/src/betterdiscord/modules/addonbase.ts
@@ -1,0 +1,20 @@
+import type {AddonMeta} from "./addonmeta";
+
+/**
+ * This is an abstract interface used for Plugin, Theme and similar direct types.
+ *
+ * Never use this type, consider using types from 'addon.ts' such as `AddonAny` instead.
+ */
+export interface AddonBase extends AddonMeta {
+    added: number;
+    donate?: string;
+    fileContent?: string;
+    filename: string;
+    format: string;
+    id: string;
+    modified: number;
+    partial?: boolean;
+    patreon?: string;
+    size: number;
+    slug: string;
+}

--- a/src/betterdiscord/modules/addonmanager.ts
+++ b/src/betterdiscord/modules/addonmanager.ts
@@ -18,6 +18,9 @@ import FloatingWindows from "@ui/floatingwindows";
 import Store from "@stores/base";
 import type {SystemError} from "bun";
 import RemoteAPI from "@polyfill/remote";
+import type {AddonMeta} from "./addonmeta";
+import type {AddonMetaLoad, AddonState, AddonStateLoad, AddonStateNotLoaded, AddonStateStart, AddonStateStarted, AddonStateStop} from "./addonstate";
+import type {AddonAny, AddonType} from "./addon";
 
 
 // const SWITCH_ANIMATION_TIME = 250;
@@ -34,152 +37,158 @@ const stripBOM = function (fileContent: string) {
     return fileContent;
 };
 
-// This is a temporary type, no one should rely on this externally
-export interface Addon {
-    added: number;
-    author: string;
-    authorId?: string;
-    authorLink?: string;
-    description: string;
-    donate?: string;
-    fileContent?: string;
-    filename: string;
-    format: string;
-    id: string;
-    invite?: string;
-    modified: number;
-    name: string;
-    partial?: boolean;
-    patreon?: string;
-    size: number;
-    slug: string;
-    source?: string;
-    version: string;
-    website?: string;
-}
+export default abstract class AddonManager<A extends AddonAny = AddonAny> extends Store {
 
+    protected abstract name: string;
 
-export default abstract class AddonManager extends Store {
+    abstract addonFolder(): string;
+    abstract validateFilename(base: string): boolean;
+    abstract initializeAddon(addon: A): Promise<AddonStateLoad>;
+    abstract startAddon(addon: A): Promise<AddonStateStart<A>>;
+    abstract stopAddon(addon: A): Promise<AddonStateStop>;
 
-    get name() {return "";}
-    get extension() {return "";}
-    get duplicatePattern() {return /./;}
-    get addonFolder() {return "";}
-    get language() {return "";}
-    get prefix() {return "";}
-    get order() {return 2;}
-
-    trigger(event: string, ...args: any[]) {
-        // Emit the events as a store for react
-        super.emitChange();
-
-        // Emit the events as a normal emitter while other parts
-        // of the codebase are still converting to stores
-        return Events.emit(`${this.prefix}-${event}`, ...args);
+    constructor(
+        public prefix: AddonType,
+        public language: string,
+        public order: number,
+    ) {
+        super();
+        this.pluralPrefix = prefix + "s";
     }
 
-    timeCache: Record<string, number> = {};
-    abstract addonList: Addon[];
-    state: Record<string, boolean> = {};
-    windows = new Set<string>();
-    hasInitialized = false;
-    initialAddonsLoaded = 0;
+    cacheByName: Record<string, A> = Object.create(null);
+    cacheByFilename: Record<string, A> = Object.create(null);
 
-    initialize() {
+    /**
+     * Stats for each relative addon file path.
+     *
+     * @example "example.plugin.js"
+     * @todo If you are implementing multi-file addons, it will be "example/index.js" or whatever you are implementing.
+     */
+    protected fileStats: Map<string, fs.Stats> = new Map();
+
+    public enablement: Record<string, boolean> = Object.create(null);
+
+    readonly pluralPrefix: string;
+
+    trigger(event: string, ...args: any[]): boolean {
+        super.emitChange();
+        return Events.emit(`${this.prefix}-${event}`, ...args);
+    };
+    async initialize(): Promise<Array<AddonState<A>>> {
         Settings.registerAddonPanel(this);
 
-        const errors = this.loadAllAddons();
-        if (this.initialAddonsLoaded > 0) {
-            Toasts.show(t("Addons.manyEnabled", {count: this.initialAddonsLoaded, context: this.prefix}));
+        const states = await this.loadAllAddons();
+        if (states.length > 0) {
+            Toasts.show(t("Addons.manyEnabled", {count: states.length, context: this.prefix}));
         }
-        this.hasInitialized = true;
-        return errors;
+        return states;
     }
 
-    // Subclasses should overload this and modify the addon object as needed to fully load it
-    abstract initializeAddon(addon: Addon): AddonError | undefined | void;
-
-    abstract startAddon(idOrAddon: string | Addon): AddonError | undefined | void;
-    abstract stopAddon(idOrAddon: string | Addon): AddonError | undefined | void;
-
-    loadState() {
-        const saved = JsonStore.get(`${this.prefix}s` as Files);
+    loadEnablement(): void {
+        const saved = JsonStore.get(this.pluralPrefix as Files);
         if (!saved) return;
-        Object.assign(this.state, saved);
+        Object.assign(this.enablement, saved);
     }
 
-    saveState() {
-        JsonStore.set(`${this.prefix}s` as Files, this.state);
+    saveState(): void {
+        JsonStore.set(this.pluralPrefix as Files, this.enablement);
     }
 
+    private watchTimers = new Map<string, Timer>();
     watcher?: fs.FSWatcher;
-    watchAddons() {
-        if (this.watcher) return Logger.err(this.name, `Already watching ${this.prefix} addons.`);
+    watchAddons(): void {
+        if (this.watcher) {
+            Logger.err(this.name, `Already watching ${this.prefix} addons.`);
+            return;
+        }
+
         Logger.log(this.name, `Starting to watch ${this.prefix} addons.`);
-        this.watcher = fs.watch(this.addonFolder, {persistent: false}, async (eventType, filename) => {
-            // console.log("watcher", eventType, filename, !eventType || !filename, !filename.endsWith(this.extension));
+
+        const addonFolder = this.addonFolder();
+        this.watcher = fs.watch(addonFolder, {persistent: false}, (eventType, filename) => {
             if (!eventType || !filename) return;
-            // console.log(eventType, filename)
 
-            const absolutePath = path.resolve(this.addonFolder, filename);
-            if (!filename.endsWith(this.extension)) {
-                // Lets check to see if this filename has the duplicated file pattern `something(1).ext`
-                const match = filename.match(this.duplicatePattern);
-                if (!match) return;
-                const ext = match[0];
-                const truncated = filename.replace(ext, "");
-                const newFilename = truncated + this.extension;
+            if (!this.validateFilename(filename)) {
+                return;
+            }
 
-                // If this file already exists, give a warning and move on.
-                if (fs.existsSync(newFilename)) {
-                    Logger.warn(this.name, `Duplicate files found: ${filename} and ${newFilename}`);
-                    return;
-                }
+            if (this.watchTimers.has(filename)) {
+                clearTimeout(this.watchTimers.get(filename)!);
+            }
 
-                // Rename the file and let it go on
+            const timer: Timer = setTimeout(async () => {
                 try {
-                    fs.renameSync(absolutePath, path.resolve(this.addonFolder, newFilename));
+                    Logger.info("AddonManager~watcher", eventType, filename);
+                    let addon = this.cacheByFilename[filename];
+
+                    if (!addon) {
+                        const loaded = await this.loadAddon(filename);
+                        if (loaded.kind === "not-loaded") {
+                            Logger.error(this.name, `Failed to instantiate ${filename}.`, loaded.error);
+                            return;
+                        }
+                        addon = loaded.addon as A;
+                        return;
+                    }
+
+                    const absolutePath = path.resolve(addonFolder, filename);
+                    let stats: fs.Stats;
+                    try {
+                        stats = await fs.promises.stat(absolutePath);
+                    }
+                    catch (err) {
+                        if ((err as SystemError).code !== "ENOENT" && !(err as SystemError)?.message.startsWith("ENOENT")) return;
+                        this.fileStats.delete(filename);
+                        Logger.info("AddonManager~watcher", "unload", eventType, filename);
+                        await this.unloadAddon(addon, true);
+                        return;
+                    }
+                    if (!stats.isFile()) return;
+                    if (this.fileStats.get(filename)?.mtimeMs === stats.mtimeMs) return;
+                    this.fileStats.set(filename, stats);
+
+                    if (eventType == "rename") {
+                        Logger.info("AddonManager~watcher", "load new", eventType, filename);
+                        const oldAddon = this.getAddon(addon.id)!;
+                        await this.loadAddon(filename, true);
+                        await this.unloadAddon(oldAddon, true);
+                    }
+                    else if (eventType == "change") {
+                        Logger.info("AddonManager~watcher", "reload", eventType, filename);
+                        await this.reloadAddon(addon, true);
+                    };
                 }
-                catch (error) {
-                    Logger.err(this.name, `Could not rename file: ${filename} ${newFilename}`, error);
+                finally {
+                    this.watchTimers.delete(filename);
                 }
-            }
-            // console.log("watcher", "before promise");
-            await new Promise(r => setTimeout(r, 100));
-            try {
-                const stats = fs.statSync(absolutePath);
-                // console.log("watcher", stats);
-                if (!stats.isFile()) return;
-                if (!stats || !stats.mtimeMs) return;
-                if (typeof (stats.mtimeMs) !== "number") return;
-                if (this.timeCache[filename] == stats.mtimeMs) return;
-                this.timeCache[filename] = stats.mtimeMs;
-                if (eventType == "rename") this.loadAddon(filename, true);
-                if (eventType == "change") this.reloadAddon(filename, true);
-            }
-            catch (err) {
-                // window.watcherError = err;
-                // console.log("watcher", err);
-                // console.dir(err);
-                if ((err as SystemError).code !== "ENOENT" && !(err as SystemError)?.message.startsWith("ENOENT")) return;
-                delete this.timeCache[filename];
-                this.unloadAddon(filename, true);
-            }
+            }, 1000);
+            this.watchTimers.set(filename, timer);
         });
     }
 
-    unwatchAddons() {
+    unwatchAddons(): void {
         if (!this.watcher) return Logger.error(this.name, `Was not watching ${this.prefix} addons.`);
         this.watcher.close();
         delete this.watcher;
         Logger.log(this.name, `No longer watching ${this.prefix} addons.`);
     }
 
-    extractMeta(fileContent: string, filename: string) {
+    extractMeta(fileContent: string, filename: string): AddonMetaLoad {
         const firstLine = fileContent.split("\n")[0];
 
         const hasMetaComment = firstLine.includes("/**");
-        if (!hasMetaComment) throw new AddonError(filename, filename, t("Addons.metaNotFound"), {message: "", stack: fileContent}, this.prefix);
+        if (!hasMetaComment) {
+            return {
+                kind: "not-loaded",
+                error: new AddonError({
+                    addonType: this.prefix,
+                    addon: {filename},
+                    message: t("Addons.metaNotFound"),
+                    cause: new TypeError(fileContent),
+                }),
+            };
+        };
         const metaInfo = this.parseJSDoc(fileContent);
 
         /**
@@ -191,10 +200,13 @@ export default abstract class AddonManager extends Store {
         if (!metaInfo.version || typeof (metaInfo.version) !== "string") metaInfo.version = "???";
         if (!metaInfo.description || typeof (metaInfo.description) !== "string") metaInfo.description = t("Addons.noDescription");
 
-        return metaInfo;
+        return {
+            kind: "loaded",
+            meta: metaInfo,
+        };
     }
 
-    parseJSDoc(fileContent: string) {
+    parseJSDoc(fileContent: string): AddonMeta {
         const block = fileContent.split("/**", 2)[1].split("*/", 1)[0];
         const out: Record<string, string | string[]> = {};
         let field = "";
@@ -226,241 +238,325 @@ export default abstract class AddonManager extends Store {
         }
         delete out[""];
         out.format = "jsdoc";
-        return out;
+        return out as unknown as AddonMeta;
     }
 
-    // Subclasses should overload this and modify the addon using the fileContent as needed to "require()"" the file
-    requireAddon(filename: string): Addon {
-        let fileContent = fs.readFileSync(filename, "utf8");
+    async requireAddon(filerel: string): Promise<AddonStateLoad> {
+        let fileContent = await fs.promises.readFile(filerel, "utf8");
         fileContent = stripBOM(fileContent);
-        const stats = fs.statSync(filename);
-        const addon = this.extractMeta(fileContent, path.basename(filename)) as Partial<Addon>;
+        const stats = fs.statSync(filerel);
+        const filename = path.basename(filerel);
+        const extract = this.extractMeta(fileContent, filename);
+        if (extract.kind === "not-loaded") {
+            return {
+                kind: "not-loaded",
+                error: new AddonError({
+                    addonType: this.prefix,
+                    addon: {filename},
+                    message: "Failed to parse addon's meta",
+                    cause: extract.error
+                }),
+            };
+        }
+        const addon = extract.meta as Partial<AddonAny>;
         if (!addon.author) addon.author = t("Addons.unknownAuthor");
         if (!addon.version) addon.version = "???";
         if (!addon.description) addon.description = t("Addons.noDescription");
         // if (!addon.name || !addon.author || !addon.description || !addon.version) return new AddonError(addon.name || path.basename(filename), filename, "Addon is missing name, author, description, or version", {message: "Addon must provide name, author, description, and version.", stack: ""}, this.prefix);
-        addon.id = addon.name || path.basename(filename);
-        addon.slug = path.basename(filename).replace(this.extension, "").replace(/ /g, "-");
-        addon.filename = path.basename(filename);
+        addon.id = addon.name || filename;
+        addon.slug = filename.replace(/.\w+.\w+$/, "").replace(/ /g, "-");
+        addon.filename = filename;
         addon.added = stats.atimeMs;
         addon.modified = stats.mtimeMs;
         addon.size = stats.size;
         addon.fileContent = fileContent;
-        if (this.addonList.find(c => c.id == addon.id)) throw new AddonError(addon.name!, filename, t("Addons.alreadyExists", {context: this.prefix, name: addon.name}), {}, this.prefix);
-        this.addonList.push(addon as Addon);
-        return addon as Addon;
+        if (this.getAddon(addon.id)) {
+            return {
+                kind: "not-loaded",
+                error: new AddonError({
+                    addonType: this.prefix,
+                    addon: addon as AddonAny,
+                    message: t("Addons.alreadyExists", {context: this.prefix, name: addon.name}),
+                }),
+            };
+        }
+        this.cacheByFilename[addon.filename] = addon as A;
+        if (addon.name) this.cacheByName[addon.name] = addon as A;
+        return {
+            kind: "loaded",
+            addon: addon as AddonAny,
+        };
     }
 
-    // Subclasses should use the return (if not AddonError) and push to this.addonList
-    loadAddon(filename: string, shouldToast = false): AddonError | false | undefined | void {
-        if (typeof (filename) === "undefined") return;
-        let addon;
-        try {
-            addon = this.requireAddon(path.resolve(this.addonFolder, filename));
-        }
-        catch (e) {
-            const partialAddon = this.addonList.find(c => c.filename == filename);
+    async loadAddon(filename: string, shouldToast = false): Promise<AddonStateLoad | AddonStateStarted<A>> {
+        const required = await this.requireAddon(path.resolve(this.addonFolder(), filename));
+        if (required.kind === "not-loaded") {
+            const partialAddon = this.cacheByFilename[filename];
             if (partialAddon) {
                 partialAddon.partial = true;
-                this.state[partialAddon.id] = false;
-                this.trigger("loaded", partialAddon);
+                this.enablement[partialAddon.id] = false;
             }
-            return e as AddonError;
+            return required;
         }
 
-
-        const error = this.initializeAddon(addon);
-        if (error) {
-            this.state[addon.id] = false;
+        const {addon} = required;
+        const inited = await this.initializeAddon(addon as A);
+        if (inited.kind === "not-loaded") {
+            this.enablement[addon.id] = false;
             addon.partial = true;
-            this.trigger("loaded", addon);
-            return error;
+            return inited;
         }
 
         if (shouldToast) Toasts.success(t("Addons.wasLoaded", {name: addon.name, version: addon.version}));
         this.trigger("loaded", addon);
 
-        if (!this.state[addon.id]) return this.state[addon.id] = false;
-        return this.startAddon(addon);
-    }
-
-    unloadAddon(idOrFileOrAddon: string | Addon, shouldToast = true, isReload = false) {
-        const addon = typeof (idOrFileOrAddon) == "string" ? this.addonList.find(c => c.id == idOrFileOrAddon || c.filename == idOrFileOrAddon) : idOrFileOrAddon;
-        // console.log("watcher", "unloadAddon", idOrFileOrAddon, addon);
-        if (!addon) return false;
-        if (this.state[addon.id]) {
-            if (isReload) this.stopAddon(addon);
-            else this.disableAddon(addon);
+        if (this.enablement[addon.id]) {
+            await this.startAddon(addon as A);
+        }
+        else if (this.enablement[addon.id] === undefined) {
+            this.enablement[addon.id] = false;
         }
 
-        this.addonList.splice(this.addonList.indexOf(addon), 1);
+        return {
+            kind: this.enablement[addon.id] ? "started" : "loaded",
+            addon: addon as A,
+        };
+    }
+
+    async unloadAddon(addon: A, shouldToast = true, isReload = false): Promise<boolean> {
+        if (typeof addon === "string") {
+            // NOTE: Currently, 'reload' is the only public consumer of the 'unloadAddon' logic.
+            const err = "'BdApi.Plugins.reload(string)' is deprecated, use 'BdApi.Plugins.reload(BdApi.Plugins.get(id))'.";
+            Logger.warn(this.name, err);
+            addon = this.getAddon(addon) as A;
+            if (!addon) {
+                return false;
+            }
+        }
+        // console.log("watcher", "unloadAddon", idOrFileOrAddon, addon);
+        if (!addon) return false;
+        if (this.enablement[addon.id]) {
+            if (isReload) await this.stopAddon(addon);
+            else await this.disableAddon(addon);
+        }
+
+        delete this.cacheByFilename[addon.filename];
+        delete this.cacheByName[addon.name];
         this.trigger("unloaded", addon);
         if (shouldToast) Toasts.success(t("Addons.wasUnloaded", {name: addon.name}));
         return true;
     }
 
-    reloadAddon(idOrFileOrAddon: string | Addon, shouldToast = true) {
-        const addon = typeof (idOrFileOrAddon) == "string" ? this.addonList.find(c => c.id == idOrFileOrAddon || c.filename == idOrFileOrAddon) : idOrFileOrAddon;
+    async reloadAddon(addon: A, shouldToast = true): Promise<AddonStateNotLoaded | AddonStateLoad | AddonStateStarted<A>> {
+        if (typeof addon === "string") {
+            const err = "'BdApi.Plugins.reload(string)' is deprecated, use 'BdApi.Plugins.reload(BdApi.Plugins.get(id))'.";
+            return {
+                kind: "not-loaded",
+                error: new AddonError({
+                    addonType: this.prefix,
+                    addon: {filename: String(addon)},
+                    message: t("Addons.methodError", {method: "reload(string)"}),
+                    cause: new Error(err),
+                }),
+            };
+        }
+        const didUnload = await this.unloadAddon(addon, shouldToast, true);
+        if (!didUnload) {
+            return {
+                kind: "not-loaded",
+                error: new AddonError({
+                    addonType: this.prefix,
+                    addon,
+                    message: "Failed to unload while reloading",
+                }),
+            };
+        }
+        return this.loadAddon(addon.filename, shouldToast);
+    }
+
+    isLoaded(idOrFile: string): boolean {
+        return this.getAddon(idOrFile) !== undefined;
+    }
+
+    isEnabled(idOrFile: string): boolean {
+        const addon = this.getAddon(idOrFile);
         if (!addon) return false;
-        const didUnload = this.unloadAddon(addon, shouldToast, true);
-        if (addon && !didUnload) return didUnload;
-        return this.loadAddon(addon ? addon.filename : idOrFileOrAddon as string, shouldToast);
+        return this.enablement[addon.id];
     }
 
-    isLoaded(idOrFile: string) {
-        const addon = this.addonList.find(c => c.id == idOrFile || c.filename == idOrFile);
-        if (!addon) return false;
-        return true;
+    getAddon(idOrFile: string): A | undefined {
+        return this.cacheByFilename[idOrFile] || this.cacheByName[idOrFile];
     }
 
-    isEnabled(idOrFile: string) {
-        const addon = this.addonList.find(c => c.id == idOrFile || c.filename == idOrFile);
-        if (!addon) return false;
-        return this.state[addon.id];
-    }
-
-    getAddon(idOrFile: string) {
-        return this.addonList.find(c => c.id == idOrFile || c.filename == idOrFile);
-    }
-
-    enableAddon(idOrAddon: string | Addon) {
-        const addon = typeof (idOrAddon) == "string" ? this.addonList.find(p => p.id == idOrAddon) : idOrAddon;
-        if (!addon || addon.partial) return;
-        if (this.state[addon.id]) return;
-        this.state[addon.id] = true;
+    async enableAddon(addon: A): Promise<AddonStateStart<A>> {
+        if (addon.partial || this.enablement[addon.id]) {
+            return {
+                kind: "not-started",
+                error: new AddonError({
+                    addonType: this.prefix,
+                    addon,
+                    message: t("Addons.couldNotEnable", {name: addon.id}),
+                }),
+            };
+        }
+        this.enablement[addon.id] = true;
         this.trigger("enabled", addon);
         // setTimeout(() => {
 
-        const err = this.startAddon(addon);
+        const err = await this.startAddon(addon);
         this.saveState();
         return err;
         // }, SWITCH_ANIMATION_TIME);
     }
 
-    enableAllAddons() {
+    async enableAllAddons(): Promise<Array<AddonStateStart<A>>> {
         const originalSetting = Settings.get("settings", "general", "showToasts");
         Settings.set("settings", "general", "showToasts", false);
-        for (let a = 0; a < this.addonList.length; a++) {
-            this.enableAddon(this.addonList[a]);
-        }
+        const results: Array<AddonStateStart<A>> = await Promise.all(Object.values(this.cacheByName).map(this.enableAddon.bind(this)));
         Settings.set("settings", "general", "showToasts", originalSetting);
         this.trigger("batch");
+        return results;
     }
 
-    disableAddon(idOrAddon: string | Addon) {
-        const addon = typeof (idOrAddon) == "string" ? this.addonList.find(p => p.id == idOrAddon) : idOrAddon;
-        if (!addon || addon.partial) return;
-        if (!this.state[addon.id]) return;
-        this.state[addon.id] = false;
+    async disableAddon(addon: A): Promise<AddonStateStop> {
+        if (addon.partial || !this.enablement[addon.id]) {
+            return {
+                kind: "not-stopped",
+                error: new AddonError({
+                    addonType: this.prefix,
+                    addon,
+                    message: t("Addons.couldNotDisable", {name: addon.id}),
+                }),
+            };
+        }
+        this.enablement[addon.id] = false;
         this.trigger("disabled", addon);
         // setTimeout(() => {
-        const err = this.stopAddon(addon);
+        const err = await this.stopAddon(addon);
         this.saveState();
         return err;
         // }, SWITCH_ANIMATION_TIME);
     }
 
-    disableAllAddons() {
+    async disableAllAddons(): Promise<AddonStateStop[]> {
         const originalSetting = Settings.get("settings", "general", "showToasts");
         Settings.set("settings", "general", "showToasts", false);
-        for (let a = 0; a < this.addonList.length; a++) {
-            this.disableAddon(this.addonList[a]);
-        }
+        const results: AddonStateStop[] = await Promise.all(Object.values(this.cacheByName).map(this.disableAddon.bind(this)));
         Settings.set("settings", "general", "showToasts", originalSetting);
         this.trigger("batch");
+        return results;
     }
 
-    toggleAddon(id: string) {
-        if (this.state[id]) this.disableAddon(id);
-        else this.enableAddon(id);
+    toggleAddon(addon: A): Promise<AddonStateStart<A> | AddonStateStop> {
+        if (this.enablement[addon.id]) return this.disableAddon(addon);
+        return this.enableAddon(addon);
     }
 
-    loadNewAddons() {
-        const files = fs.readdirSync(this.addonFolder);
-        const removed = this.addonList.filter(a => !files.includes(a.filename)).map(c => c.id);
-        const added = files.filter(f => !this.addonList.find(a => a.filename == f) && f.endsWith(this.extension) && fs.statSync(path.resolve(this.addonFolder, f)).isFile());
+    async loadNewAddons(): Promise<{added: string[]; removed: A[];}> {
+        const addonFolder = this.addonFolder();
+        const actual = new Set((await fs.promises.readdir(addonFolder)));
+        const known = new Set(Object.keys(this.cacheByFilename));
+        const removed = Array.from(known.difference(actual)).map(f => this.cacheByFilename[f]);
+        const potentialAdded = actual.difference(known);
+
+        const added: string[] = [];
+        for (const f of potentialAdded) {
+            const fullPath = path.resolve(addonFolder, f);
+            if (this.validateFilename(f)) {
+                const stats = await fs.promises.stat(fullPath);
+                if (stats.isFile()) {
+                    added.push(f);
+                }
+            }
+        }
         return {added, removed};
     }
 
-    updateList() {
-        const results = this.loadNewAddons();
-        for (const filename of results.added) this.loadAddon(filename);
-        for (const name of results.removed) this.unloadAddon(name);
+    async updateList(): Promise<void> {
+        const results = await this.loadNewAddons();
+        await Promise.all([
+            ...results.added.map(filename => this.loadAddon(filename)),
+            ...results.removed.map(addon => this.unloadAddon(addon)),
+        ]);
     }
 
-    loadAllAddons() {
-        this.loadState();
-        const errors = [];
-        const files = fs.readdirSync(this.addonFolder);
+    async loadAllAddons(): Promise<Array<AddonState<A>>> {
+        this.loadEnablement();
+        let states: Array<AddonState<A>> = [];
+        const addonFolder = this.addonFolder();
+        const files = await fs.promises.readdir(addonFolder);
+
+        type Resolved = {
+            filename: string;
+            absolute: string;
+            content: string;
+            stats: fs.Stats;
+            meta: AddonMeta;
+        };
+
+        const resolved: Resolved[] = [];
 
         for (const filename of files) {
-            const absolutePath = path.resolve(this.addonFolder, filename);
-            const stats = fs.statSync(absolutePath);
-            if (!stats || !stats.isFile()) continue;
-            this.timeCache[filename] = stats.mtimeMs;
-
-            if (!filename.endsWith(this.extension)) {
-                // Lets check to see if this filename has the duplicated file pattern `something(1).ext`
-                const match = filename.match(this.duplicatePattern);
-                if (!match) continue;
-                const ext = match[0];
-                const truncated = filename.replace(ext, "");
-                const newFilename = truncated + this.extension;
-
-                // If this file already exists, give a warning and move on.
-                if (fs.existsSync(newFilename)) {
-                    Logger.warn("AddonManager", `Duplicate files found: ${filename} and ${newFilename}`);
-                    continue;
-                }
-
-                // Rename the file and let it go on
-                fs.renameSync(absolutePath, path.resolve(this.addonFolder, newFilename));
+            if (!this.validateFilename(filename)) continue;
+            const absolute = path.resolve(addonFolder, filename);
+            const stats = await fs.promises.stat(absolute);
+            const content = await fs.promises.readFile(absolute, "utf8");
+            const extracted = await this.extractMeta(content, filename);
+            if (extracted.kind === "not-loaded") {
+                states.push(extracted);
+                continue;
             }
-            const addon = this.loadAddon(filename, false);
-            if (addon instanceof AddonError) errors.push(addon);
-            else if (addon !== false) this.initialAddonsLoaded++;
+            const meta = extracted.meta;
+            this.fileStats.set(filename, stats);
+            resolved.push({filename, absolute, content, stats, meta});
         }
+
+        const concurrency: Array<Promise<AddonStateLoad | AddonStateStarted<A>>> = [];
+        for (const {filename} of resolved) {
+            if (filename === "0BDFDB.plugin.js") {
+                // BDFDB only
+                states.push(await this.loadAddon(filename, false));
+                continue;
+            }
+            concurrency.push(this.loadAddon(filename, false));
+        }
+        states = states.concat(await Promise.all(concurrency));
 
         this.saveState();
         this.watchAddons();
-        return errors;
+        return states;
     }
 
-    deleteAddon(idOrFileOrAddon: string | Addon) {
-        const addon = typeof (idOrFileOrAddon) == "string" ? this.addonList.find(c => c.id == idOrFileOrAddon || c.filename == idOrFileOrAddon) : idOrFileOrAddon;
-        if (!addon) return;
+    deleteAddon(addon: A): Promise<void> {
         // console.log(path.resolve(this.addonFolder, addon.filename), fs.unlinkSync)
-        return fs.unlinkSync(path.resolve(this.addonFolder, addon.filename));
+        return fs.promises.unlink(path.resolve(this.addonFolder(), addon.filename));
     }
 
-    saveAddon(idOrFileOrAddon: string | Addon, content: string) {
-        const addon = typeof (idOrFileOrAddon) == "string" ? this.addonList.find(c => c.id == idOrFileOrAddon || c.filename == idOrFileOrAddon) : idOrFileOrAddon;
-        if (!addon) return;
-        return fs.writeFileSync(path.resolve(this.addonFolder, addon.filename), content);
+    saveAddon(addon: A, content: string): Promise<void> {
+        return fs.promises.writeFile(path.resolve(this.addonFolder(), addon.filename), content);
     }
 
-    editAddon(idOrFileOrAddon: string | Addon, system?: "system" | "detached" | "external" | boolean) {
-        const addon = typeof (idOrFileOrAddon) == "string" ? this.addonList.find(c => c.id == idOrFileOrAddon || c.filename == idOrFileOrAddon) : idOrFileOrAddon;
-        if (!addon) return;
-        const fullPath = path.resolve(this.addonFolder, addon.filename);
+    async editAddon(addon: A, system?: "system" | "detached" | "external" | boolean): Promise<void> {
+        const fullPath = path.resolve(this.addonFolder(), addon.filename);
         if (typeof (system) == "undefined") system = Settings.get("settings", "addons", "editAction");
         if (system === "system") return openItem(`${fullPath}`);
         else if (system === "external") return RemoteAPI.editor.open(this.prefix as "theme", addon.filename);
         return this.openDetached(addon);
     }
 
-    openDetached(addon: Addon) {
-        const fullPath = path.resolve(this.addonFolder, addon.filename);
-        const content = fs.readFileSync(fullPath).toString();
-
+    windows = new Set<string>();
+    async openDetached(addon: A): Promise<void> {
+        const fullPath = path.resolve(this.addonFolder(), addon.filename);
         if (this.windows.has(fullPath)) return;
+
+        const content = fs.promises.readFile(fullPath, "utf8");
         this.windows.add(fullPath);
 
         const editorRef = React.createRef<{resize(): void; hasUnsavedChanges: boolean;}>();
         const editor = React.createElement(AddonEditor, {
             id: "bd-floating-editor-" + addon.id,
             ref: editorRef,
-            content: content,
+            content: await content,
             save: this.saveAddon.bind(this, addon),
             openNative: this.editAddon.bind(this, addon, true),
             language: this.language

--- a/src/betterdiscord/modules/addonmanagerfrom.ts
+++ b/src/betterdiscord/modules/addonmanagerfrom.ts
@@ -1,0 +1,8 @@
+import type {AddonType} from "./addon";
+import pluginmanager from "./pluginmanager";
+import thememanager from "./thememanager";
+
+export type ManagerFromType<T extends AddonType> = T extends "plugin" ? typeof pluginmanager : typeof thememanager;
+export function managerFromType<T extends AddonType>(addonType: NoInfer<T>): ManagerFromType<T> {
+    return (addonType === "plugin" ? pluginmanager : thememanager) as ManagerFromType<T>;
+}

--- a/src/betterdiscord/modules/addonmeta.ts
+++ b/src/betterdiscord/modules/addonmeta.ts
@@ -1,0 +1,44 @@
+
+export interface AddonMeta {
+    /**
+     * The name of the addon. It typically does not contain spaces, but it is allowed.
+     */
+    name: string;
+    author: string;
+    /**
+     * A basic description of what the addon does.
+     */
+    description: string;
+    /**
+     * Version representing the current update level. Semantic versioning recommended.
+     */
+    version: string;
+    /**
+     * A Discord invite code, useful for directing users to a support server.
+     */
+    invite?: string;
+    /**
+     * Discord snowflake ID of the developer. This allows users to get in touch.
+     */
+    authorId?: string;
+    /**
+     * Link to use for the author's name on the addon pages.
+     */
+    authorLink?: string;
+    /**
+     * Link to donate to the developer.
+     */
+    donate?: string;
+    /**
+     * Link to the Patreon of the developer.
+     */
+    patreon?: string;
+    /**
+     * Developer's (or addon's) website link.
+     */
+    website?: string;
+    /**
+     * Link to the source on GitHub of the addon.
+     */
+    source?: string;
+}

--- a/src/betterdiscord/modules/addonstate.ts
+++ b/src/betterdiscord/modules/addonstate.ts
@@ -1,0 +1,48 @@
+import type AddonError from "@structs/addonerror";
+import type {AddonMeta} from "./addonmeta";
+import type {AddonAny} from "./addon";
+
+export type AddonMetaLoaded = {
+    kind: "loaded";
+    meta: AddonMeta;
+};
+export type AddonMetaNotLoaded = {
+    kind: "not-loaded";
+    error: AddonError;
+};
+export type AddonMetaLoad = AddonMetaLoaded | AddonMetaNotLoaded;
+
+export type AddonStateLoaded = {
+    kind: "loaded";
+    addon: AddonAny;
+};
+
+export type AddonStateNotLoaded = {
+    kind: "not-loaded";
+    error: AddonError;
+};
+
+export type AddonStateStarted<A extends AddonAny> = {
+    kind: "started";
+    addon: A;
+};
+
+export type AddonStateNotStarted = {
+    kind: "not-started";
+    error: AddonError;
+};
+
+export type AddonStateStopped = {
+    kind: "stopped";
+};
+
+export type AddonStateNotStopped = {
+    kind: "not-stopped";
+    error: AddonError;
+};
+
+export type AddonStateError = AddonStateNotLoaded | AddonStateNotStarted | AddonStateNotStopped;
+export type AddonStateLoad = AddonStateLoaded | AddonStateNotLoaded;
+export type AddonStateStart<A extends AddonAny> = AddonStateStarted<A> | AddonStateNotStarted;
+export type AddonStateStop = AddonStateStopped | AddonStateNotStopped;
+export type AddonState<A extends AddonAny> = AddonStateStart<A> | AddonStateLoad | AddonStateStop;

--- a/src/betterdiscord/modules/addonstore.ts
+++ b/src/betterdiscord/modules/addonstore.ts
@@ -16,13 +16,14 @@ import Settings from "@stores/settings";
 import Web from "@data/web";
 import AddonManager from "./addonmanager";
 import type {BdWebGuild, BdWebAddon} from "../types/betterdiscordweb";
+import type {AddonAny, AddonSome} from "./addon";
 
 
 /**
- * @param {Addon} addon
+ * @param {AddonAny} addon
  * @returns {Promise<boolean>}
  */
-function showConfirmDelete(addon: import("./addonmanager").Addon) {
+function showConfirmDelete(addon: AddonAny) {
     return new Promise(resolve => {
         Modals.showConfirmationModal(t("Modals.confirmAction"), t("Addons.confirmDelete", {name: addon.name}), {
             danger: true,
@@ -33,10 +34,7 @@ function showConfirmDelete(addon: import("./addonmanager").Addon) {
     });
 }
 
-/** @typedef {Addon} Addon */
-/** @typedef {Guild} Guild */
-
-class Guild {
+export class Guild {
 
     name: string;
     id: string;
@@ -100,13 +98,13 @@ class Guild {
     }
 }
 
-class Addon {
+export class Addon {
 
     id: number;
     name: string;
     avatar: string;
     author: string;
-    manager: AddonManager;
+    manager: typeof PluginManager | typeof ThemeManager;
     filename: string;
     type: "theme" | "plugin";
     description: string;
@@ -292,19 +290,20 @@ class Addon {
                     }
 
                     if (shouldEnable) {
-                        // Shouldn't need a try..catch but better safe than sorry
-                        try {
-                            const meta = AddonManager.prototype.extractMeta(text, this.filename);
-                            this.manager.state[meta.name as string || this.name] = true;
+                        const extracted = AddonManager.prototype.extractMeta(text, this.filename);
+                        let name: string;
+                        if (extracted.kind === "not-loaded") {
+                            name = this.name;
                         }
-                        catch {
-                            this.manager.state[this.name] = true;
+                        else {
+                            name = extracted.meta.name as string || this.name;
                         }
+                        this.manager.enablement[name] = true;
 
                         this.manager.saveState();
                     }
 
-                    fs.writeFileSync(path.join(this.manager.addonFolder, this.filename), text);
+                    fs.writeFileSync(path.join(this.manager.addonFolder(), this.filename), text);
 
                     Toasts.show(t("Addons.successfullyDownload", {name: this.name}), {
                         type: "success"
@@ -364,8 +363,8 @@ class Addon {
      * @public
      * @param {boolean} shouldSkipConfirm Should skip the confirm to delete the addon
      */
-    async delete(shouldSkipConfirm = false) {
-        const foundAddon = this.manager.addonList.find(a => a.filename == this.filename);
+    async delete(shouldSkipConfirm = false): Promise<void> {
+        const foundAddon = this.manager.cacheByFilename[this.filename];
 
         if (!foundAddon) return;
 
@@ -374,7 +373,7 @@ class Addon {
             if (!shouldDelete) return;
         }
 
-        if (this.manager.deleteAddon) this.manager.deleteAddon(foundAddon);
+        await this.manager.deleteAddon(foundAddon as AddonSome);
     }
 
     /** @public */

--- a/src/betterdiscord/modules/core.ts
+++ b/src/betterdiscord/modules/core.ts
@@ -87,11 +87,11 @@ export default new class Core {
 
         Logger.log("Startup", "Loading Plugins");
         // const pluginErrors = [];
-        const pluginErrors = PluginManager.initialize();
+        const pluginErrors = await PluginManager.initialize();
 
         Logger.log("Startup", "Loading Themes");
         // const themeErrors = [];
-        const themeErrors = ThemeManager.initialize();
+        const themeErrors = await ThemeManager.initialize();
 
         Logger.log("Startup", "Initializing Updater");
         Updater.initialize();
@@ -101,7 +101,10 @@ export default new class Core {
 
         // Show loading errors
         Logger.log("Startup", "Collecting Startup Errors");
-        Modals.showAddonErrors({plugins: pluginErrors, themes: themeErrors});
+        Modals.showAddonErrors({
+            plugins: pluginErrors.filter(stat => stat.kind.startsWith("not-")),
+            themes: themeErrors.filter(stat => stat.kind.startsWith("not-")),
+        });
 
         const previousVersion = JsonStore.get("misc", "version");
         if (Config.get("version") !== previousVersion) {

--- a/src/betterdiscord/modules/plugin.ts
+++ b/src/betterdiscord/modules/plugin.ts
@@ -1,0 +1,18 @@
+import type {AddonBase} from "./addonbase";
+import type {AddonMeta} from "./addonmeta";
+
+export interface PluginMeta extends AddonMeta {
+    use: string[];
+};
+
+export interface Plugin extends AddonBase, PluginMeta {
+    exports: any;
+    instance: {
+        load?(): void | Promise<void>;
+        start(): void | Promise<void>;
+        stop(): void | Promise<void>;
+        observer?(m: MutationRecord): void | Promise<void>;
+        getSettingsPanel?(): any | Promise<any>;
+        onSwitch?(): void | Promise<void>;
+    };
+}

--- a/src/betterdiscord/modules/pluginmanager.ts
+++ b/src/betterdiscord/modules/pluginmanager.ts
@@ -1,5 +1,5 @@
-import path from "path";
 import vm from "vm";
+import path from "path";
 
 import Logger from "@common/logger";
 
@@ -8,47 +8,24 @@ import Toasts from "@stores/toasts";
 
 import AddonError from "@structs/addonerror";
 
-import AddonManager, {type Addon} from "./addonmanager";
+import AddonManager from "./addonmanager";
 import {t} from "@common/i18n";
 import Events from "./emitter";
 
 import Modals from "@ui/modals";
+import type {Plugin} from "./plugin";
+import type {AddonStateLoad, AddonStateLoaded, AddonStateStart, AddonStateStop} from "./addonstate";
 
-
-export interface Plugin extends Addon {
-    exports: any;
-    instance: {
-        load?(): void;
-        start(): void;
-        stop(): void;
-        observer?(m: MutationRecord): void;
-        getSettingsPanel?(): any;
-        onSwitch?(): void;
-    };
-}
-
-const normalizeExports = (name: string) => `
-if (module.exports.default) {
-    module.exports = module.exports.default;
-}
-if (typeof(module.exports) !== "function") {
-    module.exports = eval("${name}");
-}`;
-
-export default new class PluginManager extends AddonManager {
-    get name() {return "PluginManager";}
-    get extension() {return ".plugin.js";}
-    get duplicatePattern() {return /\.plugin\s?\([0-9]+\)\.js/;}
-    get addonFolder() {return Config.get("pluginsPath");}
-    get prefix() {return "plugin" as const;}
-    get language() {return "javascript";}
-    get order() {return 3;}
-
-    addonList: Plugin[] = [];
+export default new class PluginManager extends AddonManager<Plugin> {
     observer: MutationObserver;
+    name = "PluginManager";
 
     constructor() {
-        super();
+        super(
+            "plugin",
+            "javascript",
+            3,
+        );
         this.onSwitch = this.onSwitch.bind(this);
         this.observer = new MutationObserver((mutations) => {
             for (let i = 0, mlen = mutations.length; i < mlen; i++) {
@@ -57,129 +34,304 @@ export default new class PluginManager extends AddonManager {
         });
     }
 
-    initialize() {
-        const errors = super.initialize();
+    async initialize() {
+        const errors = await super.initialize();
         this.setupFunctions();
         return errors;
     }
 
     /* Aliases */
     updatePluginList() {return this.updateList();}
-    loadAllPlugins() {return this.loadAllAddons();}
 
-    enablePlugin(idOrAddon: string | Plugin) {return this.enableAddon(idOrAddon);}
-    disablePlugin(idOrAddon: string | Plugin) {return this.disableAddon(idOrAddon);}
-    togglePlugin(id: string) {return this.toggleAddon(id);}
+    enablePlugin(plugin: Plugin) {return this.enableAddon(plugin);}
+    disablePlugin(plugin: Plugin) {return this.disableAddon(plugin);}
+    togglePlugin(plugin: Plugin) {return this.toggleAddon(plugin);}
 
-    unloadPlugin(idOrFileOrAddon: string | Plugin) {return this.unloadAddon(idOrFileOrAddon);}
+    unloadPlugin(plugin: Plugin) {return this.unloadAddon(plugin);}
     loadPlugin(filename: string) {return this.loadAddon(filename);}
 
-    loadAddon(filename: string, shouldCTE = true) {
-        const error = super.loadAddon(filename, shouldCTE);
-        if (error && shouldCTE) Modals.showAddonErrors({plugins: [error]});
-        return error;
+    async loadAddon(filename: string, shouldCTE = true) {
+        const load = await super.loadAddon(filename, shouldCTE);
+        if (load.kind === "not-loaded" && shouldCTE) Modals.showAddonErrors({plugins: [load]});
+        return load;
     }
 
-    reloadPlugin(idOrFileOrAddon: string | Plugin) {
-        const error = this.reloadAddon(idOrFileOrAddon);
-        if (error) Modals.showAddonErrors({plugins: [error]});
-        return typeof (idOrFileOrAddon) == "string" ? this.addonList.find(c => c.id == idOrFileOrAddon || c.filename == idOrFileOrAddon) : idOrFileOrAddon;
+    async reloadPlugin(plugin: Plugin) {
+        const reload = await this.reloadAddon(plugin);
+        if (reload.kind === "not-loaded") Modals.showAddonErrors({plugins: [reload]});
+        return typeof (plugin) == "string" ? this.getAddon(plugin) : plugin;
     }
 
     /* Overrides */
-    initializeAddon(addon: Plugin) {
-        if (!addon.exports || !addon.name) return new AddonError(addon.name || addon.filename, addon.filename, "Plugin had no exports or @name property", {message: "Plugin had no exports or no @name property. @name property is required for all addons.", stack: ""}, this.prefix);
+    addonFolder(): string {
+        return Config.get("pluginsPath");
+    }
+
+    validateFilename(base: string): boolean {
+        return base.endsWith(".plugin.js") || base.endsWith(".plugin.mjs");
+    }
+
+    async initializeAddon(addon: Plugin): Promise<AddonStateLoad> {
+        if (!addon.exports || !addon.name) {
+            return {
+                kind: "not-loaded",
+                error: new AddonError({
+                    addonType: this.prefix,
+                    addon,
+                    message: "Plugin had no exports or @name property",
+                }),
+            };
+        };
 
         try {
-            const isValid = typeof (addon.exports) === "function";
-            if (!isValid) return new AddonError(addon.name || addon.filename, addon.filename, "Plugin not a valid format.", {message: "Plugins should be either a function or a class", stack: ""}, this.prefix);
+            const isFunc = typeof addon.exports === "function";
+            const isObj = typeof addon.exports === "object";
+            const isValid = isFunc || isObj;
+            if (!isValid) {
+                return {
+                    kind: "not-loaded",
+                    error: new AddonError({
+                        addonType: this.prefix,
+                        addon,
+                        message: "Plugins should be either a function, object or a class"
+                    }),
+                };
+            };
 
             const PluginClass = addon.exports;
             const meta = Object.assign({}, addon);
             delete meta.exports;
-            const thePlugin = PluginClass.prototype ? new PluginClass(meta) : addon.exports(meta);
-            if (!thePlugin.start || !thePlugin.stop) return new AddonError(addon.name || addon.filename, addon.filename, "Missing start or stop function.", {message: "Plugins must have both a start and stop function.", stack: ""}, this.prefix);
+            const thePlugin = isObj ? addon.exports : PluginClass.prototype ? new PluginClass(meta) : addon.exports(meta);
+            if (!thePlugin.start || !thePlugin.stop) {
+                return {
+                    kind: "not-loaded",
+                    error: new AddonError({
+                        addonType: this.prefix,
+                        addon,
+                        message: "Plugins must have both a start and stop function."
+                    }),
+                };
+            };
 
             addon.instance = thePlugin;
             addon.name = thePlugin.getName ? thePlugin.getName() : addon.name;
             addon.author = thePlugin.getAuthor ? thePlugin.getAuthor() : addon.author;
             addon.description = thePlugin.getDescription ? thePlugin.getDescription() : addon.description;
             addon.version = thePlugin.getVersion ? thePlugin.getVersion() : addon.version;
-            if (!addon.name || !addon.author || !addon.description || !addon.version) return new AddonError(addon.name || addon.filename, addon.filename, "Plugin is missing name, author, description, or version", {message: "Plugin must provide name, author, description, and version.", stack: ""}, this.prefix);
+            if (!addon.name || !addon.author || !addon.description || !addon.version) {
+                return {
+                    kind: "not-loaded",
+                    error: new AddonError({
+                        addonType: this.prefix,
+                        addon,
+                        message: "Plugin must provide name, author, description, and version.",
+                    }),
+                };
+            };
             try {
-                if (typeof (addon.instance.load) == "function") addon.instance.load();
+                if (typeof (addon.instance.load) == "function") await addon.instance.load();
             }
             catch (error) {
-                this.state[addon.id] = false;
-                return new AddonError(addon.name, addon.filename, t("Addons.methodError", {method: "load()"}), {message: (error as Error).message, stack: (error as Error).stack}, this.prefix);
+                this.enablement[addon.id] = false;
+                return {
+                    kind: "not-loaded",
+                    error: new AddonError({
+                        addonType: this.prefix,
+                        addon,
+                        message: t("Addons.methodError", {method: "load()"}),
+                        cause: error as Error,
+                    }),
+                };
             }
         }
         catch (error) {
-            return new AddonError(addon.name, addon.filename, t("Addons.methodError", {method: "Plugin constructor()"}), {message: (error as Error).message, stack: (error as Error).stack}, this.prefix);
+            return {
+                kind: "not-loaded",
+                error: new AddonError({
+                    addonType: this.prefix,
+                    addon,
+                    message: t("Addons.methodError", {method: "constructor()"}),
+                    cause: error as Error,
+                }),
+            };
+        }
+        return {
+            kind: "loaded",
+            addon,
+        };
+    }
+
+    private async runIIFE(addon: Plugin): Promise<void> {
+        const module = {filename: addon.filename, exports: {} as any};
+        const extension = `\n//# sourceURL=betterdiscord://plugins/${addon.filename}`;
+        addon.fileContent += extension;
+        vm.compileFunction(addon.fileContent!, ["require", "module", "exports", "__filename", "__dirname"], {filename: path.basename(addon.filename)});
+        const wrappedPlugin = new Function("require", "module", "exports", "__filename", "__dirname", addon.fileContent!); // eslint-disable-line no-new-func
+        await wrappedPlugin(window.require, module, module.exports, module.filename, this.addonFolder());
+
+        if (module.exports.default) {
+            module.exports = module.exports.default;
+        }
+        if (typeof module.exports !== "function" && typeof module.exports !== "object") {
+            module.exports = null;
+        }
+        addon.exports = module.exports;
+        delete addon.fileContent;
+    }
+
+    private async requireIIFEAddon(loaded: AddonStateLoaded): Promise<AddonStateLoad> {
+        const addon = loaded.addon as Plugin;
+        try {
+            await this.runIIFE(addon);
+            return {
+                kind: "loaded",
+                addon,
+            };
+        }
+        catch (err) {
+            return {
+                kind: "not-loaded",
+                error: new AddonError({
+                    addonType: this.prefix,
+                    addon,
+                    message: t("Addons.compileError"),
+                    cause: err as Error,
+                }),
+            };
         }
     }
 
-    requireAddon(filename: string) {
-        const addon = super.requireAddon(filename) as Plugin;
+    private async requireESMAddon(loaded: AddonStateLoaded): Promise<AddonStateLoad> {
+        const addon = loaded.addon as Plugin;
+
         try {
-            const module = {filename, exports: {}};
-            // Test if the code is valid gracefully
-            vm.compileFunction(addon.fileContent!, ["require", "module", "exports", "__filename", "__dirname"], {filename: path.basename(filename)});
-            addon.fileContent += normalizeExports(addon.exports || addon.name);
-            addon.fileContent += `\n//# sourceURL=betterdiscord://plugins/${addon.filename}`;
-            const wrappedPlugin = new Function("require", "module", "exports", "__filename", "__dirname", addon.fileContent!); // eslint-disable-line no-new-func
-            wrappedPlugin(window.require, module, module.exports, module.filename, this.addonFolder);
-            addon.exports = module.exports;
-            delete addon.fileContent;
-            return addon;
+            addon.exports = await import("bd:addons/plugins/" + addon.filename + "?t=" + Date.now());
+            if (addon.exports.default) {
+                addon.exports = addon.exports.default;
+            }
+
+            return {
+                kind: "loaded",
+                addon,
+            };
         }
         catch (err) {
-            throw new AddonError(addon.name || addon.filename, filename, t("Addons.compileError"), {message: (err as Error).message, stack: (err as Error).stack}, this.prefix);
+            return {
+                kind: "not-loaded",
+                error: new AddonError({
+                    addonType: this.prefix,
+                    addon,
+                    message: t("Addons.compileError"),
+                    cause: err as Error,
+                }),
+            };
         }
     }
 
-    startAddon(idOrAddon: string | Plugin) {return this.startPlugin(idOrAddon);}
-    stopAddon(idOrAddon: string | Plugin) {return this.stopPlugin(idOrAddon);}
-    getAddon(id: string) {return this.getPlugin(id);}
-
-    startPlugin(idOrAddon: string | Plugin) {
-        const addon = typeof (idOrAddon) == "string" ? this.addonList.find(p => p.id == idOrAddon) : idOrAddon;
-        if (!addon) return;
-        const plugin = addon.instance;
-        try {
-            plugin.start();
+    async requireAddon(filename: string): Promise<AddonStateLoad> {
+        const requireResult = await super.requireAddon(path.resolve(this.addonFolder(), filename));
+        if (requireResult.kind === "not-loaded") return requireResult;
+        const plugin = requireResult.addon as Plugin;
+        const usesESM = plugin.use && plugin.use.includes("esm");
+        if (filename.endsWith(".plugin.mjs") || usesESM) {
+            return this.requireESMAddon(requireResult);
         }
-        catch (err) {
-            this.state[addon.id] = false;
-            this.trigger("disabled", addon);
-            Toasts.warning(t("Addons.couldNotStart", {name: addon.name, version: addon.version}));
-            Logger.stacktrace(this.name, `${addon.name} v${addon.version} could not be started.`, err as Error);
-            return new AddonError(addon.name, addon.filename, t("Addons.methodError", {method: "start()"}), {message: (err as Error).message, stack: (err as Error).stack}, this.prefix);
-        }
-        this.trigger("started", addon.id);
-
-        if (this.hasInitialized) Toasts.success(t("Addons.enabled", {name: addon.name, version: addon.version}));
+        return this.requireIIFEAddon(requireResult);
     }
 
-    stopPlugin(idOrAddon: string | Plugin) {
-        const addon = typeof (idOrAddon) == "string" ? this.addonList.find(p => p.id == idOrAddon) : idOrAddon;
-        if (!addon) return;
-        const plugin = addon.instance;
+    startAddon(plugin: Plugin) {return this.startPlugin(plugin);}
+    stopAddon(plugin: Plugin) {return this.stopPlugin(plugin);}
+    getAddon(idOrFile: string) {return this.getPlugin(idOrFile);}
+
+    async startPlugin(plugin: Plugin): Promise<AddonStateStart<Plugin>> {
+        if (typeof plugin === "string") {
+            const err = "'BdApi.Plugins.start(string)' is deprecated, use 'BdApi.Plugins.start(BdApi.Plugins.get(id))'.";
+            Logger.warn(this.name, err);
+            plugin = this.getPlugin(plugin) as Plugin;
+            if (!plugin) {
+                return {
+                    kind: "not-started",
+                    error: new AddonError({
+                        addonType: this.prefix,
+                        addon: {filename: String(plugin)},
+                        message: t("Addons.methodError", {method: "start(string)"}),
+                        cause: new Error(err),
+                    }),
+                };
+            }
+        }
+        const instance = plugin.instance;
         try {
-            plugin.stop();
+            instance.start();
         }
         catch (err) {
-            this.state[addon.id] = false;
-            Toasts.warning(t("Addons.couldNotStop", {name: addon.name, version: addon.version}));
-            Logger.stacktrace(this.name, `${addon.name} v${addon.version} could not be started.`, err as Error);
-            return new AddonError(addon.name, addon.filename, t("Addons.enabled", {method: "stop()"}), {message: (err as Error).message, stack: (err as Error).stack}, this.prefix);
+            this.enablement[plugin.id] = false;
+            this.trigger("disabled", plugin);
+            Toasts.warning(t("Addons.couldNotStart", {name: plugin.name, version: plugin.version}));
+            Logger.stacktrace(this.name, `${plugin.name} v${plugin.version} could not be started.`, err as Error);
+            return {
+                kind: "not-started",
+                error: new AddonError({
+                    addonType: this.prefix,
+                    addon: plugin,
+                    message: t("Addons.methodError", {method: "start(name)"}),
+                    cause: err as Error,
+                }),
+            };
         }
-        this.trigger("stopped", addon.id);
-        Toasts.error(t("Addons.disabled", {name: addon.name, version: addon.version}));
+        this.trigger("started", plugin.id);
+
+        Toasts.success(t("Addons.enabled", {name: plugin.name, version: plugin.version}));
+        return {
+            kind: "started",
+            addon: plugin,
+        };
+    }
+
+    async stopPlugin(plugin: Plugin): Promise<AddonStateStop> {
+        if (typeof plugin === "string") {
+            const err = "'BdApi.Plugins.stop(string)' is deprecated, use 'BdApi.Plugins.stop(BdApi.Plugins.get(id))'.";
+            Logger.warn(this.name, err);
+            plugin = this.getPlugin(plugin) as Plugin;
+            if (!plugin) {
+                return {
+                    kind: "not-stopped",
+                    error: new AddonError({
+                        addonType: this.prefix,
+                        addon: {filename: String(plugin)},
+                        message: t("Addons.methodError", {method: "stop(string)"}),
+                        cause: new Error(err),
+                    }),
+                };
+            }
+        }
+        const instance = plugin.instance;
+        try {
+            instance.stop();
+        }
+        catch (err) {
+            this.enablement[plugin.id] = false;
+            Toasts.warning(t("Addons.couldNotStop", {name: plugin.name, version: plugin.version}));
+            Logger.stacktrace(this.name, `${plugin.name} v${plugin.version} could not be started.`, err as Error);
+            return {
+                kind: "not-stopped",
+                error: new AddonError({
+                    addonType: this.prefix,
+                    addon: plugin,
+                    message: t("Addons.enabled", {method: "stop()"}),
+                    cause: err as Error,
+                }),
+            };
+        }
+        this.trigger("stopped", plugin.id);
+        Toasts.error(t("Addons.disabled", {name: plugin.name, version: plugin.version}));
+        return {
+            kind: "stopped",
+        };
     }
 
     getPlugin(idOrFile: string) {
-        const addon = this.addonList.find(c => c.id == idOrFile || c.filename == idOrFile);
+        const addon = super.getAddon(idOrFile);
         if (!addon) return;
         return addon;
     }
@@ -193,28 +345,39 @@ export default new class PluginManager extends AddonManager {
     }
 
     onSwitch() {
-        for (let i = 0; i < this.addonList.length; i++) {
-            if (!this.state[this.addonList[i].id]) continue;
-            const plugin = this.addonList[i].instance;
+        for (const id in this.enablement) {
+            const plugin = this.getAddon(id);
+            if (!plugin) {
+                continue;
+            }
+            const {instance} = plugin;
+            const {onSwitch} = instance;
             try {
-                if (typeof plugin?.onSwitch === "function") {
-                    plugin.onSwitch();
+                if (typeof onSwitch === "function") {
+                    onSwitch();
                 }
             }
-            catch (err) {Logger.stacktrace(this.name, `Unable to fire onSwitch for ${this.addonList[i].name} v${this.addonList[i].version}`, err as Error);}
+            catch (err) {Logger.stacktrace(this.name, `Unable to fire onSwitch for ${plugin.name} v${plugin.version}`, err as Error);}
         }
     }
 
     onMutation(mutation: MutationRecord) {
-        for (let i = 0; i < this.addonList.length; i++) {
-            if (!this.state[this.addonList[i].id]) continue;
-            const plugin = this.addonList[i].instance;
+        for (const id in this.enablement) {
+            const plugin = this.getAddon(id);
+            if (!plugin) {
+                continue;
+            }
+            const {instance} = plugin;
+            if (!instance) {
+                continue;
+            }
+            const {observer} = instance;
             try {
-                if (typeof plugin?.observer === "function") {
-                    plugin.observer(mutation);
+                if (typeof observer === "function") {
+                    observer(mutation);
                 }
             }
-            catch (err) {Logger.stacktrace(this.name, `Unable to fire observer for ${this.addonList[i].name} v${this.addonList[i].version}`, err as Error);}
+            catch (err) {Logger.stacktrace(this.name, `Unable to fire observer for ${plugin.name} v${plugin.version}`, err as Error);}
         }
     }
 };

--- a/src/betterdiscord/modules/theme.ts
+++ b/src/betterdiscord/modules/theme.ts
@@ -1,0 +1,6 @@
+import type {AddonBase} from "./addonbase";
+
+export interface Theme extends AddonBase {
+    css: string;
+    properties?: Record<string, Record<string, string | boolean>>;
+}

--- a/src/betterdiscord/modules/thememanager.ts
+++ b/src/betterdiscord/modules/thememanager.ts
@@ -3,17 +3,13 @@ import Toasts from "@stores/toasts";
 
 import AddonError from "@structs/addonerror";
 
-import AddonManager, {type Addon} from "./addonmanager";
+import AddonManager from "./addonmanager";
 import DOMManager from "./dommanager";
 import {t} from "@common/i18n";
 
 import Modals from "@ui/modals";
-
-
-export interface Theme extends Addon {
-    css: string;
-    properties?: Record<string, Record<string, string | boolean>>;
-}
+import type {Theme} from "./theme";
+import type {AddonStateLoad, AddonStateStart, AddonStateStop} from "./addonstate";
 
 const propertyRegex = /@property\s+--([A-Za-z0-9-_]+)\s*\{(.+?)\}/gs;
 
@@ -32,65 +28,93 @@ function parseProperty(raw: string) {
     return out;
 }
 
-export default new class ThemeManager extends AddonManager {
-    get name() {return "ThemeManager";}
-    get extension() {return ".theme.css";}
-    get duplicatePattern() {return /\.theme\s?\([0-9]+\)\.css/;}
-    get addonFolder() {return Config.get("themesPath");}
-    get prefix() {return "theme" as const;}
-    get language() {return "css";}
-    get order() {return 4;}
+export default new class ThemeManager extends AddonManager<Theme> {
+    name = "ThemeManager";
 
-    addonList: Theme[] = [];
+    constructor() {
+        super(
+            "theme",
+            "css",
+            4,
+        );
+    }
+
+    validateFilename(base: string): boolean {
+        return base.endsWith(".theme.css");
+    }
+
+    addonFolder(): string {
+        return Config.get("themesPath");
+    }
 
     /* Aliases */
     updateThemeList() {return this.updateList();}
     loadAllThemes() {return this.loadAllAddons();}
 
-    enableTheme(idOrAddon: string | Theme) {return this.enableAddon(idOrAddon);}
-    disableTheme(idOrAddon: string | Theme) {return this.disableAddon(idOrAddon);}
-    toggleTheme(id: string) {return this.toggleAddon(id);}
+    enableTheme(theme: Theme) {return this.enableAddon(theme);}
+    disableTheme(theme: Theme) {return this.disableAddon(theme);}
+    toggleTheme(theme: Theme) {return this.toggleAddon(theme);}
 
-    unloadTheme(idOrFileOrAddon: string | Theme) {return this.unloadAddon(idOrFileOrAddon);}
+    unloadTheme(theme: Theme) {return this.unloadAddon(theme);}
     loadTheme(filename: string) {return this.loadAddon(filename);}
-    reloadTheme(idOrFileOrAddon: string | Theme) {return this.reloadAddon(idOrFileOrAddon);}
+    reloadTheme(theme: Theme) {return this.reloadAddon(theme);}
 
-    loadAddon(filename: string, shouldCTE = true) {
-        const error = super.loadAddon(filename, shouldCTE);
-        if (error && shouldCTE) Modals.showAddonErrors({themes: [error]});
-        return error;
+    async loadAddon(filename: string, shouldCTE = true) {
+        const load = await super.loadAddon(filename, shouldCTE);
+        if (load.kind === "not-loaded" && shouldCTE) Modals.showAddonErrors({themes: [load]});
+        return load;
     }
 
     /* Overrides */
-    initializeAddon(addon: Theme) {
-        if (!addon.name || !addon.author || !addon.description || !addon.version) return new AddonError(addon.name || addon.filename, addon.filename, "Addon is missing name, author, description, or version", {message: "Addon must provide name, author, description, and version.", stack: ""}, this.prefix);
+    async initializeAddon(addon: Theme): Promise<AddonStateLoad> {
+        if (!addon.name || !addon.author || !addon.description || !addon.version) {
+            return {
+                kind: "not-loaded",
+                error: new AddonError({
+                    addonType: this.prefix,
+                    addon,
+                    message: "Addon must provide name, author, description, and version.",
+                }),
+            };
+        }
+        return {
+            kind: "loaded",
+            addon,
+        };
     }
 
-    requireAddon(filename: string) {
-        const addon = super.requireAddon(filename) as Theme;
+    async requireAddon(filename: string) {
+        const require = await super.requireAddon(filename);
+        if (require.kind === "not-loaded") {
+            return require;
+        }
+        const addon = require.addon as Theme;
         addon.css = addon.fileContent!;
         delete addon.fileContent;
         const properties = this.extractCustomProperties(addon.css);
         addon.properties = properties;
-        return addon;
+        return require;
     }
 
-    startAddon(idOrAddon: string | Theme) {return this.addTheme(idOrAddon);}
-    stopAddon(idOrAddon: string | Theme) {return this.removeTheme(idOrAddon);}
+    startAddon(theme: Theme) {return this.addTheme(theme);}
+    stopAddon(theme: Theme) {return this.removeTheme(theme);}
 
-    addTheme(idOrAddon: string | Theme) {
-        const addon = typeof (idOrAddon) == "string" ? this.addonList.find(p => p.id == idOrAddon) : idOrAddon;
-        if (!addon) return;
-        DOMManager.injectTheme(addon.slug + "-theme-container", addon.css);
+    async addTheme(theme: Theme): Promise<AddonStateStart<Theme>> {
+        DOMManager.injectTheme(theme.slug + "-theme-container", theme.css);
 
-        if (this.hasInitialized) Toasts.success(t("Addons.enabled", {name: addon.name, version: addon.version}));
+        Toasts.success(t("Addons.enabled", {name: theme.name, version: theme.version}));
+        return {
+            kind: "started",
+            addon: theme,
+        };
     }
 
-    removeTheme(idOrAddon: string | Theme) {
-        const addon = typeof (idOrAddon) == "string" ? this.addonList.find(p => p.id == idOrAddon) : idOrAddon;
-        if (!addon) return;
+    async removeTheme(addon: Theme): Promise<AddonStateStop> {
         DOMManager.removeTheme(addon.slug + "-theme-container");
         Toasts.error(t("Addons.disabled", {name: addon.name, version: addon.version}));
+        return {
+            kind: "stopped",
+        };
     }
 
     extractCustomProperties(css: string) {

--- a/src/betterdiscord/modules/updater.ts
+++ b/src/betterdiscord/modules/updater.ts
@@ -24,11 +24,12 @@ import Notifications from "@ui/notifications";
 import Modals from "@ui/modals";
 import UpdaterPanel from "@ui/updater";
 import Web from "@data/web";
-import type AddonManager from "./addonmanager";
 import type {Release} from "github";
 import type {BdWebAddon} from "betterdiscordweb";
 import {Logo} from "@ui/logo";
 import {RefreshCcwIcon} from "lucide-react";
+import {managerFromType} from "./addonmanagerfrom";
+import type {AddonType} from "./addon";
 
 const getJSON = (url: string) => {
     return new Promise(resolve => {
@@ -243,52 +244,48 @@ export class CoreUpdater {
 
 
 export class AddonUpdater {
-    manager: AddonManager;
-    type: "plugin" | "theme";
+    manager: typeof PluginManager | typeof ThemeManager;
+    addonType: AddonType;
     cache: Record<string, {name: string; version: string; id: number;}> | Record<string, never>;
-    pending: string[];
+    readonly pending = new Set<string>();
 
-    constructor(type: "plugin" | "theme") {
-        this.manager = type === "plugin" ? PluginManager : ThemeManager;
-        this.type = type;
+    constructor(addonType: AddonType) {
+        this.manager = managerFromType(addonType);
+        this.addonType = addonType;
         this.cache = {};
-        this.pending = [];
     }
 
     async initialize() {
         await this.updateCache();
         if (SettingsStore.get("addons", "checkForUpdates")) this.checkAll();
 
-        Events.on(`${this.type}-loaded`, addon => {
+        Events.on(`${this.addonType}-loaded`, addon => {
             if (!SettingsStore.get("addons", "checkForUpdates")) return;
             this.checkForUpdate(addon.filename, addon.version);
         });
 
-        Events.on(`${this.type}-unloaded`, addon => {
-            const index = this.pending.indexOf(addon.filename);
-            if (index >= 0) this.pending.splice(index, 1);
+        Events.on(`${this.addonType}-unloaded`, addon => {
+            this.pending.delete(addon.filename);
         });
     }
 
     async updateCache() {
         this.cache = {};
-        this.pending.length = 0;
-        const addonData = (await getJSON(Web.store[(this.type + "s") as keyof typeof Web.store] as string)) as BdWebAddon[];
+        this.pending.clear();
+        const addonData = (await getJSON(Web.store[(this.addonType + "s") as keyof typeof Web.store] as string)) as BdWebAddon[];
         addonData.reduce(reducer, this.cache as Record<string, never>);
-    }
-
-    clearPending() {
-        this.pending.splice(0, this.pending.length);
     }
 
     async checkAll(showNotice = true) {
         await this.updateCache();
-        for (const addon of this.manager.addonList) this.checkForUpdate(addon.filename, addon.version);
+        for (const filename in this.manager.cacheByFilename) {
+            this.checkForUpdate(filename, this.manager.cacheByFilename[filename].version);
+        }
         if (showNotice) this.showUpdateNotice();
     }
 
     checkForUpdate(filename: string, currentVersion: string) {
-        if (this.pending.includes(filename)) return;
+        if (this.pending.has(filename)) return;
         const info = this.cache[path.basename(filename)];
         if (!info) return;
         let hasUpdate = info.version > currentVersion;
@@ -296,7 +293,7 @@ export class AddonUpdater {
             hasUpdate = semverComparator(currentVersion, info.version) > 0;
         }
         if (!hasUpdate) return;
-        this.pending.push(filename);
+        this.pending.add(filename);
     }
 
     async updateAddon(filename: string) {
@@ -314,18 +311,18 @@ export class AddonUpdater {
                 return;
             }
 
-            const file = path.join(path.resolve(this.manager.addonFolder), filename);
+            const file = path.join(path.resolve(this.manager.addonFolder()), filename);
             fileSystem.writeFile(file, body.toString(), () => {
                 Toasts.success(t("Updater.addonUpdated", {name: info.name, version: info.version}));
-                this.pending.splice(this.pending.indexOf(filename), 1);
+                this.pending.delete(filename);
             });
         });
     }
 
     showUpdateNotice() {
-        if (!this.pending.length) return;
+        if (!this.pending.size) return;
 
-        const addonDetails = this.pending.map(filename => {
+        const addonDetails = Array.from(this.pending).map(filename => {
             const info = this.cache[path.basename(filename)];
             return {
                 name: info ? info.name : filename,
@@ -334,10 +331,10 @@ export class AddonUpdater {
         });
 
         Notifications.show({
-            id: `addon-updates-${this.type}`,
+            id: `addon-updates-${this.addonType}`,
             title: t("Updater.addonUpdaterNotificationTitle"),
             content: [
-                t("Updater.addonUpdatesAvailable", {count: this.pending.length, context: this.type}),
+                t("Updater.addonUpdatesAvailable", {count: this.pending.size, context: this.addonType}),
                 React.createElement("ul", {className: "bd-notification-updates-list"},
                     addonDetails.map(addon =>
                         React.createElement("li", {}, [

--- a/src/betterdiscord/polyfill/fs.ts
+++ b/src/betterdiscord/polyfill/fs.ts
@@ -165,7 +165,46 @@ export const createWriteStream = (path: string, options: object) => {
 export const unlinkSync = (path: string) => Remote.filesystem.unlinkSync(path);
 export const unlink = (path: string) => Remote.filesystem.unlinkSync(path);
 
+export const promises = {
+    readFile: (path: string, options: object | BufferEncoding = "utf8") =>
+        Remote.filesystem.promises.readFile(path, options),
+
+    writeFile: (path: string, data: string | Uint8Array, options?: WriteOptions) =>
+        Remote.filesystem.promises.writeFile(path, data, options),
+
+    readdir: (path: string, options: object) =>
+        Remote.filesystem.promises.readDirectory(path, options),
+
+    mkdir: (path: string, options: object) =>
+        Remote.filesystem.promises.createDirectory(path, options),
+
+    rmdir: (path: string, options: object) =>
+        Remote.filesystem.promises.deleteDirectory(path, options),
+
+    rm: (path: string) =>
+        Remote.filesystem.promises.rm(path),
+
+    exists: (path: string) =>
+        Remote.filesystem.promises.exists(path),
+
+    stat: (path: string, options: object) =>
+        Remote.filesystem.promises.getStats(path, options),
+
+    lstat: (path: string, options: object) =>
+        Remote.filesystem.promises.getStats(path, options),
+
+    rename: (oldPath: string, newPath: string) =>
+        Remote.filesystem.promises.rename(oldPath, newPath),
+
+    realpath: (path: string, options: object) =>
+        Remote.filesystem.promises.getRealPath(path, options),
+
+    unlink: (path: string) =>
+        Remote.filesystem.promises.unlink(path)
+};
+
 export default {
+    promises,
     readFile,
     exists,
     existsSync,

--- a/src/betterdiscord/stores/settings.ts
+++ b/src/betterdiscord/stores/settings.ts
@@ -8,7 +8,7 @@ import DiscordModules from "@modules/discordmodules";
 import {t} from "@common/i18n";
 import Store from "./base";
 import type {ComponentType} from "react";
-import type AddonManager from "@modules/addonmanager";
+import type {default as AddonManager} from "@modules/addonmanager";
 import {PaletteIcon, PlugIcon, type LucideIcon} from "lucide-react";
 
 export interface SettingsCollection {
@@ -81,15 +81,15 @@ export default new class SettingsManager extends Store {
     }
 
     registerAddonPanel(manager: AddonManager) {
-        const plural = manager.prefix + "s";
-        const title = t(`Panels.${plural as "plugins" | "themes"}`)!;
+        const plural = manager.pluralPrefix as "plugins" | "themes";
+        const title = t(`Panels.${plural}`)!;
 
         this.registerPanel(plural, title, {
             order: manager.order,
             type: "addon",
             manager: manager,
             icon: manager.prefix === "plugin" ? PlugIcon : PaletteIcon,
-            searchable: () => manager.addonList.flatMap((addon) => [addon.name, addon.filename])
+            searchable: () => Array.from(new Set([...Object.keys(manager.cacheByName), ...Object.keys(manager.cacheByFilename)]))
         });
     }
 

--- a/src/betterdiscord/structs/addonerror.ts
+++ b/src/betterdiscord/structs/addonerror.ts
@@ -1,12 +1,28 @@
-export default class AddonError<T extends {message?: string, stack?: string;} = {message?: string, stack?: string;}> extends Error {
-    file: string;
-    error: T;
-    type: string;
-    constructor(name: string, filename: string, message: string, error: T, type: string) {
-        super(message);
-        this.name = name;
-        this.file = filename;
-        this.error = error;
-        this.type = type;
+import type {AddonType} from "@modules/addonmanager";
+
+export interface AddonErrorOptions<T extends Error> {
+    addonType: AddonType;
+    addon: {
+        name?: string;
+        filename: string;
+    };
+    message: string;
+    cause?: T;
+}
+export default class AddonError<T extends Error | SyntaxError = Error | SyntaxError> extends Error {
+    override name = "AddonError";
+    addon: {
+        name?: string;
+        filename: string;
+    };
+    addonType: AddonType;
+    constructor(options: AddonErrorOptions<T>) {
+        super(options.message, {cause: options.cause});
+        const {addon} = options;
+        this.addon = {
+            name: addon.name || addon.filename || "<missing name>",
+            filename: addon.filename || "<missing file>",
+        };
+        this.addonType = options.addonType;
     }
 }

--- a/src/betterdiscord/types/discord/modules.d.ts
+++ b/src/betterdiscord/types/discord/modules.d.ts
@@ -172,11 +172,11 @@ export interface InviteActions {
 export type RuleTypes = "heading" | "nptable" | "lheading" | "hr" | "codeBlock" | "fence" | "blockQuote" | "list" | "def" | "table" | "newline" | "paragraph" | "escape" | "tableSeparator" | "autolink" | "mailto" | "url" | "link" | "image" | "reflink" | "refimage" | "em" | "strong" | "u" | "del" | "inlineCode" | "br" | "text";
 
 export type Rule = {
-    html?: (e: {content: string;}, t: (s: string, o: object) => string, n: object) => string;
+    html?: (e: {content: string;}, t: ((s: string, o: object) => string), n: object) => string;
     match: ((s: string, o: {inline: boolean;}) => RegExpExecArray) & {regex: RegExp;};
     order: number;
-    parse: (e: RegExpExecArray, t: (s: string, o: object) => string, n: object) => {content: string;};
-    react?: (e: Record<string, any>, t: (s: string, o: object) => string, n: object) => ReactElement;
+    parse: (e: RegExpExecArray, t: ((s: string, o: object) => string), n: object) => {content: string;};
+    react?: (e: Record<string, any>, t: null | ((s: string, o: object) => string), n: object) => ReactElement;
     requiredFirstCharacters?: string[];
 };
 

--- a/src/betterdiscord/ui/misc/storeembed.tsx
+++ b/src/betterdiscord/ui/misc/storeembed.tsx
@@ -41,7 +41,7 @@ export default function AddonEmbed({id, original}: {id: string; original: ReactN
                 (tag, state) => setTags(($tags) => ({...$tags, [tag]: state ?? !$tags[tag]}))
             ]}
         >
-            <AddonCard addon={addon} isEmbed />
+            <AddonCard addonStore={addon} isEmbed />
         </TagContext.Provider>
     );
 }

--- a/src/betterdiscord/ui/modals.ts
+++ b/src/betterdiscord/ui/modals.ts
@@ -26,7 +26,9 @@ import ChangelogModal, {type ChangelogProps} from "./modals/changelog";
 import ModalStack, {generateKey} from "./modals/stack";
 import {Filters, getMangled} from "@webpack";
 import type {ComponentType, ReactElement, ReactNode, RefObject} from "react";
-import type AddonError from "@structs/addonerror";
+import type {Plugin} from "@modules/pluginmanager.js";
+import type {AddonState} from "@modules/addonmanager.js";
+import type {Theme} from "@modules/thememanager.js";
 
 
 const queue: Array<() => void> = [];
@@ -209,13 +211,13 @@ export default class Modals {
         return modalKey;
     }
 
-    static showAddonErrors({plugins: pluginErrors = [], themes: themeErrors = []}: {plugins?: AddonError[]; themes?: AddonError[];}) {
-        if (!pluginErrors || !themeErrors || !this.shouldShowAddonErrors) return;
+    static showAddonErrors({plugins: pluginErrors = [], themes: themeErrors = []}: {plugins?: Array<AddonState<Plugin>>; themes?: Array<AddonState<Theme>>;}) {
         if (!pluginErrors.length && !themeErrors.length) return;
+        if (!this.shouldShowAddonErrors) return;
 
         const options = {
-            pluginErrors: Array.isArray(pluginErrors) ? pluginErrors : [],
-            themeErrors: Array.isArray(themeErrors) ? themeErrors : []
+            pluginErrors: pluginErrors,
+            themeErrors: themeErrors,
         };
         this.openModal(props => {
             return React.createElement(ErrorBoundary, {id: "showAddonErrors", name: "Modals"}, React.createElement(AddonErrorModal, Object.assign(options, props)));

--- a/src/betterdiscord/ui/modals/addonerrormodal.tsx
+++ b/src/betterdiscord/ui/modals/addonerrormodal.tsx
@@ -13,19 +13,41 @@ import ModalRoot from "./root";
 import Footer from "./footer";
 import {ChevronRightIcon, PlugIcon, InfoIcon, PaletteIcon} from "lucide-react";
 import clsx from "clsx";
-import type AddonErrorType from "@structs/addonerror";
+import AddonErrorType from "@structs/addonerror";
 import DiscordModules from "@modules/discordmodules";
+import Logger from "@common/logger";
+import type {AddonState} from "@modules/addonstate";
+import type {Plugin} from "@modules/plugin";
+import type {Theme} from "@modules/theme";
 
 const Parser = DiscordModules.SimpleMarkdownWrapper.defaultRules;
 const {useState, useCallback, useMemo} = React;
 
+function getFullStack(err: Error): string {
+    if (err instanceof AddonErrorType && err.cause instanceof SyntaxError && "loc" in err.cause) {
+        // const loc = err.cause.loc as Record<"line" | "column", number>;
+        return err.cause.message;
+    }
+    let stack = err.stack || `${err.name}: ${err.message}`;
+
+    if (err.cause instanceof Error) {
+        stack += `\n\nCaused by: ${getFullStack(err.cause)}`;
+    }
+
+    return stack;
+}
 
 function AddonError({err, index}: {err: AddonErrorType; index: number;}) {
     const [expanded, setExpanded] = useState(false);
     const toggle = useCallback(() => setExpanded(!expanded), [expanded]);
 
+    const stack = useMemo(() => {
+        const fullStack = getFullStack(err);
+        Logger.error("AddonError", err);
+        return fullStack;
+    }, [err]);
+
     function renderErrorBody() {
-        const stack = err?.error?.stack ?? err.stack;
         if (!expanded || !stack) return null;
         return <div className="bd-addon-error-body">
             <Divider />
@@ -35,13 +57,13 @@ function AddonError({err, index}: {err: AddonErrorType; index: number;}) {
         </div>;
     }
 
-    return <details key={`${err.type}-${index}`} className={clsx("bd-addon-error", (expanded) ? "expanded" : "collapsed")}>
+    return <details key={`${err.addonType}-${index}`} className={clsx("bd-addon-error", (expanded) ? "expanded" : "collapsed")}>
         <summary className="bd-addon-error-header" onClick={toggle} >
             <div className="bd-addon-error-icon">
-                {err.type == "plugin" ? <PlugIcon /> : <PaletteIcon />}
+                {err.addonType == "plugin" ? <PlugIcon /> : <PaletteIcon />}
             </div>
             <div className="bd-addon-error-header-inner">
-                <Text tag="h3" size={Text.Sizes.SIZE_16} color={Text.Colors.HEADER_PRIMARY} strong={true}>{err.name}</Text>
+                <Text tag="h3" size={Text.Sizes.SIZE_16} color={Text.Colors.HEADER_PRIMARY} strong={true}>{err.addon.name}</Text>
                 <div className="bd-addon-error-details">
                     <InfoIcon className="bd-addon-error-details-icon" size="16px" />
                     <Text color={Text.Colors.HEADER_SECONDARY} size={Text.Sizes.SIZE_12}>{err.message}</Text>
@@ -54,23 +76,33 @@ function AddonError({err, index}: {err: AddonErrorType; index: number;}) {
 }
 
 
-function generateTab(id: string, errors: AddonErrorType[]) {
-    return {id, errors, name: t(`Panels.${id}`)};
+function generateTab(id: "plugins" | "themes", states: Array<AddonState<Plugin>> | Array<AddonState<Theme>>
+): {id: "plugins" | "themes"; errors: Array<AddonErrorType<Error>>; name: string;} {
+    const errors: AddonErrorType[] = [];
+    for (const state of states) {
+        if (!("error" in state)) continue;
+        errors.push(state.error);
+    }
+    return {
+        id,
+        errors,
+        name: t(`Panels.${id}`),
+    };
 }
 
 export interface AddonErrorModalProps {
     transitionState?: number;
     onClose?(): void;
-    pluginErrors: AddonErrorType[];
-    themeErrors: AddonErrorType[];
+    pluginErrors: Array<AddonState<Plugin>>;
+    themeErrors: Array<AddonState<Theme>>;
 }
 
 /**
- *
- * @param {{transitionState?: number; onClose?(): void; pluginErrors: (import("@structs/addonerror").default)[]; themeErrors: (import("@structs/addonerror").default)[];}} param0
- * @returns
+ * Provides addon errors and their details.
+ * @param {AddonErrorModalProps} param0
+ * @returns {React.JSX.Element}
  */
-export default function AddonErrorModal({transitionState, onClose, pluginErrors, themeErrors}: AddonErrorModalProps) {
+export default function AddonErrorModal({transitionState, onClose, pluginErrors, themeErrors}: AddonErrorModalProps): React.JSX.Element {
     const tabs = useMemo<Array<ReturnType<typeof generateTab>>>(() => {
         return [
             pluginErrors.length && generateTab("plugins", pluginErrors),
@@ -79,7 +111,7 @@ export default function AddonErrorModal({transitionState, onClose, pluginErrors,
     }, [pluginErrors, themeErrors]);
 
     const [tabId, setTab] = useState(tabs[0].id);
-    const switchToTab = useCallback((id: string) => setTab(id), []);
+    const switchToTab = useCallback((id: "plugins" | "themes") => setTab(id), []);
     const selectedTab = tabs.find(e => e.id === tabId)!;
 
     return <ModalRoot transitionState={transitionState} className="bd-error-modal" size={ModalRoot.Sizes.MEDIUM}>

--- a/src/betterdiscord/ui/settings.tsx
+++ b/src/betterdiscord/ui/settings.tsx
@@ -22,11 +22,11 @@ import {HistoryIcon} from "lucide-react";
 import {t} from "@common/i18n";
 import Modals from "./modals";
 import changelog from "@data/changelog";
-import {type Plugin} from "@modules/pluginmanager";
 import DOMManager from "@modules/dommanager";
 import type AddonManager from "@modules/addonmanager";
 import toasts from "@stores/toasts";
 import ContextMenuPatcher from "@api/contextmenu";
+import type {Plugin} from "@modules/plugin";
 
 const SettingsRenderer = new class SettingsRenderer {
     initialize() {
@@ -552,7 +552,15 @@ function useCollectionMenu(collection: SettingsCollection) {
 }
 
 function useAddonMenu(manager: AddonManager) {
-    const addons = useStateFromStores(manager, () => manager.addonList.map(a => a.name || (a as any).getName?.()).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase())).map((name) => [name as string, manager.getAddon(name), manager.isEnabled(name)] as const), [], true);
+    const addons = useStateFromStores(manager, () => {
+        return Object.values(manager.cacheByName)
+            .sort((a, b) => {
+                return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+            })
+            .map((a) => {
+                return [a.name, a, manager.enablement[a.id] || false] as const;
+            });
+    }, [], true);
     const addonStoreIsEnabled = useStateFromStores(Settings, () => Settings.get("settings", "store", "bdAddonStore"), []);
 
     const toggles = React.useMemo(() => addons.map(([name, addon, enabled]) => (
@@ -564,7 +572,7 @@ function useAddonMenu(manager: AddonManager) {
             disabled={addon?.partial}
             action={(e: MouseEvent) => {
                 if (!e.shiftKey) {
-                    manager.toggleAddon(name);
+                    manager.toggleAddon(addon);
                     return;
                 }
 

--- a/src/betterdiscord/ui/settings/addoncard.tsx
+++ b/src/betterdiscord/ui/settings/addoncard.tsx
@@ -15,7 +15,8 @@ import Modals from "@ui/modals";
 import {CircleDollarSignIcon, CircleHelpIcon, PlugIcon, GithubIcon, GlobeIcon, HeartHandshakeIcon, PaletteIcon, PencilIcon, SettingsIcon, ShieldAlertIcon, Trash2Icon} from "lucide-react";
 import {getByKeys} from "@webpack";
 import type {MouseEvent, ReactNode} from "react";
-import type {default as AddonManager, Addon} from "@modules/addonmanager";
+import type {default as AddonManager} from "@modules/addonmanager";
+import type {AddonAny, AddonType} from "@modules/addon";
 
 const {useCallback, useMemo} = React;
 
@@ -85,11 +86,11 @@ function buildLink(type: keyof typeof LinkIcons, url?: string) {
 }
 
 export interface AddonCardProps {
-    addon: Addon;
+    addon: AddonAny;
     enabled: boolean;
-    type: "plugin" | "theme";
+    type: AddonType;
     disabled?: boolean;
-    onChange(id: string): void;
+    onChange(addon: AddonAny): void;
     hasSettings: boolean;
     editAddon(): void;
     deleteAddon(): void;
@@ -100,7 +101,7 @@ export interface AddonCardProps {
 export default function AddonCard({addon, enabled, type, disabled, onChange: parentChange, hasSettings, editAddon, deleteAddon, getSettingsPanel}: AddonCardProps) {
 
     const onChange = useCallback(() => {
-        if (parentChange) parentChange(addon.id);
+        if (parentChange) parentChange(addon as AddonAny);
     }, [addon.id, parentChange]);
 
     const showSettings = useCallback(() => {

--- a/src/betterdiscord/ui/settings/addonlist.tsx
+++ b/src/betterdiscord/ui/settings/addonlist.tsx
@@ -19,10 +19,10 @@ import Settings from "@stores/settings";
 import Text from "@ui/base/text";
 import {CheckIcon, ChevronRightIcon, FolderIcon, LayoutGridIcon, StoreIcon, StretchHorizontalIcon, XIcon} from "lucide-react";
 import {useStateFromStores} from "@ui/hooks";
-import {type Addon} from "@modules/addonmanager";
-import type AddonManager from "@modules/addonmanager"; // eslint-disable-line no-duplicate-imports
-import type {Plugin} from "@modules/pluginmanager";
+import type AddonManager from "@modules/addonmanager";
 import type {ChangeEvent, MouseEvent, ReactNode} from "react";
+import type {AddonAny, AddonType} from "@modules/addon";
+import type {Plugin} from "@modules/plugin";
 
 
 
@@ -43,7 +43,7 @@ function openFolder(folder: string) {
     ipc.openPath(folder);
 }
 
-function Blankslate({type, folder}: {type: "plugin" | "theme"; folder: string;}) {
+function Blankslate({type, folder}: {type: AddonType; folder: string;}) {
     // TODO: doggy update context type as needed
     const {toggleStore} = React.useContext(addonContext) as {title: string; toggleStore(): void;};
     const storeEnabled = Settings.get("settings", "store", "bdAddonStore");
@@ -65,7 +65,7 @@ function makeControlButton(title: string, children: ReactNode, action: () => voi
     </DiscordModules.Tooltip>;
 }
 
-function confirmDelete(addon: Addon) {
+function confirmDelete(addon: AddonAny) {
     return new Promise(resolve => {
         Modals.showConfirmationModal(t("Modals.confirmAction"), t("Addons.confirmDelete", {name: addon.name}), {
             danger: true,
@@ -133,11 +133,11 @@ export default function AddonList({store}: {store: AddonManager;}) {
     const [view, setView] = useState<ViewTypes>(getState.bind(null, store.prefix, "view", "list"));
 
 
-    const addonList = useStateFromStores(store, () => store.addonList.concat(), [store], true);
-    const addonState = useStateFromStores(store, () => Object.assign({}, store.state), [store], true);
+    const cacheByName = useStateFromStores(store, () => ({...store.cacheByName}), [store], true);
+    const addonState = useStateFromStores(store, () => ({...store.enablement}), [store], true);
 
-    const onChange = useCallback((id: string) => {
-        store.toggleAddon(id);
+    const onChange = useCallback((addon: AddonAny) => {
+        store.toggleAddon(addon);
     }, [store]);
 
     const enableAll = useCallback(() => {
@@ -167,16 +167,17 @@ export default function AddonList({store}: {store: AddonManager;}) {
     }, [store.prefix]);
 
     const search = useCallback((e: ChangeEvent<HTMLInputElement>) => setQuery(e.currentTarget.value.toLocaleLowerCase()), []);
-    const triggerEdit = useCallback((id: string) => store.editAddon?.(id), [store]);
-    const triggerDelete = useCallback(async (id: string) => {
-        const addon = addonList.find(a => a.id == id)!;
+    const triggerEdit = useCallback((addon: AddonAny) => {
+        store.editAddon?.(addon);
+    }, [store]);
+    const triggerDelete = useCallback(async (addon: AddonAny) => {
         const shouldDelete = await confirmDelete(addon);
         if (!shouldDelete) return;
-        store?.deleteAddon?.(addon);
-    }, [addonList, store]);
+        await store?.deleteAddon?.(addon);
+    }, [store]);
 
     const renderedCards = useMemo(() => {
-        let sorted = addonList.sort((a, b) => {
+        let sorted = Object.values(cacheByName).sort((a, b) => {
             const sortByEnabled = sort === "isEnabled";
             const first = sortByEnabled ? addonState[a.id] : a[sort];
             const second = sortByEnabled ? addonState[b.id] : b[sort];
@@ -204,12 +205,12 @@ export default function AddonList({store}: {store: AddonManager;}) {
             const hasSettings = (addon as Plugin).instance && typeof ((addon as Plugin).instance.getSettingsPanel) === "function";
             const getSettings = hasSettings && (addon as Plugin).instance.getSettingsPanel!.bind((addon as Plugin).instance);
             return <ErrorBoundary id={addon.id} name="AddonCard">
-                <AddonCard store={store} disabled={addon.partial} type={store.prefix as "plugin" | "theme"} editAddon={() => triggerEdit(addon.id)} deleteAddon={() => triggerDelete(addon.id)} key={addon.id} addon={addon} onChange={onChange} enabled={addonState[addon.id]} hasSettings={hasSettings} getSettingsPanel={getSettings ? getSettings : undefined} />
+                <AddonCard store={store} disabled={addon.partial} type={store.prefix as AddonType} editAddon={() => triggerEdit(addon)} deleteAddon={() => triggerDelete(addon)} key={addon.id} addon={addon} onChange={onChange} enabled={addonState[addon.id]} hasSettings={hasSettings} getSettingsPanel={getSettings ? getSettings : undefined} />
             </ErrorBoundary>;
         });
-    }, [store, addonList, addonState, onChange, triggerDelete, triggerEdit, query, ascending, sort]);
+    }, [store, cacheByName, addonState, onChange, triggerDelete, triggerEdit, query, ascending, sort]);
 
-    const hasAddonsInstalled = addonList.length !== 0;
+    const hasAddonsInstalled = Object.keys(cacheByName).length > 0;
     const isSearching = !!query;
     const hasResults = renderedCards.length !== 0;
 
@@ -219,7 +220,7 @@ export default function AddonList({store}: {store: AddonManager;}) {
         </AddonHeader>,
         <div className={"bd-controls bd-addon-controls"}>
             <div className="bd-controls-basic">
-                {makeBasicButton(t("Addons.openFolder", {context: store.prefix}), <FolderIcon size="20px" />, openFolder.bind(null, store.addonFolder), "folder")}
+                {makeBasicButton(t("Addons.openFolder", {context: store.prefix}), <FolderIcon size="20px" />, openFolder.bind(null, store.addonFolder()), "folder")}
                 {makeBasicButton(t("Addons.enableAll"), <CheckIcon size="20px" />, confirmEnable(enableAll, store.prefix), "enable-all")}
                 {makeBasicButton(t("Addons.disableAll"), <XIcon size="20px" />, disableAll, "disable-all")}
             </div>
@@ -241,7 +242,7 @@ export default function AddonList({store}: {store: AddonManager;}) {
             </div>
         </div>,
         <StoreCard />,
-        !hasAddonsInstalled && <Blankslate type={store.prefix as "plugin" | "theme"} folder={store.addonFolder} />,
+        !hasAddonsInstalled && <Blankslate type={store.prefix as AddonType} folder={store.addonFolder()} />,
         isSearching && !hasResults && hasAddonsInstalled && <NoResults />,
         hasAddonsInstalled && <div key="addonList" className={"bd-addon-list" + (view == "grid" ? " bd-grid-view" : "")}>{renderedCards}</div>
     ];

--- a/src/betterdiscord/ui/settings/addonpage.tsx
+++ b/src/betterdiscord/ui/settings/addonpage.tsx
@@ -15,7 +15,10 @@ export function getAddonPanel(title: string, options = {}) {
 
 export default function AddonPage(props: any) {
     // If 0 addons installed open the store automatically
-    const [showStore, setShowStore] = useState(() => Settings.get("settings", "store", "bdAddonStore") && !props.store.addonList.length);
+    const [showStore, setShowStore] = useState(() => {
+        const empty = Object.keys(props.store.cacheByName).length === 0;
+        return Settings.get("settings", "store", "bdAddonStore") && empty;
+    });
 
     const toggleStore = useCallback(() => setShowStore((v: boolean) => !v), []);
 

--- a/src/betterdiscord/ui/settings/addonstore.tsx
+++ b/src/betterdiscord/ui/settings/addonstore.tsx
@@ -232,7 +232,7 @@ export default function AddonStorePage({type, refToScroller}) {
         });
 
         const cards = $addons.map((addon) => (
-            <ErrorBoundary key={addon.id}><AddonCard addon={addon} /></ErrorBoundary>
+            <ErrorBoundary key={addon.id}><AddonCard addonStore={addon} /></ErrorBoundary>
         ));
 
         return <StoreContent content={cards} refToScroller={refToScroller} setPage={setPage} page={page} />;
@@ -248,7 +248,7 @@ export default function AddonStorePage({type, refToScroller}) {
         <div className="bd-controls bd-addon-controls">
             <div className="bd-controls-basic">
                 {/* {makeBasicButton(t("Addons.website"), <Globe />, () => window.open(Web.pages[`${manager.prefix}s`]))} */}
-                {makeBasicButton(t("Addons.openFolder", {context: type}), <FolderIcon size="20px" />, () => ipc.openPath(manager.addonFolder), "folder")}
+                {makeBasicButton(t("Addons.openFolder", {context: type}), <FolderIcon size="20px" />, () => ipc.openPath(manager.addonFolder()), "folder")}
                 {makeBasicButton(t("Addons.reload"), <RotateCwIcon size="20px" />, () => loading ? {} : AddonStore.requestAddons(), "reload")}
             </div>
             <div className="bd-controls-advanced">

--- a/src/betterdiscord/ui/settings/storecard.tsx
+++ b/src/betterdiscord/ui/settings/storecard.tsx
@@ -9,13 +9,14 @@ import Events from "@modules/emitter";
 import Button from "@ui/base/button";
 import {FlowerStar} from "./addonshared";
 import {CircleHelpIcon, EyeIcon, GithubIcon, GlobeIcon, Trash2Icon} from "lucide-react";
+import type {Addon} from "@modules/addonstore";
 
 const {useCallback, useMemo, useState, useEffect, useContext, createContext} = React;
 
 // TODO: let doggy fix these
 export const TagContext = createContext();
 
-function formatNumberWithSuffix(value) {
+function formatNumberWithSuffix(value: any) {
     value = Number(value);
     if (value === 0) return "0";
 
@@ -29,59 +30,66 @@ function formatNumberWithSuffix(value) {
     return `${formattedValue}${suffixes[index]}`;
 }
 
-/**
- * @param {{ addon: import("@modules/addonstore").Addon, isEmbed?: boolean }} props
- */
-export default function AddonCard({addon, isEmbed}) {
-    const [isInstalled, setInstalled] = useState(() => addon.isInstalled());
+export default function AddonCard({addonStore, isEmbed}: {addonStore: Addon, isEmbed: boolean;}) {
+    const [isInstalled, setInstalled] = useState(() => addonStore.isInstalled());
     const [disabled, setDisabled] = useState(false);
-    const [downloadCount, setDownloads] = useState(addon.downloads);
+    const [downloadCount, setDownloads] = useState(addonStore.downloads);
 
     const [isTagEnabled, toggleTag] = useContext(TagContext);
 
-    const triggerDelete = useCallback((event) => addon.delete(event.shiftKey), [addon]);
+    const triggerDelete = useCallback(async (event) => {
+        setDisabled(true);
+        try {
+            await addonStore.delete(event.shiftKey);
+            // Manually sync state after delete completes
+            setInstalled(addonStore.isInstalled());
+        }
+        finally {
+            setDisabled(false);
+        }
+    }, [addonStore]);
 
     const installAddon = useCallback(async (event) => {
         setDisabled(true);
 
-        await addon.download(event.shiftKey);
+        await addonStore.download(event.shiftKey);
 
-        setDownloads(addon.downloads);
+        setDownloads(addonStore.downloads);
 
         setDisabled(false);
-    }, [addon]);
+    }, [addonStore]);
 
-    const acceptInvite = useCallback(() => addon.guild.join(), [addon]);
-    const openSourceCode = useCallback(() => addon.openSourceCode(), [addon]);
-    const openAddonPage = useCallback(() => addon.openAddonPage(), [addon]);
-    const openAddonPreview = useCallback(() => addon.openPreview(), [addon]);
-    const openAuthorPage = useCallback(() => addon.openAuthorPage(), [addon]);
+    const acceptInvite = useCallback(() => addonStore.guild!.join(), [addonStore]);
+    const openSourceCode = useCallback(() => addonStore.openSourceCode(), [addonStore]);
+    const openAddonPage = useCallback(() => addonStore.openAddonPage(), [addonStore]);
+    const openAddonPreview = useCallback(() => addonStore.openPreview(), [addonStore]);
+    const openAuthorPage = useCallback(() => addonStore.openAuthorPage(), [addonStore]);
 
     useEffect(() => {
         const listener = () => {
-            setInstalled(addon.isInstalled());
+            setInstalled(addonStore.isInstalled());
         };
 
         listener();
 
-        Events.on(`${addon.manager.prefix}-loaded`, listener);
-        Events.on(`${addon.manager.prefix}-unloaded`, listener);
+        Events.on(`${addonStore.manager.prefix}-loaded`, listener);
+        Events.on(`${addonStore.manager.prefix}-unloaded`, listener);
 
         return () => {
-            Events.off(`${addon.manager.prefix}-loaded`, listener);
-            Events.off(`${addon.manager.prefix}-unloaded`, listener);
+            Events.off(`${addonStore.manager.prefix}-loaded`, listener);
+            Events.off(`${addonStore.manager.prefix}-unloaded`, listener);
         };
-    }, [addon]);
+    }, [addonStore]);
 
     const badge = useMemo(() => {
-        if (addon.isUnknown()) return t("Addons.new");
-        if (addon.recentlyUpdated()) return t("Addons.updated");
-    }, [addon]);
+        if (addonStore.isUnknown()) return t("Addons.new");
+        if (addonStore.recentlyUpdated()) return t("Addons.updated");
+    }, [addonStore]);
 
     const {downloads, likes} = useMemo(() => ({
         downloads: t("Addons.downloadCount", {count: downloadCount}, {count: formatNumberWithSuffix}),
-        likes: t("Addons.likeCount", {count: addon.likes}, {count: formatNumberWithSuffix}),
-    }), [addon, downloadCount]);
+        likes: t("Addons.likeCount", {count: addonStore.likes}, {count: formatNumberWithSuffix}),
+    }), [addonStore, downloadCount]);
 
     return (
         <div
@@ -90,20 +98,20 @@ export default function AddonCard({addon, isEmbed}) {
                 "bd-addon-store-card-embed": isEmbed
             })}
             onMouseEnter={() => {
-                addon.markAsKnown();
+                addonStore.markAsKnown();
             }}
         >
             <div className="bd-addon-store-card-splash">
                 <div className="bd-addon-store-card-preview">
                     <img
-                        src={addon.thumbnail}
+                        src={addonStore.thumbnail ?? undefined}
                         onError={(event) => {
                             // Fallback to blank thumbnail
                             event.currentTarget.src = Web.resources.thumbnail();
                         }}
                         loading="lazy"
                         className="bd-addon-store-card-preview-img"
-                        alt={`Thumbnail ${addon.name}`}
+                        alt={`Thumbnail ${addonStore.name}`}
                     />
                 </div>
                 <div className="bd-addon-store-card-author">
@@ -136,12 +144,12 @@ export default function AddonCard({addon, isEmbed}) {
                                         overflow="visible"
                                         mask="url(#svg-mask-squircle)"
                                     >
-                                        <DiscordModules.Tooltip text={addon.author}>
+                                        <DiscordModules.Tooltip text={addonStore.author}>
                                             {(props) => (
                                                 <img
                                                     loading="lazy"
                                                     className="bd-addon-store-card-author-img"
-                                                    src={addon.avatar}
+                                                    src={addonStore.avatar}
                                                     {...props}
                                                     onClick={openAuthorPage}
                                                 />
@@ -160,11 +168,11 @@ export default function AddonCard({addon, isEmbed}) {
             <div className="bd-addon-store-card-body">
                 <div className="bd-addon-store-card-name">
                     <FlowerStar />
-                    <span>{addon.name}</span>
+                    <span>{addonStore.name}</span>
                 </div>
-                <div className="bd-addon-store-card-description">{addon.description}</div>
+                <div className="bd-addon-store-card-description">{addonStore.description}</div>
                 <div className="bd-addon-store-card-tags">
-                    {addon.tags.map((tag) => (
+                    {addonStore.tags.map((tag) => (
                         <span
                             className={clsx({"bd-addon-store-card-tag": true, "bd-addon-store-card-tag-selected": isTagEnabled(tag)})}
                             onClick={() => toggleTag(tag)}
@@ -209,7 +217,7 @@ export default function AddonCard({addon, isEmbed}) {
                             </Button>
                         )}
                     </DiscordModules.Tooltip>
-                    {addon.type === "theme" && (
+                    {addonStore.type === "theme" && (
                         <DiscordModules.Tooltip text={t("Addons.preview")}>
                             {(props) => (
                                 <Button
@@ -223,7 +231,7 @@ export default function AddonCard({addon, isEmbed}) {
                             )}
                         </DiscordModules.Tooltip>
                     )}
-                    {addon.guild && (
+                    {addonStore.guild && (
                         <DiscordModules.Tooltip text={t("Addons.invite")}>
                             {(props) => (
                                 <Button

--- a/src/betterdiscord/ui/updater.tsx
+++ b/src/betterdiscord/ui/updater.tsx
@@ -68,7 +68,7 @@ function AddonUpdaterPanel({pending: filenames, type, updater, update, updateAll
         {!filenames.length && <NoUpdates type={type} />}
         {filenames.map(f => {
             const info = updater.cache[f];
-            const addon = updater.manager.addonList.find(a => a.filename === f)!;
+            const addon = updater.manager.cacheByFilename[f];
 
             if (!info) return null;
 
@@ -82,12 +82,12 @@ function AddonUpdaterPanel({pending: filenames, type, updater, update, updateAll
 
 export default function UpdaterPanel({coreUpdater, pluginUpdater, themeUpdater}: {coreUpdater: typeof CoreUpdater; pluginUpdater: typeof PluginUpdater; themeUpdater: typeof ThemeUpdater;}) {
     const [hasCoreUpdate, setCoreUpdate] = useState(coreUpdater.hasUpdate);
-    const [updates, setUpdates] = useState({plugins: pluginUpdater.pending.slice(0), themes: themeUpdater.pending.slice(0)});
+    const [updates, setUpdates] = useState({plugins: Array.from(pluginUpdater.pending), themes: Array.from(themeUpdater.pending)});
 
     const checkAddons = useCallback(async (type: "plugins" | "themes") => {
         const updater = type === "plugins" ? pluginUpdater : themeUpdater;
         await updater.checkAll(false);
-        setUpdates({...updates, [type]: updater.pending.slice(0)});
+        setUpdates({...updates, [type]: Array.from(updater.pending)});
     }, [updates, pluginUpdater, themeUpdater]);
 
     const update = useCallback(() => {
@@ -119,8 +119,8 @@ export default function UpdaterPanel({coreUpdater, pluginUpdater, themeUpdater}:
         await checkAddons("plugins");
         await checkAddons("themes");
         setUpdates({
-            plugins: pluginUpdater.pending.slice(0),
-            themes: themeUpdater.pending.slice(0)
+            plugins: Array.from(pluginUpdater.pending),
+            themes: Array.from(themeUpdater.pending)
         });
         Toasts.info(t("Updater.finishedChecking"));
     }, [checkAddons, checkCoreUpdate, pluginUpdater, themeUpdater]);

--- a/src/betterdiscord/utils/debug.ts
+++ b/src/betterdiscord/utils/debug.ts
@@ -1,9 +1,7 @@
 import config from "@stores/config";
-import type AddonManager from "@modules/addonmanager";
 import DiscordModules from "@modules/discordmodules";
 import PluginManager from "@modules/pluginmanager";
 import ThemeManager from "@modules/thememanager";
-
 
 export function getDiscordClientInfo() {
     const clientInfo = DiscordModules.GetClientInfo?.();
@@ -48,15 +46,15 @@ export function getDiscordInfo(string = true) {
     return info;
 }
 
-export function getAddonCounts(manager: AddonManager) {
+export function getAddonCounts(manager: typeof PluginManager | typeof ThemeManager) {
     return {
-        total: manager.addonList.length,
-        enabled: manager.addonList.filter(a => manager.isEnabled(a.id)).length
+        total: Object.keys(manager.cacheByName).length,
+        enabled: Object.keys(manager.enablement).length
     };
 }
 
-export function getAddonList(manager: AddonManager) {
-    return manager.addonList.map(a => `- ${a.name}${manager.isEnabled(a.id) ? " (Enabled)" : ""}`).join("\n");
+export function getAddonList(manager: typeof PluginManager | typeof ThemeManager) {
+    return Object.values(manager.cacheByName).map(a => `- ${a.name}${manager.isEnabled(a.id) ? " (Enabled)" : ""}`).join("\n");
 }
 
 export function getCoreInfo() {

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -34,7 +34,7 @@ export default class Logger {
      * @param {any} error - Error object to log with the message.
      */
     static stacktrace(module: string, message: any, error: Error) {
-        console.error(`%c[${module}]%c ${message}\n\n%c`, "color: #3a71c1; font-weight: 700;", "color: red; font-weight: 700;", "color: red;", error);
+        console.error(`%c[${module}]%c ${message}\n\n%c\n%o`, "color: #3a71c1; font-weight: 700;", "color: red; font-weight: 700;", "color: red;", error);
     }
 
     /**

--- a/src/editor/script.ts
+++ b/src/editor/script.ts
@@ -8,7 +8,9 @@ if (window.Editor.type === "custom-css") {
 }
 document.title = `${title} - BetterDiscord Editor`;
 
-document.getElementById("language")!.textContent = window.Editor.type === "plugin" ? " JavaScript" : " CSS";
+document.getElementById("language")!.textContent = window.Editor.type === "plugin" ? (
+    window.Editor.filename ? " TypeScript" : " JavaScript"
+) : " CSS";
 
 document.getElementById("open-editor")!.addEventListener("click", () => window.Editor.open());
 
@@ -109,7 +111,9 @@ amdLoader(["vs/editor/editor.main"], (monaco) => {
     const editor = monaco.editor.create(document.getElementById("editor")!, {
         ...options,
         value: lastSavedValue,
-        language: window.Editor.type === "plugin" ? "javascript" : "css"
+        language: window.Editor.type === "plugin" ? (
+            window.Editor.filename.endsWith("ts") ? "typescript" : "javascript"
+        ) : "css"
     });
 
     const liveUpdateNode = document.getElementById("live-update")! as HTMLInputElement;

--- a/src/electron/main/modules/betterdiscord.ts
+++ b/src/electron/main/modules/betterdiscord.ts
@@ -5,6 +5,7 @@ import {spawn} from "child_process";
 
 import ReactDevTools from "./reactdevtools";
 import * as IPCEvents from "@common/constants/ipcevents";
+import type {BrowserWindowType} from "./browserwindow";
 
 // Build info file only exists for non-linux (for current injection)
 const appPath = electron.app.getAppPath();
@@ -120,7 +121,7 @@ export default class BetterDiscord {
         if (!success) return; // TODO: cut a fatal log
     }
 
-    static setup(browserWindow: BrowserWindow) {
+    static setup(browserWindow: BrowserWindowType) {
 
         // Setup some useful vars to avoid blocking IPC calls
         try {
@@ -131,7 +132,6 @@ export default class BetterDiscord {
             process.env.DISCORD_RELEASE_CHANNEL = "stable";
         }
 
-        // @ts-expect-error adding new property, don't want to override object
         process.env.BD_DISCORD_PRELOAD = browserWindow.__originalPreload;
         process.env.DISCORD_APP_PATH = appPath;
         process.env.DISCORD_USER_DATA = electron.app.getPath("userData");
@@ -198,6 +198,90 @@ export default class BetterDiscord {
                 }
             });
         }
+
+        electron.protocol.handle("bd", async (request) => {
+            const url = new URL(request.url);
+            const {host, pathname, searchParams: params} = url;
+            const callerName = params.get("id") || "";
+
+            let prop = "", script = "";
+            const access = (host + pathname).replace(/\/$/, "");
+
+            interface PluginMatch extends RegExpMatchArray {
+                groups: {
+                    plugin: string;
+                };
+            }
+
+            const match = access.match(/addons\/plugins\/(?<plugin>\w+.plugin.m?js)/) as PluginMatch | null;
+
+            if (match) {
+                const filename = match.groups.plugin;
+
+                function validateFilename(base: string): boolean {
+                    return base.endsWith(".plugin.js") || base.endsWith(".plugin.mjs");
+                }
+
+                if (!validateFilename(filename)) {
+                    return new Response("Invalid BD Plugin File", {status: 404});
+                }
+
+                script = await fs.promises.readFile(path.resolve(path.join(bdFolder, "plugins"), filename), "utf8");
+
+                return new Response(script, {
+                    headers: {
+                        "Content-Type": "text/javascript",
+                    }
+                });
+            }
+
+            switch (access) {
+                case "api": prop = ""; break;
+                case "patcher": prop = "Patcher"; break;
+                case "data": prop = "Data"; break;
+                case "dom": prop = "DOM"; break;
+                case "logger": prop = "Logger"; break;
+                case "commands": prop = "Commands"; break;
+                case "commands/types": prop = "Commands.Types"; break;
+                case "commands/types/command": prop = "Commands.Types.CommandType"; break;
+                case "commands/types/input": prop = "Commands.Types.InputTypes"; break;
+                case "commands/types/message-embed": prop = "Commands.Types.MessageEmbedTypes"; break;
+                case "commands/types/option": prop = "Commands.Types.OptionTypes"; break;
+                case "net": prop = "Net"; break;
+                case "ui": prop = "UI"; break;
+                case "addons/themes": prop = "Themes"; break;
+                case "addons/plugins": prop = "Plugins"; break;
+                case "utils": prop = "Utils"; break;
+                case "react-utils": prop = "ReactUtils"; break;
+                case "context-menu": prop = "ContextMenu"; break;
+                case "context-menu/item": prop = "ContextMenu.Item"; break;
+                case "context-menu/group": prop = "ContextMenu.Group"; break;
+                case "components": prop = "Components"; break;
+                case "webpack": prop = "Webpack"; break;
+                case "webpack/filters": prop = "Webpack.Filters"; break;
+                case "webpack/stores": prop = "Webpack.Stores"; break;
+                case "react": prop = "React"; break;
+                case "react-dom": case "react-dom/client": prop = "ReactDOM"; break;
+                case "lodash": prop = `Webpack.getByKeys("debounce", "throttle")`; break;
+                case "moment": prop = `Webpack.getByKeys("isMoment")`; break;
+                case "highlight.js": prop = `Webpack.getByKeys("highlight", "highlightAll")`; break;
+                default:
+                    return new Response("Invalid BD Module", {status: 404});
+            }
+
+            if (!script) {
+                prop &&= "." + prop;
+                script = `
+                    const target = ${callerName ? `(new BdApi("${callerName}"))` : "BdApi"}${prop};
+                    export default target;`;
+            }
+
+            return new Response(script, {
+                headers: {
+                    "Content-Type": "text/javascript",
+                }
+            });
+        });
     }
 
     static disableMediaKeys() {

--- a/src/electron/main/modules/browserwindow.ts
+++ b/src/electron/main/modules/browserwindow.ts
@@ -19,15 +19,19 @@ function maybeHasOtherClientMod() {
     return extendsIndex < str.indexOf("{");
 }
 
+export type BrowserWindowType = BrowserWindow;
 class BrowserWindow extends electron.BrowserWindow {
-    private __originalPreload?: string;
+    public __originalPreload?: string;
 
     /**
      * @param {import("electron").BrowserWindowConstructorOptions} options
      * @returns
      */
     constructor(options: BrowserWindowConstructorOptions) {
-        if (!options || !options.webPreferences || !options.webPreferences.preload || !options.title) return super(options);
+        if (!options || !options.webPreferences || !options.webPreferences.preload || !options.title) {
+            super(options);
+            return;
+        };
 
         if (maybeHasOtherClientMod() && BetterDiscord.clientModCompatibility.shouldShow()) {
             // Not i18n but the i18n system doesn't exist here
@@ -67,8 +71,8 @@ class BrowserWindow extends electron.BrowserWindow {
 
         const inAppTrafficLights = Boolean(BetterDiscord.getSetting("window", "inAppTrafficLights") ?? false);
 
-        process.env.BETTERDISCORD_NATIVE_FRAME = options.frame = Boolean(BetterDiscord.getSetting("window", "frame") ?? options.frame ?? true);
-        process.env.BETTERDISCORD_IN_APP_TRAFFIC_LIGHTS = inAppTrafficLights;
+        process.env.BETTERDISCORD_NATIVE_FRAME = String(options.frame = Boolean(BetterDiscord.getSetting("window", "frame") ?? options.frame ?? true));
+        process.env.BETTERDISCORD_IN_APP_TRAFFIC_LIGHTS = String(inAppTrafficLights);
 
         if (inAppTrafficLights) {
             delete options.titleBarStyle;
@@ -94,11 +98,7 @@ class BrowserWindow extends electron.BrowserWindow {
             apply(target, thisArg, argArray) {
                 const handler = argArray[0];
 
-                /**
-                 *
-                 * @type {(details: import("electron").HandlerDetails) => import("electron").WindowOpenHandlerResponse} callback
-                 */
-                argArray[0] = function (details) {
+                argArray[0] = function (details: electron.HandlerDetails): electron.WindowOpenHandlerResponse {
                     // const match = details.url.match(EDITOR_URL_REGEX);
                     // if (match) {
                     //     const isCustomCSS = match[1] === undefined;
@@ -144,7 +144,7 @@ Object.defineProperty(BrowserWindow, "name", {value: "BrowserWindow", configurab
 export default class {
     static patchBrowserWindow() {
         const electronPath = require.resolve("electron");
-        delete require.cache[electronPath].exports; // If it didn't work, try to delete existing
-        require.cache[electronPath].exports = {...electron, BrowserWindow}; // Try to assign again after deleting
+        delete require.cache[electronPath]!.exports; // If it didn't work, try to delete existing
+        require.cache[electronPath]!.exports = {...electron, BrowserWindow}; // Try to assign again after deleting
     }
 }

--- a/src/electron/main/modules/ipc.ts
+++ b/src/electron/main/modules/ipc.ts
@@ -5,6 +5,8 @@ import * as IPCEvents from "@common/constants/ipcevents";
 import Editor from "./editor";
 import BetterDiscord from "./betterdiscord";
 
+import type {AddonType} from "@modules/addon";
+
 const getPath = (event: IpcMainEvent, pathReq: string) => {
     let returnPath;
     switch (pathReq) {
@@ -162,7 +164,7 @@ const openDialog = (event: IpcMainInvokeEvent, options: Partial<DialogOptions> =
 const registerPreload = (_: IpcMainEvent, path: string) => {
     app.commandLine.appendSwitch("preload", path);
 };
-const openEditor = (_: IpcMainInvokeEvent, type: "plugin" | "theme", filename: string) => {
+const openEditor = (_: IpcMainInvokeEvent, type: AddonType, filename: string) => {
     Editor.open(type, filename);
 };
 

--- a/src/electron/preload/api/filesystem.ts
+++ b/src/electron/preload/api/filesystem.ts
@@ -92,3 +92,58 @@ export function getStats(path: string, options?: object) {
         isSymbolicLink: stats.isSymbolicLink.bind(stats)
     };
 }
+
+export const promises = {
+    readFile: (path: string, options: object | BufferEncoding = "utf8") =>
+        fs.promises.readFile(path, options),
+
+    writeFile: (path: string, content: string | Uint8Array, options?: fs.WriteFileOptions & {originalFs: boolean;}) => {
+        const data = content instanceof Uint8Array ? Buffer.from(content) : content;
+        if (options?.originalFs) {
+            // eslint-disable-next-line @typescript-eslint/no-require-imports
+            return require("original-fs").promises.writeFile(path, data, options);
+        }
+        return fs.promises.writeFile(path, data, options);
+    },
+
+    readDirectory: (path: string, options?: object) =>
+        fs.promises.readdir(path, options),
+
+    createDirectory: (path: string, options: fs.MakeDirectoryOptions) =>
+        fs.promises.mkdir(path, options),
+
+    deleteDirectory: (path: string, options: fs.RmDirOptions) =>
+        fs.promises.rmdir(path, options),
+
+    exists: async (path: string) => {
+        try {
+            await fs.promises.access(path);
+            return true;
+        }
+        catch {
+            return false;
+        }
+    },
+
+    unlink: (path: string) =>
+        fs.promises.unlink(path),
+
+    getRealPath: (path: string, options?: object) =>
+        fs.promises.realpath(path, options as any),
+
+    rename: (oldPath: string, newPath: string) =>
+        fs.promises.rename(oldPath, newPath),
+
+    rm: (pathToFile: string, options?: fs.RmOptions) =>
+        fs.promises.rm(pathToFile, options),
+
+    getStats: async (path: string, options?: fs.StatOptions) => {
+        const stats = await fs.promises.stat(path, options);
+        return {
+            ...stats,
+            isFile: stats.isFile.bind(stats),
+            isDirectory: stats.isDirectory.bind(stats),
+            isSymbolicLink: stats.isSymbolicLink.bind(stats)
+        };
+    }
+};

--- a/tests/betterdiscord/structs/semver.test.ts
+++ b/tests/betterdiscord/structs/semver.test.ts
@@ -98,7 +98,7 @@ describe("Semver", () => {
                 ["1.2.3", "1.2.4", 1], // patch bump
                 ["1.2.0", "1.3.0", 1], // minor bump
                 ["2.0.0", "1.9.9", -1], // major takes precedence
-            ];
+            ] as const;
 
             for (const [current, remote, expected] of cases) {
                 expect(comparator(current, remote)).toBe(expected);
@@ -115,7 +115,7 @@ describe("Semver", () => {
                 ["1.0.0-beta", "1.0.0-alpha", -1], // alphabetical order
                 ["1.0.0-alpha.1", "1.0.0-alpha.beta", 1], // numeric vs non-numeric
                 ["1.0.0-alpha.beta", "1.0.0-beta", 1] // depth comparison
-            ];
+            ] as const;
 
             for (const [current, remote, expected] of cases) {
                 expect(comparator(current, remote)).toBe(expected);
@@ -129,7 +129,7 @@ describe("Semver", () => {
                 ["1.0.0-alpha+build", "1.0.0-alpha", 0], // build metadata doesn't affect precedence
                 ["1.0.0+build.1", "1.0.1+build.1", 1], // version takes precedence over build
                 ["1.0.0-alpha+build", "1.0.0+build", 1] // prerelease takes precedence over build
-            ];
+            ] as const;
 
             for (const [current, remote, expected] of cases) {
                 expect(comparator(current, remote)).toBe(expected);
@@ -144,7 +144,7 @@ describe("Semver", () => {
                 ["", "", 0], // empty strings
                 ["1.0", "1.0.0", 0], // incomplete version
                 ["1", "1.0.0", 0] // incomplete version
-            ];
+            ] as const;
 
             for (const [current, remote, expected] of cases) {
                 expect(comparator(current, remote)).toBe(expected);
@@ -159,7 +159,7 @@ describe("Semver", () => {
                 ["1.2.3", "1.02.003", 0], // mixed leading zeros
                 ["10.0.0", "2.0.0", -1], // proper numeric comparison
                 ["2.0.0", "10.0.0", 1] // proper numeric comparison
-            ];
+            ] as const;
 
             for (const [current, remote, expected] of cases) {
                 expect(comparator(current, remote)).toBe(expected);
@@ -174,7 +174,7 @@ describe("Semver", () => {
                 ["1.0.0-beta.11", "1.0.0-rc.1", 1],
                 ["1.0.0-rc.1", "1.0.0", 1],
                 ["1.0.0-alpha", "1.0.0-alpha.beta", 1]
-            ];
+            ] as const;
 
             for (const [current, remote, expected] of cases) {
                 expect(comparator(current, remote)).toBe(expected);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "compilerOptions": {
     // Enable latest features
-    "lib": ["ESNext", "DOM", "DOM.Iterable", "DOM.AsyncIterable"],
+    "lib": [
+      "ESNext",
+      "DOM",
+      "DOM.Iterable",
+      "DOM.AsyncIterable"
+    ],
     "target": "ESNext",
     "module": "ESNext",
     "moduleDetection": "force",
@@ -9,41 +14,69 @@
     "jsxFactory": "React.createElement",
     "jsxFragmentFactory": "React.Fragment",
     "allowJs": false,
-
     // Bundler mode
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "noEmit": true,
-
     // Best practices
     "strict": true,
     "skipLibCheck": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,
-
     // Some stricter flags
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noPropertyAccessFromIndexSignature": false,
-
     // Import aliases
     "paths": {
-        "@assets/*": ["./assets/*"],
-        "@common/*": ["./src/common/*"],
-        "@builtins/*": ["./src/betterdiscord/builtins/*"],
-        "@data/*": ["./src/betterdiscord/data/*"],
-        "@api/*": ["./src/betterdiscord/api/*"],
-        "@modules/*": ["./src/betterdiscord/modules/*"],
-        "@polyfill/*": ["./src/betterdiscord/polyfill/*"],
-        "@stores/*": ["./src/betterdiscord/stores/*"],
-        "@structs/*": ["./src/betterdiscord/structs/*"],
-        "@styles/*": ["./src/betterdiscord/styles/*"],
-        "@ui/*": ["./src/betterdiscord/ui/*"],
-        "@utils/*": ["./src/betterdiscord/utils/*"],
-        "@webpack": ["./src/betterdiscord/webpack"],
+      "@assets/*": [
+        "./assets/*"
+      ],
+      "@common/*": [
+        "./src/common/*"
+      ],
+      "@builtins/*": [
+        "./src/betterdiscord/builtins/*"
+      ],
+      "@data/*": [
+        "./src/betterdiscord/data/*"
+      ],
+      "@api/*": [
+        "./src/betterdiscord/api/*"
+      ],
+      "@modules/*": [
+        "./src/betterdiscord/modules/*"
+      ],
+      "@polyfill/*": [
+        "./src/betterdiscord/polyfill/*"
+      ],
+      "@stores/*": [
+        "./src/betterdiscord/stores/*"
+      ],
+      "@structs/*": [
+        "./src/betterdiscord/structs/*"
+      ],
+      "@styles/*": [
+        "./src/betterdiscord/styles/*"
+      ],
+      "@ui/*": [
+        "./src/betterdiscord/ui/*"
+      ],
+      "@utils/*": [
+        "./src/betterdiscord/utils/*"
+      ],
+      "@workers/*": [
+        "./src/workers/*"
+      ],
+      "@webpack": [
+        "./src/betterdiscord/webpack"
+      ],
     },
-    "typeRoots": ["node_modules/@types", "src/betterdiscord/types"]
+    "typeRoots": [
+      "node_modules/@types",
+      "src/betterdiscord/types"
+    ]
   },
   "include": [
     "src/**/*",


### PR DESCRIPTION
I'm laying the infrastructure for the inevitable rewrite.

A total rewrite usually kills all existing plugins. This provides a bridge.

## Core Changes

- Asynchronous Plugin Loading: Implements a dynamic `import()`-based loader using `data:` URI import maps.
- `bd:api` Virtual Module: Provides a standardized ESM entry point for the BetterDiscord API, allowing plugins to use import BdApi from "bd:api" instead of relying on global namespace pollution.
- Adds support for `.plugin.mjs` files while maintaining a stable path for legacy `.plugin.js` (IIFE) files.

## Progress Checklist

- [ ] `app.asar` patching.
  - [ ] `inject simple` to disable.
  - [x] .deb (`sudo -E env (which bun) inject`)
  - [x] AUR (`sudo -E env (which bun) inject` for yay or `... opt` for pacman)
  - [x] flatpack (`sudo -E env (which bun) flatpak`)
  - [ ] ~~snap~~ [failed-snapd-patching](https://github.com/Mopsgamer/BetterDiscord-mopsified/tree/failed-snapd-patching)
  - [x] windows
  - [x] WSL
  - [ ] macOS
- [ ] Rewrite-compatible. (https://github.com/Mopsgamer/BetterDiscord-mopsified/tree/rewrite)
    - [ ] New BdApi in the rewrite.
    - [ ] New BdApi + Old BdApi in this PR.
- [x] Side effect: Public `AddonAPI` changes.
  - [ ] Optional `start`/`stop`.
- [x] Improved error stacks.
- [x] `bd:api` virtual module implementation.
  - [ ] BdApi shouln't be exposed. `bd:api` and `bd:*` are BdApi wrappers at this moment. (When i figure it out in the rewrite. But it can be merged without it)
  - [ ] Locking.
    - [x] Parallel loading.
- [x] `npm:*`
  - [x] `bd:react`
  - [x] `bd:react-dom`
  - [x] `bd:highlight.js`
  - [x] `bd:moment`
- [x] Support for `@use esm` header in standard `.js` files.
- [ ] Tested.
- [ ] Documented.