### PR TITLE
Default alwaysEnable for downloading addons in the addon store to true

### DIFF
--- a/src/betterdiscord/data/settings.ts
+++ b/src/betterdiscord/data/settings.ts
@@ -34,7 +34,7 @@ const DefaultSettings = [
         shown: false,
         settings: [
             {type: "switch", id: "bdAddonStore", value: true},
-            {type: "switch", id: "alwaysEnable", value: false, enableWith: "bdAddonStore"},
+            {type: "switch", id: "alwaysEnable", value: true, enableWith: "bdAddonStore"},
             {type: "switch", id: "addonEmbeds", value: true, enableWith: "bdAddonStore"}
         ]
     },


### PR DESCRIPTION
No real reason for this to be false by default, users will essentially always want to enable the plugin they just downloaded and it can be confusing if they don't notice the button.