### PR TITLE
Remove all deprecated plugin apis

### DIFF
--- a/src/betterdiscord/api/addonapi.ts
+++ b/src/betterdiscord/api/addonapi.ts
@@ -1,13 +1,14 @@
 import type AddonManager from "@modules/addonmanager";
+import type {Addon} from "@typed/addon";
 
 /**
  * `AddonAPI` is a utility class for working with plugins and themes. Instances are available on {@link BdApi}.
  */
-class AddonAPI {
-    #manager: AddonManager;
+class AddonAPI<T extends Addon> {
+    #manager: AddonManager<T>;
 
     /** @ignore */
-    constructor(manager: AddonManager) {this.#manager = manager;}
+    constructor(manager: AddonManager<T>) {this.#manager = manager;}
 
     /**
      * The path to the addon folder.

--- a/src/betterdiscord/modules/commandmanager.tsx
+++ b/src/betterdiscord/modules/commandmanager.tsx
@@ -264,7 +264,7 @@ class CommandManager {
                 const iconStyle = {width, height, padding};
 
                 const renderImageIcon = () => (
-                    <img src={iconUrl} alt={acronym} style={{width: "100%", height: "100%"}} />
+                    <img src={iconUrl as string} alt={acronym} style={{width: "100%", height: "100%"}} />
                 );
 
                 const renderAcronymIcon = () => (

--- a/src/betterdiscord/modules/pluginmanager.ts
+++ b/src/betterdiscord/modules/pluginmanager.ts
@@ -21,6 +21,7 @@ export interface Plugin extends Addon {
         getSettingsPanel?(): any;
         onSwitch?(): void;
     };
+    hasObserver: boolean;
 }
 
 const normalizeExports = `
@@ -37,20 +38,20 @@ class PluginManager extends AddonManager<Plugin> {
     language = "javascript";
     order = 3;
 
-    observer: MutationObserver;
+    private observerRef = -1;
+    private observer: MutationObserver | undefined;
+    private onObserverMutations: MutationCallback = (mutations) => {
+        // Possible speed increase
+        if (!this.addonList.length) return;
+
+        for (let i = 0, mlen = mutations.length; i < mlen; i++) {
+            this.onMutation(mutations[i]);
+        }
+    };
 
     constructor() {
         super();
         this.onSwitch = this.onSwitch.bind(this);
-        // Maybe in the future we capture .observer instead and create the observer if 1 or more plugins use it
-        this.observer = new MutationObserver((mutations) => {
-            // Possible speed increase
-            if (!this.addonList.length) return;
-
-            for (let i = 0, mlen = mutations.length; i < mlen; i++) {
-                this.onMutation(mutations[i]);
-            }
-        });
     }
 
     initialize() {
@@ -128,6 +129,7 @@ class PluginManager extends AddonManager<Plugin> {
             }
 
             plugin.instance = instance;
+            plugin.hasObserver = typeof instance.observer === "function";
 
             // Confirm required fields are present
             if (!plugin.name || !plugin.author || !plugin.description || !plugin.version) {
@@ -156,6 +158,19 @@ class PluginManager extends AddonManager<Plugin> {
         if (!plugin.instance) {
             const loaded = this.loadAddon(plugin);
             if (!loaded) return false;
+        }
+
+        if (plugin.hasObserver) {
+            this.observerRef++;
+
+            if (typeof this.observer === "undefined") {
+                this.observer = new MutationObserver(this.onObserverMutations);
+
+                this.observer.observe(document, {
+                    childList: true,
+                    subtree: true
+                });
+            }
         }
 
         try {
@@ -187,6 +202,11 @@ class PluginManager extends AddonManager<Plugin> {
         const plugin = this.resolveAddon(idOrAddon);
         if (!plugin) return false;
 
+        if (plugin.hasObserver && !this.observerRef--) {
+            this.observer?.disconnect();
+            this.observer = undefined;
+        }
+
         try {
             plugin.instance?.stop();
         }
@@ -211,10 +231,6 @@ class PluginManager extends AddonManager<Plugin> {
 
     setupFunctions() {
         Events.on("navigate", this.onSwitch);
-        this.observer.observe(document, {
-            childList: true,
-            subtree: true
-        });
     }
 
     onSwitch() {

--- a/src/betterdiscord/modules/pluginmanager.ts
+++ b/src/betterdiscord/modules/pluginmanager.ts
@@ -160,19 +160,6 @@ class PluginManager extends AddonManager<Plugin> {
             if (!loaded) return false;
         }
 
-        if (plugin.hasObserver) {
-            this.observerRef++;
-
-            if (typeof this.observer === "undefined") {
-                this.observer = new MutationObserver(this.onObserverMutations);
-
-                this.observer.observe(document, {
-                    childList: true,
-                    subtree: true
-                });
-            }
-        }
-
         try {
             plugin.instance.start();
         }
@@ -191,6 +178,19 @@ class PluginManager extends AddonManager<Plugin> {
             return false;
         }
 
+        if (plugin.hasObserver) {
+            this.observerRef++;
+
+            if (typeof this.observer === "undefined") {
+                this.observer = new MutationObserver(this.onObserverMutations);
+
+                this.observer.observe(document, {
+                    childList: true,
+                    subtree: true
+                });
+            }
+        }
+
         this.trigger("started", plugin.id);
         if (this.hasInitialized) Toasts.success(t("Addons.enabled", {name: plugin.name, version: plugin.version}));
         else this.initialAddonsLoaded++;
@@ -202,9 +202,13 @@ class PluginManager extends AddonManager<Plugin> {
         const plugin = this.resolveAddon(idOrAddon);
         if (!plugin) return false;
 
-        if (plugin.hasObserver && !this.observerRef--) {
-            this.observer?.disconnect();
-            this.observer = undefined;
+        if (plugin.hasObserver) {
+            this.observerRef = this.observerRef <= 0 ? -1 : this.observerRef - 1;
+
+            if (this.observerRef === -1) {
+                this.observer?.disconnect();
+                this.observer = undefined;
+            }
         }
 
         try {

--- a/src/betterdiscord/modules/pluginmanager.ts
+++ b/src/betterdiscord/modules/pluginmanager.ts
@@ -42,7 +42,7 @@ class PluginManager extends AddonManager<Plugin> {
     constructor() {
         super();
         this.onSwitch = this.onSwitch.bind(this);
-        // Maybe future we capture .observer instead and create the observer if 1 or more plugins use it
+        // Maybe in the future we capture .observer instead and create the observer if 1 or more plugins use it
         this.observer = new MutationObserver((mutations) => {
             // Possible speed increase
             if (!this.addonList.length) return;

--- a/src/betterdiscord/modules/pluginmanager.ts
+++ b/src/betterdiscord/modules/pluginmanager.ts
@@ -50,10 +50,10 @@ type PluginConstructor = new (meta: Addon) => PluginInstance;
 /**
  * Technically only arrows functions are treated as functions
  * @example
- * const MyPlugin: BetterDiscord.PluginFactory = (meta) => {
+ * const MyPlugin: BetterDiscord.PluginFactory = (meta) => ({
  *      start() {},
  *      stop() {}
- * };
+ * });
  */
 type PluginFactory = (meta: Addon) => PluginInstance;
 // Do not rename
@@ -160,9 +160,7 @@ class PluginManager extends AddonManager<Plugin> {
             return false;
         }
 
-        const meta: Omit<Plugin, "exports"> & {exports?: unknown;} = Object.assign({}, plugin);
-        const exports = plugin.exports;
-        delete meta.exports;
+        const {exports, ...meta} = Object.assign({}, plugin);
 
         try {
             // Load the plugin instance
@@ -178,7 +176,6 @@ class PluginManager extends AddonManager<Plugin> {
             }
 
             plugin.instance = instance;
-            plugin.hasObserver = typeof instance.observer === "function";
 
             // Confirm required fields are present
             if (!plugin.name || !plugin.author || !plugin.description || !plugin.version) {
@@ -211,6 +208,8 @@ class PluginManager extends AddonManager<Plugin> {
 
         try {
             plugin.instance.start();
+
+            plugin.hasObserver = typeof plugin.instance.observer === "function";
         }
         catch (err) {
             // Disable the addon if it can't be started

--- a/src/betterdiscord/modules/pluginmanager.ts
+++ b/src/betterdiscord/modules/pluginmanager.ts
@@ -10,18 +10,64 @@ import Events from "./emitter";
 
 type PluginLoadPoint = "connection" | "idle";
 
+// Do not rename
+export interface PluginInstance {
+    /**
+     * Custom icon for slash commands
+     */
+    icon?: React.FunctionComponent | React.ComponentClass | string;
+    /**
+     * Runs when your plugin is enabled
+     */
+    start(): void;
+    /**
+     * Runs when your plugin is disabled
+     */
+    stop(): void;
+    /**
+     * @returns A React functional (not exotic react components like memo) / class component or React Node or a DOM node or a string
+     */
+    getSettingsPanel?(): React.ComponentClass | React.FunctionComponent | React.ReactNode | Element;
+    /** @deprecated Create your own [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) instead */
+    observer?(m: MutationRecord): void;
+    /** @deprecated Use the [Navigation: navigate event](https://developer.mozilla.org/en-US/docs/Web/API/Navigation/navigate_event) event instead */
+    onSwitch?(): void;
+}
+
+// Do not rename
+// Why does ts have no way to do classes properly without extending a real class?
+/**
+ * For both class and function (non arrow) exports
+ * @example
+ * const MyPlugin: BetterDiscord.PluginConstructor = class implements BetterDiscord.PluginInstance {
+ *      constructor(meta: BetterDiscord.Addon) {}
+ *      start() {}
+ *      stop() {}
+ * }
+ */
+type PluginConstructor = new (meta: Addon) => PluginInstance;
+// Do not rename
+/**
+ * Technically only arrows functions are treated as functions
+ * @example
+ * const MyPlugin: BetterDiscord.PluginFactory = (meta) => {
+ *      start() {},
+ *      stop() {}
+ * };
+ */
+type PluginFactory = (meta: Addon) => PluginInstance;
+// Do not rename
+type PluginExport = PluginConstructor | PluginFactory;
+
 export interface Plugin extends Addon {
-    exports: any;
-    instance: {
-        icon?: any;
-        load?(): void;
-        start(): void;
-        stop(): void;
-        observer?(m: MutationRecord): void;
-        getSettingsPanel?(): any;
-        onSwitch?(): void;
-    };
+    exports: PluginExport;
+    instance: PluginInstance;
     hasObserver: boolean;
+}
+
+export interface PluginModule {
+    exports: PluginExport;
+    filename: string;
 }
 
 const normalizeExports = `
@@ -74,7 +120,10 @@ class PluginManager extends AddonManager<Plugin> {
     initAddon(plugin: Plugin) {
         // Evaluate the plugin
         try {
-            const module = {filename: plugin.filename, exports: {}};
+            const module = {
+                filename: plugin.filename,
+                exports: {} as PluginExport
+            } as PluginModule;
 
             plugin.fileContent += normalizeExports + `\n//# sourceURL=betterdiscord://betterdiscord/plugins/${plugin.filename}`;
 
@@ -82,7 +131,7 @@ class PluginManager extends AddonManager<Plugin> {
             const wrappedPlugin = new Function("require", "module", "exports", "__filename", "__dirname", plugin.fileContent!); // eslint-disable-line no-new-func
             wrappedPlugin(window.require, module, module.exports, module.filename, this.addonFolder);
 
-            plugin.exports = module.exports;
+            plugin.exports = module.exports as PluginExport;
             delete plugin.fileContent;
         }
         catch (err) {
@@ -111,16 +160,16 @@ class PluginManager extends AddonManager<Plugin> {
             return false;
         }
 
-        const meta = Object.assign({}, plugin);
+        const meta: Omit<Plugin, "exports"> & {exports?: unknown;} = Object.assign({}, plugin);
         const exports = plugin.exports;
         delete meta.exports;
 
         try {
             // Load the plugin instance
-            const instance = exports.prototype ? new exports(meta) : exports(meta);
+            const instance = exports.prototype ? new (exports as PluginConstructor)(meta) : (exports as PluginFactory)(meta);
 
             // Confirm the required methods are present
-            if (!instance.start || !instance.stop) {
+            if (typeof instance.start !== "function" || typeof instance.stop !== "function") {
                 this.showAddonError(plugin, "Missing start or stop function.", {
                     message: "Plugins must have both a start and stop function.",
                     stack: ""

--- a/src/betterdiscord/modules/pluginmanager.ts
+++ b/src/betterdiscord/modules/pluginmanager.ts
@@ -42,7 +42,11 @@ class PluginManager extends AddonManager<Plugin> {
     constructor() {
         super();
         this.onSwitch = this.onSwitch.bind(this);
+        // Maybe future we capture .observer instead and create the observer if 1 or more plugins use it
         this.observer = new MutationObserver((mutations) => {
+            // Possible speed increase
+            if (!this.addonList.length) return;
+
             for (let i = 0, mlen = mutations.length; i < mlen; i++) {
                 this.onMutation(mutations[i]);
             }
@@ -124,10 +128,6 @@ class PluginManager extends AddonManager<Plugin> {
             }
 
             plugin.instance = instance;
-            plugin.name = instance.getName ? instance.getName() : plugin.name;
-            plugin.author = instance.getAuthor ? instance.getAuthor() : plugin.author;
-            plugin.description = instance.getDescription ? instance.getDescription() : plugin.description;
-            plugin.version = instance.getVersion ? instance.getVersion() : plugin.version;
 
             // Confirm required fields are present
             if (!plugin.name || !plugin.author || !plugin.description || !plugin.version) {
@@ -138,19 +138,7 @@ class PluginManager extends AddonManager<Plugin> {
                 return false;
             }
 
-            // Run the plugin's load function
-            try {
-                if (typeof instance.load === "function") instance.load();
-                return true;
-            }
-            catch (err) {
-                this.state[plugin.id] = false;
-                this.showAddonError(plugin, t("Addons.methodError", {method: "load()"}), {
-                    message: (err as Error).message,
-                    stack: (err as Error).stack
-                });
-                return false;
-            }
+            return true;
         }
         catch (err) {
             this.showAddonError(plugin, t("Addons.methodError", {method: "Plugin constructor()"}), {

--- a/src/betterdiscord/ui/settings.tsx
+++ b/src/betterdiscord/ui/settings.tsx
@@ -565,7 +565,7 @@ function useCollectionMenu(collection: SettingsCollection) {
 }
 
 function useAddonMenu(manager: AddonManager) {
-    const addons = useStateFromStores(manager, () => manager.addonList.map(a => a.name || (a as any).getName?.()).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase())).map((name) => [name as string, manager.resolveAddon(name), manager.isEnabled(name)] as const), [], true);
+    const addons = useStateFromStores(manager, () => manager.addonList.map(a => a.name).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase())).map((name) => [name as string, manager.resolveAddon(name), manager.isEnabled(name)] as const), [], true);
     const addonStoreIsEnabled = useStateFromStores(Settings, () => Settings.get("settings", "store", "bdAddonStore"), []);
 
     const toggles = React.useMemo(() => addons.map(([name, addon, enabled]) => (

--- a/src/betterdiscord/ui/settings.tsx
+++ b/src/betterdiscord/ui/settings.tsx
@@ -587,10 +587,9 @@ function useAddonMenu(manager: AddonManager) {
                 }
 
                 const hasSettings = (addon as Plugin).instance && typeof ((addon as Plugin).instance.getSettingsPanel) === "function";
-                const getSettings = (hasSettings && (addon as Plugin).instance.getSettingsPanel!.bind((addon as Plugin).instance)) as () => any;
 
                 if (hasSettings) {
-                    Modals.showAddonSettingsModal(name, getSettings());
+                    Modals.showAddonSettingsModal(name, (addon as Plugin).instance.getSettingsPanel!());
                 }
                 else {
                     toasts.warning(t("Addons.noSettings", {name}));

--- a/src/betterdiscord/ui/settings/addoncard.tsx
+++ b/src/betterdiscord/ui/settings/addoncard.tsx
@@ -16,6 +16,7 @@ import {CircleDollarSignIcon, CircleHelpIcon, PlugIcon, GithubIcon, GlobeIcon, H
 import {getByKeys} from "@webpack";
 import type {default as AddonManager} from "@modules/addonmanager";
 import type {Addon, AddonType} from "@typed/addon";
+import type {PluginInstance} from "@modules/pluginmanager";
 
 const {useCallback, useMemo} = React;
 
@@ -93,7 +94,7 @@ export interface AddonCardProps {
     hasSettings: boolean;
     editAddon(): void;
     deleteAddon(): void;
-    getSettingsPanel?(): HTMLElement | ReactNode;
+    getSettingsPanel?: PluginInstance["getSettingsPanel"];
     store: AddonManager;
 }
 


### PR DESCRIPTION
Removes all uses of `.load()`, `.getName()`, `.getVersion()` ,`.getDescription()` and, `.getAuthor()` on the plugin object