### PR TITLE
Fix panel-wide onChange for buildSettingsPanel

### DIFF
--- a/src/betterdiscord/api/ui.ts
+++ b/src/betterdiscord/api/ui.ts
@@ -68,13 +68,11 @@ function SettingsBuilderUI({settings, onChange, onDrawerToggle, getDrawerState}:
                     if (x.enableWith) disabled = subgroup[x.enableWith];
                     if (x.disableWith) disabled = !subgroup[x.disableWith];
 
-                    if (x.type !== "switch") return {...x, defaultValue: value, disabled};
-
                     return {
                         ...x,
                         defaultValue: value,
                         onChange(newValue: any) {
-                            setSwitchStates(v => ({
+                            if (x.type === "switch") setSwitchStates(v => ({
                                 ...v,
                                 [setting.id]: {
                                     ...v[setting.id] as Record<string, boolean>,

--- a/src/betterdiscord/api/ui.ts
+++ b/src/betterdiscord/api/ui.ts
@@ -101,15 +101,12 @@ function SettingsBuilderUI({settings, onChange, onDrawerToggle, getDrawerState}:
         const {value, ...x} = setting;
 
         // @ts-expect-error ts is annoying
-        if (setting.type !== "switch") return buildSetting({...x, defaultValue: value, disabled});
-
-        // @ts-expect-error ts is annoying
         return buildSetting({
             ...x,
             disabled,
             defaultValue: value,
             onChange: (newValue: any) => {
-                setSwitchStates(v => ({...v, [setting.id]: newValue}));
+                if (setting.type === "switch") setSwitchStates(v => ({...v, [setting.id]: newValue}));
 
                 setting?.onChange?.(newValue as never);
                 onChange?.(null, setting.id, newValue);

--- a/src/betterdiscord/api/ui.ts
+++ b/src/betterdiscord/api/ui.ts
@@ -72,15 +72,18 @@ function SettingsBuilderUI({settings, onChange, onDrawerToggle, getDrawerState}:
                         ...x,
                         defaultValue: value,
                         onChange(newValue: any) {
-                            if (x.type === "switch") setSwitchStates(v => ({
-                                ...v,
-                                [setting.id]: {
-                                    ...v[setting.id] as Record<string, boolean>,
-                                    [x.id]: newValue
-                                }
-                            }));
+                            if (x.type === "switch") {
+                                setSwitchStates(v => ({
+                                    ...v,
+                                    [setting.id]: {
+                                        ...v[setting.id] as Record<string, boolean>,
+                                        [x.id]: newValue
+                                    }
+                                }));
+                            }
 
                             x.onChange?.(newValue as never);
+                            onChange?.(setting.id, x.id, newValue);
                         },
                         disabled
                     };

--- a/src/betterdiscord/modules/patcher.ts
+++ b/src/betterdiscord/modules/patcher.ts
@@ -112,7 +112,7 @@ export default class Patcher {
                     const insteadPatch = insteads[index];
                     if (!insteadPatch) {
                         // Why eslint? It is `this` why care if its duplicated
-                         
+                        // eslint-disable-next-line no-shadow
                         return function (this: any, ...innerArgs: any[]) {
                             if (typeof returnValue === "undefined") return returnValue = patch.originalFunction.apply(this, innerArgs);
                             return patch.originalFunction.apply(this, innerArgs);
@@ -120,7 +120,7 @@ export default class Patcher {
                     }
 
                     // Why eslint? It is `this` why care if its duplicated
-                     
+                    // eslint-disable-next-line no-shadow
                     return function (this: any, ...innerArgs: any[]) {
                         try {
                             const tempReturn = insteadPatch.callback(this, innerArgs, getPatch(index + 1));

--- a/src/betterdiscord/modules/patcher.ts
+++ b/src/betterdiscord/modules/patcher.ts
@@ -112,7 +112,7 @@ export default class Patcher {
                     const insteadPatch = insteads[index];
                     if (!insteadPatch) {
                         // Why eslint? It is `this` why care if its duplicated
-                        // eslint-disable-next-line no-shadow
+                         
                         return function (this: any, ...innerArgs: any[]) {
                             if (typeof returnValue === "undefined") return returnValue = patch.originalFunction.apply(this, innerArgs);
                             return patch.originalFunction.apply(this, innerArgs);
@@ -120,7 +120,7 @@ export default class Patcher {
                     }
 
                     // Why eslint? It is `this` why care if its duplicated
-                    // eslint-disable-next-line no-shadow
+                     
                     return function (this: any, ...innerArgs: any[]) {
                         try {
                             const tempReturn = insteadPatch.callback(this, innerArgs, getPatch(index + 1));


### PR DESCRIPTION
This fixes a regression where the `onChange` callback passed to `buildSettingsPanel` does not fire unless the setting changed is a switch.