### PR TITLE
Fix BdApi.DOM.removeStyle not working for styles with special characters in ids

### DIFF
--- a/src/betterdiscord/modules/dommanager.ts
+++ b/src/betterdiscord/modules/dommanager.ts
@@ -80,13 +80,13 @@ export default class DOMManager {
 
     static removeStyle(id: string) {
         id = this.escapeID(id);
-        const exists = this.getElement(`#${id}`, this.bdStyles);
+        const exists = document.getElementById(id);
         if (exists) exists.remove();
     }
 
     static injectStyle(id: string, css: string) {
         id = this.escapeID(id);
-        const style = this.getElement(`#${id}`, this.bdStyles) || this.createElement("style", {id});
+        const style = document.getElementById(id) || this.createElement("style", {id});
         style.textContent = css;
         this.bdStyles.append(style);
     }
@@ -98,7 +98,7 @@ export default class DOMManager {
     static linkStyle(id: string, url: string, {documentHead = false} = {}) {
         id = this.escapeID(id);
         return new Promise(resolve => {
-            const link: HTMLLinkElement = this.getElement(`#${id}`, this.bdStyles) as HTMLLinkElement || this.createElement("link", {id});
+            const link: HTMLLinkElement = document.getElementById(id) as HTMLLinkElement || this.createElement("link", {id});
             link.rel = "stylesheet";
             link.href = url;
             link.onload = resolve;
@@ -126,14 +126,14 @@ export default class DOMManager {
 
     static removeScript(id: string) {
         id = this.escapeID(id);
-        const exists = this.getElement(`#${id}`, this.bdScripts);
+        const exists = document.getElementById(id);
         if (exists) exists.remove();
     }
 
     static injectScript(id: string, url: string) {
         id = this.escapeID(id);
         return new Promise((resolve, reject) => {
-            const script: HTMLScriptElement = this.getElement(`#${id}`, this.bdScripts) as HTMLScriptElement || this.createElement("script", {id});
+            const script: HTMLScriptElement = document.getElementById(id) as HTMLScriptElement || this.createElement("script", {id});
             script.src = url;
             script.onload = resolve;
             script.onerror = reject;


### PR DESCRIPTION
This is the same issue as in #2149, where querySelector handles escaping special characters very strangely. In this case, it manifests by having removeStyle not work if the id has a special character. This can be seen through the following:
```js
BdApi.DOM.addStyle("test+", "* { color: red }");
BdApi.DOM.removeStyle("test+"); // doesn't do anything
```
Like before, this issue can be solved by replacing `querySelector` with `getElementById`, and for good measure I have done this everywhere applicable in DOMManager.