### PR TITLE
Fix enableWith jank for core settings

### DIFF
--- a/src/betterdiscord/ui/settings/components/utils.ts
+++ b/src/betterdiscord/ui/settings/components/utils.ts
@@ -28,7 +28,7 @@ export function useItemProps<T, V extends any = T>(props: BaseSettingProps<T>, c
     const [original] = useState(() => (ctx.fail ? usesDefaultValue ? props.defaultValue : props.value : ctx.value) as T);
 
     const change = useCallbackRef<HandledValue<T, V>["setState"]>((value, stateOnly) => {
-        if (ctx.disabled || props.disabled) return;
+        if (ctx.fail ? props.disabled : ctx.disabled) return;
 
         const out = convertValue(value, ctx.fail ? (usesDefaultValue ? internalState : props.value) as T : ctx.value);
 


### PR DESCRIPTION
This fixes an issue with core settings where settings that are `enableWith`ed will visually appear to be enabled, but won't be interactable until they are re-rendered. For example, after enabling devtools you currently can't enable react devtools until you switch settings tabs.